### PR TITLE
[BUG] Distribute Query blocks to nodes, to balance load to tasks

### DIFF
--- a/integration/spark/src/test/java/org/carbondata/integration/spark/load/CarbonLoaderUtilTest.java
+++ b/integration/spark/src/test/java/org/carbondata/integration/spark/load/CarbonLoaderUtilTest.java
@@ -1,6 +1,7 @@
 package org.carbondata.integration.spark.load;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,34 +25,28 @@ public class CarbonLoaderUtilTest {
 
     Map<TableBlockInfo, List<String>> inputMap = new HashMap<TableBlockInfo, List<String>>(5);
 
-    TableBlockInfo block1 = new TableBlockInfo("path1", 123, 1, new String[] { "sdf" }, 111);
-    TableBlockInfo block2 = new TableBlockInfo("path2", 123, 2, new String[] { "sdf" }, 111);
-    TableBlockInfo block3 = new TableBlockInfo("path3", 123, 3, new String[] { "sdf" }, 111);
-    TableBlockInfo block4 = new TableBlockInfo("path4", 123, 4, new String[] { "sdf" }, 111);
+    TableBlockInfo block1 =
+        new TableBlockInfo("path1", 123, 1, new String[] { "1", "2", "3" }, 111);
+    TableBlockInfo block2 =
+        new TableBlockInfo("path2", 123, 2, new String[] { "2", "3", "4" }, 111);
+    TableBlockInfo block3 =
+        new TableBlockInfo("path3", 123, 3, new String[] { "3", "4", "1" }, 111);
+    TableBlockInfo block4 =
+        new TableBlockInfo("path4", 123, 4, new String[] { "1", "2", "4" }, 111);
 
-    List<String> list1 = new ArrayList(3);
-    list1.add("1");
-    list1.add("2");
-    list1.add("3");
-    List<String> list2 = new ArrayList(3);
-    list2.add("2");
-    list2.add("3");
-    list2.add("4");
-    List<String> list3 = new ArrayList(3);
-    list3.add("3");
-    list3.add("4");
-    list3.add("1");
-    List<String> list4 = new ArrayList(3);
-    list4.add("1");
-    list4.add("2");
-    list4.add("4");
+    inputMap.put(block1, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block2, Arrays.asList(new String[]{"2","3","4"}));
+    inputMap.put(block3, Arrays.asList(new String[]{"3","4","1"}));
+    inputMap.put(block4, Arrays.asList(new String[]{"1","2","4"}));
 
-    inputMap.put(block1, list1);
-    inputMap.put(block2, list2);
-    inputMap.put(block3, list3);
-    inputMap.put(block4, list4);
+    List<TableBlockInfo> inputBlocks = new ArrayList(6);
+    inputBlocks.add(block1);
+    inputBlocks.add(block2);
+    inputBlocks.add(block3);
+    inputBlocks.add(block4);
 
-    Map<String, List<TableBlockInfo>> outputMap = CarbonLoaderUtil.nodeBlockMapping(inputMap, 4, 4);
+    Map<String, List<TableBlockInfo>> outputMap
+        = CarbonLoaderUtil.nodeBlockMapping(inputBlocks, 4);
 
     Assert.assertTrue(calculateBlockDistribution(inputMap, outputMap, 4, 4));
 
@@ -79,7 +74,7 @@ public class CarbonLoaderUtilTest {
 
     System.out.println(
         ((notInNodeLocality / numberOfBlocks) * 100) + " " + "is the node locality mismatch");
-    if ((notInNodeLocality / numberOfBlocks) * 100 > 25) {
+    if ((notInNodeLocality / numberOfBlocks) * 100 > 30) {
       return false;
     }
     return true;
@@ -109,28 +104,30 @@ public class CarbonLoaderUtilTest {
     Map<TableBlockInfo, List<String>> inputMap = new HashMap<TableBlockInfo, List<String>>(5);
 
     TableBlockInfo block1 =
-        new TableBlockInfo("part-0-0-1462341987000", 123, 1, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-0-0-1462341987000", 123, 1, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block2 =
-        new TableBlockInfo("part-1-0-1462341987000", 123, 2, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-1-0-1462341987000", 123, 2, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block3 =
-        new TableBlockInfo("part-2-0-1462341987000", 123, 3, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-2-0-1462341987000", 123, 3, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block4 =
-        new TableBlockInfo("part-3-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-3-0-1462341987000", 123, 4, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block5 =
-        new TableBlockInfo("part-4-0-1462341987000", 123, 5, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-4-0-1462341987000", 123, 5, new String[] { "1", "2", "3" }, 111);
 
-    List<String> list1 = new ArrayList(3);
-    list1.add("1");
-    list1.add("2");
-    list1.add("3");
+    inputMap.put(block1, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block2, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block3, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block4, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block5, Arrays.asList(new String[]{"1","2","3"}));
 
-    inputMap.put(block1, list1);
-    inputMap.put(block2, list1);
-    inputMap.put(block3, list1);
-    inputMap.put(block4, list1);
-    inputMap.put(block5, list1);
+    List<TableBlockInfo> inputBlocks = new ArrayList(6);
+    inputBlocks.add(block1);
+    inputBlocks.add(block2);
+    inputBlocks.add(block3);
+    inputBlocks.add(block4);
+    inputBlocks.add(block5);
 
-    Map<String, List<TableBlockInfo>> outputMap = CarbonLoaderUtil.nodeBlockMapping(inputMap, 5, 3);
+    Map<String, List<TableBlockInfo>> outputMap = CarbonLoaderUtil.nodeBlockMapping(inputBlocks, 3);
 
     Assert.assertTrue(calculateBlockDistribution(inputMap, outputMap, 5, 3));
 
@@ -148,51 +145,35 @@ public class CarbonLoaderUtilTest {
     Map<TableBlockInfo, List<String>> inputMap = new HashMap<TableBlockInfo, List<String>>(5);
 
     TableBlockInfo block1 =
-        new TableBlockInfo("part-0-0-1462341987000", 123, 1, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-0-0-1462341987000", 123, 1, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block2 =
-        new TableBlockInfo("part-1-0-1462341987000", 123, 2, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-1-0-1462341987000", 123, 2, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block3 =
-        new TableBlockInfo("part-2-0-1462341987000", 123, 3, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-2-0-1462341987000", 123, 3, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block4 =
-        new TableBlockInfo("part-3-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-3-0-1462341987000", 123, 4, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block5 =
-        new TableBlockInfo("part-4-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-4-0-1462341987000", 123, 4, new String[] { "1", "2", "3" }, 111);
     TableBlockInfo block6 =
-        new TableBlockInfo("part-5-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-5-0-1462341987000", 123, 4, new String[] { "1", "2", "3" }, 111);
 
-    List<String> list1 = new ArrayList(3);
-    list1.add("1");
-    list1.add("2");
-    list1.add("3");
-    List<String> list2 = new ArrayList(3);
-    list2.add("1");
-    list2.add("2");
-    list2.add("3");
-    List<String> list3 = new ArrayList(3);
-    list3.add("1");
-    list3.add("2");
-    list3.add("3");
-    List<String> list4 = new ArrayList(3);
-    list4.add("1");
-    list4.add("2");
-    list4.add("3");
-    List<String> list5 = new ArrayList(3);
-    list5.add("1");
-    list5.add("2");
-    list5.add("3");
-    List<String> list6 = new ArrayList(3);
-    list6.add("1");
-    list6.add("2");
-    list6.add("3");
+    inputMap.put(block1, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block2, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block3, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block4, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block5, Arrays.asList(new String[]{"1","2","3"}));
+    inputMap.put(block6, Arrays.asList(new String[]{"1","2","3"}));
 
-    inputMap.put(block1, list1);
-    inputMap.put(block2, list2);
-    inputMap.put(block3, list3);
-    inputMap.put(block4, list4);
-    inputMap.put(block5, list5);
-    inputMap.put(block6, list6);
 
-    Map<String, List<TableBlockInfo>> outputMap = CarbonLoaderUtil.nodeBlockMapping(inputMap, 6, 4);
+    List<TableBlockInfo> inputBlocks = new ArrayList(6);
+    inputBlocks.add(block1);
+    inputBlocks.add(block2);
+    inputBlocks.add(block3);
+    inputBlocks.add(block4);
+    inputBlocks.add(block5);
+    inputBlocks.add(block6);
+
+    Map<String, List<TableBlockInfo>> outputMap = CarbonLoaderUtil.nodeBlockMapping(inputBlocks, 4);
 
     Assert.assertTrue(calculateBlockDistribution(inputMap, outputMap, 6, 4));
 
@@ -210,70 +191,50 @@ public class CarbonLoaderUtilTest {
     Map<TableBlockInfo, List<String>> inputMap = new HashMap<TableBlockInfo, List<String>>(5);
 
     TableBlockInfo block1 =
-        new TableBlockInfo("part-1-0-1462341987000", 123, 1, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-1-0-1462341987000", 123, 1, new String[] { "2", "4" }, 111);
     TableBlockInfo block2 =
-        new TableBlockInfo("part-2-0-1462341987000", 123, 2, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-2-0-1462341987000", 123, 2, new String[] { "2", "4" }, 111);
     TableBlockInfo block3 =
-        new TableBlockInfo("part-3-0-1462341987000", 123, 3, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-3-0-1462341987000", 123, 3, new String[] { "2", "4" }, 111);
     TableBlockInfo block4 =
-        new TableBlockInfo("part-4-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-4-0-1462341987000", 123, 4, new String[] { "2", "4" }, 111);
     TableBlockInfo block5 =
-        new TableBlockInfo("part-5-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-5-0-1462341987000", 123, 4, new String[] { "2", "4" }, 111);
     TableBlockInfo block6 =
-        new TableBlockInfo("part-6-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-6-0-1462341987000", 123, 4, new String[] { "2", "4" }, 111);
     TableBlockInfo block7 =
-        new TableBlockInfo("part-7-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-7-0-1462341987000", 123, 4, new String[] { "3", "4" }, 111);
     TableBlockInfo block8 =
-        new TableBlockInfo("part-8-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-8-0-1462341987000", 123, 4, new String[] { "3", "4" }, 111);
     TableBlockInfo block9 =
-        new TableBlockInfo("part-9-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-9-0-1462341987000", 123, 4, new String[] { "3", "4" }, 111);
     TableBlockInfo block10 =
-        new TableBlockInfo("part-10-0-1462341987000", 123, 4, new String[] { "sdf" }, 111);
+        new TableBlockInfo("part-10-0-1462341987000", 123, 4, new String[] { "1", "4" }, 111);
 
-    List<String> list1 = new ArrayList<String>(3);
-    list1.add("2");
-    list1.add("4");
-    List<String> list2 = new ArrayList<String>(3);
-    list2.add("2");
-    list2.add("4");
-    List<String> list3 = new ArrayList<String>(3);
-    list3.add("2");
-    list3.add("4");
-    List<String> list4 = new ArrayList<String>(3);
-    list4.add("2");
-    list4.add("4");
-    List<String> list5 = new ArrayList<String>(3);
-    list5.add("2");
-    list5.add("4");
-    List<String> list6 = new ArrayList<String>(3);
-    list6.add("2");
-    list6.add("4");
-    List<String> list7 = new ArrayList<String>(3);
-    list7.add("3");
-    list7.add("4");
-    List<String> list8 = new ArrayList<String>(3);
-    list8.add("3");
-    list8.add("4");
-    List<String> list9 = new ArrayList<String>(3);
-    list9.add("3");
-    list9.add("4");
-    List<String> list10 = new ArrayList<String>(3);
-    list10.add("1");
-    list10.add("4");
+    inputMap.put(block1, Arrays.asList(new String[]{"2","4"}));
+    inputMap.put(block2, Arrays.asList(new String[]{"2","4"}));
+    inputMap.put(block3, Arrays.asList(new String[]{"2","4"}));
+    inputMap.put(block4, Arrays.asList(new String[]{"2","4"}));
+    inputMap.put(block5, Arrays.asList(new String[]{"2","4"}));
+    inputMap.put(block6, Arrays.asList(new String[]{"2","4"}));
+    inputMap.put(block7, Arrays.asList(new String[]{"3","4"}));
+    inputMap.put(block8, Arrays.asList(new String[]{"3","4"}));
+    inputMap.put(block9, Arrays.asList(new String[]{"3","4"}));
+    inputMap.put(block10, Arrays.asList(new String[]{"1","4"}));
 
-    inputMap.put(block1, list1);
-    inputMap.put(block2, list2);
-    inputMap.put(block3, list3);
-    inputMap.put(block4, list4);
-    inputMap.put(block5, list5);
-    inputMap.put(block6, list6);
-    inputMap.put(block7, list7);
-    inputMap.put(block8, list8);
-    inputMap.put(block9, list9);
-    inputMap.put(block10, list10);
+    List<TableBlockInfo> inputBlocks = new ArrayList(6);
+    inputBlocks.add(block1);
+    inputBlocks.add(block2);
+    inputBlocks.add(block3);
+    inputBlocks.add(block4);
+    inputBlocks.add(block5);
+    inputBlocks.add(block6);
+    inputBlocks.add(block7);
+    inputBlocks.add(block8);
+    inputBlocks.add(block9);
+    inputBlocks.add(block10);
 
-    Map<String, List<TableBlockInfo>> outputMap =
-        CarbonLoaderUtil.nodeBlockMapping(inputMap, 10, 4);
+    Map<String, List<TableBlockInfo>> outputMap = CarbonLoaderUtil.nodeBlockMapping(inputBlocks, 4);
 
     Assert.assertTrue(calculateBlockDistribution(inputMap, outputMap, 10, 4));
 


### PR DESCRIPTION
Based on number of executor.cores per node, distribute blocks to each task. So that query load is evenly distributed to all tasks.