### PR TITLE
Filter and encoding lookup optimizations

### DIFF
--- a/core/src/main/java/org/carbondata/core/carbon/datastore/block/SegmentProperties.java
+++ b/core/src/main/java/org/carbondata/core/carbon/datastore/block/SegmentProperties.java
@@ -232,7 +232,7 @@ public class SegmentProperties {
         tableOrdinal++;
         // not adding the cardinality of the non dictionary
         // column as it was not the part of mdkey
-        if (CarbonUtil.hasEncoding(columnSchema.getEncodingList(), Encoding.DICTIONARY)
+        if (columnSchema.hasEncoding(Encoding.DICTIONARY)
             && !isComplexDimensionStarted && columnSchema.getNumberOfChild() == 0) {
           cardinalityIndexForNormalDimensionColumn.add(tableOrdinal);
           if (columnSchema.isColumnar()) {
@@ -313,7 +313,7 @@ public class SegmentProperties {
     while (counter < dimensions.size()) {
       CarbonDimension carbonDimension = dimensions.get(counter);
       // if dimension is not a part of mdkey then no need to add
-      if (!carbonDimension.getEncoder().contains(Encoding.DICTIONARY)) {
+      if (!carbonDimension.hasEncoding(Encoding.DICTIONARY)) {
         isDictionaryColumn.add(false);
         counter++;
         continue;

--- a/core/src/main/java/org/carbondata/core/carbon/datastore/chunk/DimensionChunkAttributes.java
+++ b/core/src/main/java/org/carbondata/core/carbon/datastore/chunk/DimensionChunkAttributes.java
@@ -35,6 +35,11 @@ public class DimensionChunkAttributes {
   private int[] invertedIndexesReverse;
 
   /**
+   * Run length encoding
+   */
+  private int[] rle;
+
+  /**
    * each row size
    */
   private int columnValueSize;
@@ -98,5 +103,13 @@ public class DimensionChunkAttributes {
    */
   public void setNoDictionary(boolean isNoDictionary) {
     this.isNoDictionary = isNoDictionary;
+  }
+
+  public int[] getRle() {
+    return rle;
+  }
+
+  public void setRle(int[] rle) {
+    this.rle = rle;
   }
 }

--- a/core/src/main/java/org/carbondata/core/carbon/datastore/chunk/reader/dimension/CompressedDimensionChunkFileBasedReader.java
+++ b/core/src/main/java/org/carbondata/core/carbon/datastore/chunk/reader/dimension/CompressedDimensionChunkFileBasedReader.java
@@ -85,8 +85,7 @@ public class CompressedDimensionChunkFileBasedReader extends AbstractChunkReader
         .readByteArray(filePath, dimensionColumnChunk.get(blockIndex).getDataPageOffset(),
             dimensionColumnChunk.get(blockIndex).getDataPageLength()));
     // if row id block is present then read the row id chunk and uncompress it
-    if (CarbonUtil.hasEncoding(dimensionColumnChunk.get(blockIndex).getEncodingList(),
-        Encoding.INVERTED_INDEX)) {
+    if (dimensionColumnChunk.get(blockIndex).hasEncoding(Encoding.INVERTED_INDEX)) {
       invertedIndexes = CarbonUtil
           .getUnCompressColumnIndex(dimensionColumnChunk.get(blockIndex).getRowIdPageLength(),
               fileReader.readByteArray(filePath,
@@ -97,21 +96,21 @@ public class CompressedDimensionChunkFileBasedReader extends AbstractChunkReader
     }
     // if rle is applied then read the rle block chunk and then uncompress
     //then actual data based on rle block
-    if (CarbonUtil
-        .hasEncoding(dimensionColumnChunk.get(blockIndex).getEncodingList(), Encoding.RLE)) {
+    if (dimensionColumnChunk.get(blockIndex).hasEncoding(Encoding.RLE)) {
       // read and uncompress the rle block
       rlePage = numberComressor.unCompress(fileReader
           .readByteArray(filePath, dimensionColumnChunk.get(blockIndex).getRlePageOffset(),
               dimensionColumnChunk.get(blockIndex).getRlePageLength()));
       // uncompress the data with rle indexes
-      dataPage = UnBlockIndexer.uncompressData(dataPage, rlePage, eachColumnValueSize[blockIndex]);
-      rlePage = null;
+      // dataPage = UnBlockIndexer.uncompressData(dataPage, rlePage, eachColumnValueSize[blockIndex]);
+      // rlePage = null;
     }
     // fill chunk attributes
     DimensionChunkAttributes chunkAttributes = new DimensionChunkAttributes();
     chunkAttributes.setEachRowSize(eachColumnValueSize[blockIndex]);
     chunkAttributes.setInvertedIndexes(invertedIndexes);
     chunkAttributes.setInvertedIndexesReverse(invertedIndexesReverse);
+    chunkAttributes.setRle(rlePage);
     DimensionColumnDataChunk columnDataChunk = null;
 
     if (dimensionColumnChunk.get(blockIndex).isRowChunk()) {
@@ -120,8 +119,7 @@ public class CompressedDimensionChunkFileBasedReader extends AbstractChunkReader
     }
     // if no dictionary column then first create a no dictionary column chunk
     // and set to data chunk instance
-    if (!CarbonUtil
-        .hasEncoding(dimensionColumnChunk.get(blockIndex).getEncodingList(), Encoding.DICTIONARY)) {
+    if (!dimensionColumnChunk.get(blockIndex).hasEncoding(Encoding.DICTIONARY)) {
       columnDataChunk =
           new VariableLengthDimensionDataChunk(getNoDictionaryDataChunk(dataPage), chunkAttributes);
       chunkAttributes.setNoDictionary(true);

--- a/core/src/main/java/org/carbondata/core/carbon/datastore/chunk/reader/dimension/CompressedDimensionChunkFileBasedReader.java
+++ b/core/src/main/java/org/carbondata/core/carbon/datastore/chunk/reader/dimension/CompressedDimensionChunkFileBasedReader.java
@@ -28,7 +28,6 @@ import org.carbondata.core.carbon.datastore.chunk.impl.VariableLengthDimensionDa
 import org.carbondata.core.carbon.metadata.blocklet.datachunk.DataChunk;
 import org.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.carbondata.core.datastorage.store.FileHolder;
-import org.carbondata.core.datastorage.store.columnar.UnBlockIndexer;
 import org.carbondata.core.util.CarbonUtil;
 
 /**
@@ -102,15 +101,16 @@ public class CompressedDimensionChunkFileBasedReader extends AbstractChunkReader
           .readByteArray(filePath, dimensionColumnChunk.get(blockIndex).getRlePageOffset(),
               dimensionColumnChunk.get(blockIndex).getRlePageLength()));
       // uncompress the data with rle indexes
-      // dataPage = UnBlockIndexer.uncompressData(dataPage, rlePage, eachColumnValueSize[blockIndex]);
-      // rlePage = null;
+      // dataPage = UnBlockIndexer
+      // .uncompressData(dataPage, rlePage, eachColumnValueSize[blockIndex]);
+      // rlePage = null;`
     }
     // fill chunk attributes
     DimensionChunkAttributes chunkAttributes = new DimensionChunkAttributes();
     chunkAttributes.setEachRowSize(eachColumnValueSize[blockIndex]);
     chunkAttributes.setInvertedIndexes(invertedIndexes);
     chunkAttributes.setInvertedIndexesReverse(invertedIndexesReverse);
-    chunkAttributes.setRle(rlePage);
+    chunkAttributes.setRle(rlePage.length > 0 ? rlePage : null);
     DimensionColumnDataChunk columnDataChunk = null;
 
     if (dimensionColumnChunk.get(blockIndex).isRowChunk()) {

--- a/core/src/main/java/org/carbondata/core/carbon/metadata/blocklet/datachunk/DataChunk.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/blocklet/datachunk/DataChunk.java
@@ -19,6 +19,7 @@
 package org.carbondata.core.carbon.metadata.blocklet.datachunk;
 
 import java.io.Serializable;
+import java.util.BitSet;
 import java.util.List;
 
 import org.carbondata.core.carbon.metadata.blocklet.compressor.ChunkCompressorMeta;
@@ -113,6 +114,8 @@ public class DataChunk implements Serializable {
    * about max, min, decimal length, type
    */
   private List<ValueEncoderMeta> valueEncoderMetaList;
+
+  private BitSet encodingSet = new BitSet();
 
   /**
    * @return the chunkCompressionMeta
@@ -308,6 +311,14 @@ public class DataChunk implements Serializable {
    */
   public void setEncoderList(List<Encoding> encodingList) {
     this.encodingList = encodingList;
+    encodingSet.clear();
+    for (Encoding encoding : encodingList) {
+      encodingSet.set(encoding.getEncodingIndex());
+    }
+  }
+
+  public boolean hasEncoding(Encoding encoding) {
+    return encodingSet.get(encoding.getEncodingIndex());
   }
 
   /**

--- a/core/src/main/java/org/carbondata/core/carbon/metadata/encoder/Encoding.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/encoder/Encoding.java
@@ -22,10 +22,20 @@ package org.carbondata.core.carbon.metadata.encoder;
  * Encoding type supported in carbon
  */
 public enum Encoding {
-  DICTIONARY,
-  DELTA,
-  RLE,
-  INVERTED_INDEX,
-  BIT_PACKED,
-  DIRECT_DICTIONARY;
+  DICTIONARY(1),
+  DELTA(2),
+  RLE(3),
+  INVERTED_INDEX(4),
+  BIT_PACKED(5),
+  DIRECT_DICTIONARY(6);
+
+  private int encodingIndex;
+
+  Encoding(int encodingIndex) {
+    this.encodingIndex = encodingIndex;
+  }
+
+  public int getEncodingIndex() {
+    return encodingIndex;
+  }
 }

--- a/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTable.java
@@ -132,9 +132,9 @@ public class CarbonTable implements Serializable {
                   listOfColumns, complexDimension);
           i = dimensionOrdinal - 1;
         } else {
-          if (!columnSchema.getEncodingList().contains(Encoding.DICTIONARY)) {
+          if (!columnSchema.hasEncoding(Encoding.DICTIONARY)) {
             dimensions.add(new CarbonDimension(columnSchema, dimensionOrdinal++, -1, -1));
-          } else if (columnSchema.getEncodingList().contains(Encoding.DICTIONARY)
+          } else if (columnSchema.hasEncoding(Encoding.DICTIONARY)
               && columnSchema.getColumnGroupId() == -1) {
             dimensions.add(new CarbonDimension(columnSchema, dimensionOrdinal++, keyOrdinal++, -1));
           } else {

--- a/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/column/CarbonDimension.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/column/CarbonDimension.java
@@ -91,7 +91,7 @@ public class CarbonDimension extends CarbonColumn {
   }
 
   public boolean hasEncoding(Encoding encoding) {
-    return columnSchema.getEncodingList().contains(encoding);
+    return columnSchema.hasEncoding(encoding);
   }
 
   /**

--- a/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
@@ -19,6 +19,7 @@
 package org.carbondata.core.carbon.metadata.schema.table.column;
 
 import java.io.Serializable;
+import java.util.BitSet;
 import java.util.List;
 
 import org.carbondata.core.carbon.metadata.datatype.ConvertedType;
@@ -105,6 +106,11 @@ public class ColumnSchema implements Serializable {
    * used in case of schema restructuring
    */
   private byte[] defaultValue;
+
+  /**
+   * Bit set to recognize the encodings
+   */
+  private BitSet encodingSet = new BitSet();
 
   /**
    * @return the columnName
@@ -321,6 +327,10 @@ public class ColumnSchema implements Serializable {
    */
   public void setEncodingList(List<Encoding> encodingList) {
     this.encodingList = encodingList;
+    encodingSet.clear();
+    for (Encoding encoding : encodingList) {
+      encodingSet.set(encoding.getEncodingIndex());
+    }
   }
 
   /**
@@ -328,11 +338,7 @@ public class ColumnSchema implements Serializable {
    * @return true if contains the passing encoding
    */
   public boolean hasEncoding(Encoding encoding) {
-    if (encodingList == null || encodingList.isEmpty()) {
-      return false;
-    } else {
-      return encodingList.contains(encoding);
-    }
+    return encodingSet.get(encoding.getEncodingIndex());
   }
 
   /**

--- a/core/src/main/java/org/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonUtil.java
@@ -1834,18 +1834,6 @@ public final class CarbonUtil {
   }
 
   /**
-   * Below method will be used to check whether particular encoding is present
-   * in the dimension or not
-   *
-   * @param dimension
-   * @param encoding  encoding to search
-   * @return if encoding is present in dimension
-   */
-  public static boolean hasEncoding(List<Encoding> encodings, Encoding encoding) {
-    return encodings.contains(encoding);
-  }
-
-  /**
    * below method is to check whether data type is present in the data type array
    *
    * @param dataType  data type to be searched
@@ -1985,8 +1973,8 @@ public final class CarbonUtil {
     List<Boolean> isDictionaryDimensions = new ArrayList<Boolean>();
     Set<Integer> processedColumnGroup = new HashSet<Integer>();
     for (CarbonDimension carbonDimension : tableDimensionList) {
-      if (carbonDimension.isColumnar() && hasEncoding(carbonDimension.getEncoder(),
-          Encoding.DICTIONARY)) {
+      if (carbonDimension.isColumnar() &&
+          carbonDimension.hasEncoding(Encoding.DICTIONARY)) {
         isDictionaryDimensions.add(true);
       } else if (!carbonDimension.isColumnar()) {
         if (processedColumnGroup.add(carbonDimension.columnGroupId())) {
@@ -2053,6 +2041,17 @@ public final class CarbonUtil {
       total += byteBufferArr[index].capacity();
     }
     return total;
+  }
+
+  /**
+   * Calculates of size of data till the index
+   */
+  public static int calculateRleIndexSize(int index, int[] rle) {
+    int size = 0;
+    for (int i = 1; i < index * 2; i += 2) {
+      size = rle[i] + size;
+    }
+    return size;
   }
 
 }

--- a/core/src/main/java/org/carbondata/query/carbon/aggregator/expression/ExpressionAggregator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/aggregator/expression/ExpressionAggregator.java
@@ -99,7 +99,7 @@ public class ExpressionAggregator {
                 row[j] = scannedResult.getDoubleMeasureValue(carbonColumn.getOrdinal());
             }
           }
-        } else if (!CarbonUtil.hasEncoding(carbonColumn.getEncoder(), Encoding.DICTIONARY)) {
+        } else if (!carbonColumn.hasEncoding(Encoding.DICTIONARY)) {
           // for dictionary column get the data
           String noDictionaryColumnData =
               new String(scannedResult.getDimensionKey(carbonColumn.getOrdinal()));

--- a/core/src/main/java/org/carbondata/query/carbon/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/impl/AbstractQueryExecutor.java
@@ -39,7 +39,6 @@ import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.impl.FileFactory;
 import org.carbondata.core.keygenerator.KeyGenException;
 import org.carbondata.core.keygenerator.KeyGenerator;
-import org.carbondata.core.util.CarbonUtil;
 import org.carbondata.query.aggregator.util.MeasureAggregatorFactory;
 import org.carbondata.query.carbon.executor.QueryExecutor;
 import org.carbondata.query.carbon.executor.exception.QueryExecutionException;
@@ -376,8 +375,7 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
       if (queryDimension.get(counter).getDimension().numberOfChild() > 0) {
         counter += queryDimension.get(counter).getDimension().numberOfChild();
         continue;
-      } else if (!CarbonUtil.hasEncoding(queryDimension.get(counter).getDimension().getEncoder(),
-          Encoding.DICTIONARY)) {
+      } else if (!queryDimension.get(counter).getDimension().hasEncoding(Encoding.DICTIONARY)) {
         counter++;
       } else {
         fixedLengthDimensionOrdinal.add(queryDimension.get(counter).getDimension().getKeyOrdinal());

--- a/core/src/main/java/org/carbondata/query/carbon/executor/impl/QueryResultPreparator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/impl/QueryResultPreparator.java
@@ -27,7 +27,6 @@ import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.carbondata.core.constants.CarbonCommonConstants;
-import org.carbondata.core.util.CarbonUtil;
 import org.carbondata.query.aggregator.MeasureAggregator;
 import org.carbondata.query.aggregator.impl.CountAggregator;
 import org.carbondata.query.aggregator.impl.DistinctCountAggregator;
@@ -100,8 +99,7 @@ public class QueryResultPreparator {
           .getKeyArray(key.getDictionaryKey(),
               queryExecuterProperties.keyStructureInfo.getMaskedBytes());
       for (int i = 0; i < dimensionCount; i++) {
-        if (!CarbonUtil
-            .hasEncoding(queryDimension.get(i).getDimension().getEncoder(), Encoding.DICTIONARY)) {
+        if (!queryDimension.get(i).getDimension().hasEncoding(Encoding.DICTIONARY)) {
           resultData[currentRow][i] = DataTypeUtil.getDataBasedOnDataType(
               new String(key.getNoDictionaryKeyByIndex(noDictionaryColumnIndex++)),
               queryDimension.get(i).getDimension().getDataType());
@@ -162,8 +160,7 @@ public class QueryResultPreparator {
       row = new Object[dimensionCount + msrCount];
       for (int i = 0; i < dimensionCount; i++) {
         queryDimension = queryDimensions.get(i);
-        if (!CarbonUtil
-            .hasEncoding(queryDimension.getDimension().getEncoder(), Encoding.DICTIONARY)) {
+        if (!queryDimension.getDimension().hasEncoding(Encoding.DICTIONARY)) {
           row[queryDimension.getQueryOrder()] = convertedResult[i][columnIndex];
         } else {
           if (queryExecuterProperties.sortDimIndexes[i] == 1) {

--- a/core/src/main/java/org/carbondata/query/carbon/executor/util/QueryUtil.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/util/QueryUtil.java
@@ -48,7 +48,6 @@ import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.keygenerator.KeyGenException;
 import org.carbondata.core.keygenerator.KeyGenerator;
-import org.carbondata.core.util.CarbonUtil;
 import org.carbondata.core.util.CarbonUtilException;
 import org.carbondata.query.carbon.aggregator.dimension.DimensionDataAggregator;
 import org.carbondata.query.carbon.aggregator.dimension.impl.ColumnGroupDimensionsAggregator;
@@ -278,19 +277,19 @@ public class QueryUtil {
     // so we need to get only one instance of dictionary
     Set<String> dictionaryDimensionFromQuery = new HashSet<String>();
     for (int i = 0; i < queryDimensions.size(); i++) {
-      if (queryDimensions.get(i).getDimension().getEncoder().contains(Encoding.DICTIONARY)) {
+      if (queryDimensions.get(i).getDimension().hasEncoding(Encoding.DICTIONARY)) {
         dictionaryDimensionFromQuery.add(queryDimensions.get(i).getDimension().getColumnId());
       }
     }
     for (int i = 0; i < dimAggInfo.size(); i++) {
-      if (dimAggInfo.get(i).getDim().getEncoder().contains(Encoding.DICTIONARY)) {
+      if (dimAggInfo.get(i).getDim().hasEncoding(Encoding.DICTIONARY)) {
         dictionaryDimensionFromQuery.add(dimAggInfo.get(i).getDim().getColumnId());
       }
     }
     for (int i = 0; i < customAggExpression.size(); i++) {
       List<CarbonColumn> referredColumns = customAggExpression.get(i).getReferredColumns();
       for (CarbonColumn column : referredColumns) {
-        if (CarbonUtil.hasEncoding(column.getEncoder(), Encoding.DICTIONARY)) {
+        if (column.hasEncoding(Encoding.DICTIONARY)) {
           dictionaryDimensionFromQuery.add(column.getColumnId());
         }
       }
@@ -397,7 +396,7 @@ public class QueryUtil {
     int index = 0;
     for (int i = 0; i < dimensionCompareIndex.length; i++) {
       Set<Integer> integers = new TreeSet<Integer>();
-      if (!orderByDimensions.get(i).getDimension().getEncoder().contains(Encoding.DICTIONARY)
+      if (!orderByDimensions.get(i).getDimension().hasEncoding(Encoding.DICTIONARY)
           || orderByDimensions.get(i).getDimension().numberOfChild() > 0) {
         continue;
       }
@@ -670,8 +669,7 @@ public class QueryUtil {
       } else {
         // if it is a dictionary column than create a fixed length
         // aggeragtor
-        if (CarbonUtil
-            .hasEncoding(entry.getValue().get(0).getDim().getEncoder(), Encoding.DICTIONARY)) {
+        if (entry.getValue().get(0).getDim().hasEncoding(Encoding.DICTIONARY)) {
           dimensionDataAggregators.add(
               new FixedLengthDimensionAggregator(entry.getValue().get(0), null,
                   columnUniqueIdToDictionaryMap.get(entry.getValue().get(0).getDim().getColumnId()),
@@ -745,7 +743,7 @@ public class QueryUtil {
       Map<Integer, Integer> columnOrdinalToBlockIndexMapping,
       List<Integer> dictionaryDimensionBlockIndex, List<Integer> noDictionaryDimensionBlockIndex) {
     for (QueryDimension queryDimension : queryDimensions) {
-      if (CarbonUtil.hasEncoding(queryDimension.getDimension().getEncoder(), Encoding.DICTIONARY)) {
+      if (queryDimension.getDimension().hasEncoding(Encoding.DICTIONARY)) {
         dictionaryDimensionBlockIndex
             .add(columnOrdinalToBlockIndexMapping.get(queryDimension.getDimension().getOrdinal()));
       } else {

--- a/core/src/main/java/org/carbondata/query/carbon/merger/impl/SortedScannedResultMerger.java
+++ b/core/src/main/java/org/carbondata/query/carbon/merger/impl/SortedScannedResultMerger.java
@@ -30,7 +30,6 @@ import org.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.iterator.CarbonIterator;
 import org.carbondata.core.keygenerator.KeyGenException;
-import org.carbondata.core.util.CarbonUtil;
 import org.carbondata.query.carbon.executor.exception.QueryExecutionException;
 import org.carbondata.query.carbon.executor.infos.BlockExecutionInfo;
 import org.carbondata.query.carbon.executor.infos.KeyStructureInfo;
@@ -74,8 +73,7 @@ public class SortedScannedResultMerger extends AbstractScannedResultMerger {
     int length = sortInfo.getSortDimension().size();
     int noDictionaryIndex = 0;
     for (int i = 0; i < length; i++) {
-      if (!CarbonUtil.hasEncoding(sortInfo.getSortDimension().get(i).getDimension().getEncoder(),
-          Encoding.DICTIONARY)) {
+      if (!sortInfo.getSortDimension().get(i).getDimension().hasEncoding(Encoding.DICTIONARY)) {
         compratorList.add(new VariableLengthKeyResultComparator(sortInfo.getDimensionSortOrder()[i],
             noDictionaryIndex++, sortInfo.getSortDimension().get(i).getDimension().getDataType()));
       } else {
@@ -131,8 +129,7 @@ public class SortedScannedResultMerger extends AbstractScannedResultMerger {
         keyArray = keyStructureInfo.getKeyGenerator()
             .getKeyArray(key.getDictionaryKey(), keyStructureInfo.getMaskedBytes());
         for (int i = 0; i < sortInfo.getSortDimension().size(); i++) {
-          if (CarbonUtil.hasEncoding(sortInfo.getSortDimension().get(i).getDimension().getEncoder(),
-              Encoding.DICTIONARY)) {
+          if (sortInfo.getSortDimension().get(i).getDimension().hasEncoding(Encoding.DICTIONARY)) {
             keyArray[sortInfo.getSortDimension().get(i).getDimension().getKeyOrdinal()] =
                 blockExecutionInfo.getColumnIdToDcitionaryMapping()
                     .get(sortInfo.getSortDimension().get(i).getDimension().getColumnId())

--- a/core/src/main/java/org/carbondata/query/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/executer/ExcludeFilterExecuterImpl.java
@@ -136,6 +136,9 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     BitSet bitSet = new BitSet(numerOfRows);
     bitSet.flip(0, numerOfRows);
     int[] rle = dimColumnDataChunk.getAttributes().getRle();
+    if (rle != null) {
+      numerOfRows = rle.length / 2;
+    }
     byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
     for (int i = 0; i < filterValues.length; i++) {
       startKey = CarbonUtil
@@ -181,6 +184,9 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     bitSet.flip(0, numerOfRows);
     int startIndex = 0;
     int[] rle = dimColumnDataChunk.getAttributes().getRle();
+    if (rle != null) {
+      numerOfRows = rle.length / 2;
+    }
     byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
     for (int k = 0; k < filterValues.length; k++) {
       startKey = CarbonUtil

--- a/core/src/main/java/org/carbondata/query/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/executer/IncludeFilterExecuterImpl.java
@@ -132,13 +132,17 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     BitSet bitSet = new BitSet(numerOfRows);
     int[] columnIndex = dimensionColumnDataChunk.getAttributes().getInvertedIndexes();
     int[] rle = dimensionColumnDataChunk.getAttributes().getRle();
+    if (rle != null) {
+      numerOfRows = rle.length / 2;
+    }
     int start = 0;
     int last = 0;
     int startIndex = 0;
     byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
     for (int i = 0; i < filterValues.length; i++) {
-      start = CarbonUtil.getFirstIndexUsingBinarySearch(dimensionColumnDataChunk, startIndex,
-          dimensionColumnDataChunk.getCompleteDataChunk().length - 1, filterValues[i]);
+      start = CarbonUtil
+          .getFirstIndexUsingBinarySearch(dimensionColumnDataChunk, startIndex, numerOfRows - 1,
+              filterValues[i]);
       if (start == -1) {
         continue;
       }
@@ -184,6 +188,9 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
         int last = 0;
         int startIndex = 0;
         int[] rle = dimensionColumnDataChunk.getAttributes().getRle();
+        if (rle != null) {
+          numerOfRows = rle.length / 2;
+        }
         byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
         for (int k = 0; k < filterValues.length; k++) {
           start = CarbonUtil.getFirstIndexUsingBinarySearch(

--- a/core/src/main/java/org/carbondata/query/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/executer/IncludeFilterExecuterImpl.java
@@ -80,50 +80,48 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
   private BitSet setDirectKeyFilterIndexToBitSet(
       VariableLengthDimensionDataChunk dimensionColumnDataChunk, int numerOfRows) {
     BitSet bitSet = new BitSet(numerOfRows);
-    if (dimensionColumnDataChunk instanceof VariableLengthDimensionDataChunk) {
-      List<byte[]> listOfColumnarKeyBlockDataForNoDictionaryVals =
-          ((VariableLengthDimensionDataChunk) dimensionColumnDataChunk).getCompleteDataChunk();
-      byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
-      int[] columnIndexArray = dimensionColumnDataChunk.getAttributes().getInvertedIndexes();
-      int[] columnReverseIndexArray =
-          dimensionColumnDataChunk.getAttributes().getInvertedIndexesReverse();
-      for (int i = 0; i < filterValues.length; i++) {
-        byte[] filterVal = filterValues[i];
-        if (null != listOfColumnarKeyBlockDataForNoDictionaryVals) {
+    List<byte[]> listOfColumnarKeyBlockDataForNoDictionaryVals =
+        dimensionColumnDataChunk.getCompleteDataChunk();
+    byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
+    int[] columnIndexArray = dimensionColumnDataChunk.getAttributes().getInvertedIndexes();
+    int[] columnReverseIndexArray =
+        dimensionColumnDataChunk.getAttributes().getInvertedIndexesReverse();
+    for (int i = 0; i < filterValues.length; i++) {
+      byte[] filterVal = filterValues[i];
+      if (null != listOfColumnarKeyBlockDataForNoDictionaryVals) {
 
-          if (null != columnIndexArray) {
-            for (int index : columnIndexArray) {
-              byte[] noDictionaryVal =
-                  listOfColumnarKeyBlockDataForNoDictionaryVals.get(columnReverseIndexArray[index]);
-              if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(filterVal, noDictionaryVal) == 0) {
-                bitSet.set(index);
-              }
+        if (null != columnIndexArray) {
+          for (int index : columnIndexArray) {
+            byte[] noDictionaryVal =
+                listOfColumnarKeyBlockDataForNoDictionaryVals.get(columnReverseIndexArray[index]);
+            if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(filterVal, noDictionaryVal) == 0) {
+              bitSet.set(index);
             }
-          } else if (null != columnReverseIndexArray) {
+          }
+        } else if (null != columnReverseIndexArray) {
 
-            for (int index : columnReverseIndexArray) {
-              byte[] noDictionaryVal =
-                  listOfColumnarKeyBlockDataForNoDictionaryVals.get(columnReverseIndexArray[index]);
-              if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(filterVal, noDictionaryVal) == 0) {
-                bitSet.set(index);
-              }
+          for (int index : columnReverseIndexArray) {
+            byte[] noDictionaryVal =
+                listOfColumnarKeyBlockDataForNoDictionaryVals.get(columnReverseIndexArray[index]);
+            if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(filterVal, noDictionaryVal) == 0) {
+              bitSet.set(index);
             }
-          } else {
+          }
+        } else {
 
-            for (int index = 0;
-                 index < listOfColumnarKeyBlockDataForNoDictionaryVals.size(); index++) {
-              if (ByteUtil.UnsafeComparer.INSTANCE
-                  .compareTo(filterVal, listOfColumnarKeyBlockDataForNoDictionaryVals.get(index))
-                  == 0) {
-                bitSet.set(index);
-              }
-
+          for (int index = 0;
+               index < listOfColumnarKeyBlockDataForNoDictionaryVals.size(); index++) {
+            if (ByteUtil.UnsafeComparer.INSTANCE
+                .compareTo(filterVal, listOfColumnarKeyBlockDataForNoDictionaryVals.get(index))
+                == 0) {
+              bitSet.set(index);
             }
 
           }
-        }
 
+        }
       }
+
     }
     return bitSet;
 
@@ -132,27 +130,33 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
   private BitSet setFilterdIndexToBitSetWithColumnIndex(
       FixedLengthDimensionDataChunk dimensionColumnDataChunk, int numerOfRows) {
     BitSet bitSet = new BitSet(numerOfRows);
-    if (dimensionColumnDataChunk instanceof FixedLengthDimensionDataChunk) {
-      FixedLengthDimensionDataChunk fixedColumnDataChunk =
-          (FixedLengthDimensionDataChunk) dimensionColumnDataChunk;
-      int[] columnIndex = dimensionColumnDataChunk.getAttributes().getInvertedIndexes();
-      int start = 0;
-      int last = 0;
-      int startIndex = 0;
-      byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
-      for (int i = 0; i < filterValues.length; i++) {
-        start = CarbonUtil
-            .getFirstIndexUsingBinarySearch(dimensionColumnDataChunk, startIndex, numerOfRows - 1,
-                filterValues[i]);
-        if (start == -1) {
-          continue;
+    int[] columnIndex = dimensionColumnDataChunk.getAttributes().getInvertedIndexes();
+    int[] rle = dimensionColumnDataChunk.getAttributes().getRle();
+    int start = 0;
+    int last = 0;
+    int startIndex = 0;
+    byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
+    for (int i = 0; i < filterValues.length; i++) {
+      start = CarbonUtil.getFirstIndexUsingBinarySearch(dimensionColumnDataChunk, startIndex,
+          dimensionColumnDataChunk.getCompleteDataChunk().length - 1, filterValues[i]);
+      if (start == -1) {
+        continue;
+      }
+      if (rle != null) {
+        // take advantage of rle
+        int rleIndexSize = rle[(start*2) + 1];
+        int size = CarbonUtil.calculateRleIndexSize(start, rle);
+        for (int j = size; j < size + rleIndexSize; j++) {
+          bitSet.set(columnIndex[j]);
         }
+      } else {
         bitSet.set(columnIndex[start]);
         last = start;
         for (int j = start + 1; j < numerOfRows; j++) {
           if (ByteUtil.UnsafeComparer.INSTANCE
-              .compareTo(fixedColumnDataChunk.getCompleteDataChunk(), j * filterValues[i].length,
-                  filterValues[i].length, filterValues[i], 0, filterValues[i].length) == 0) {
+              .compareTo(dimensionColumnDataChunk.getCompleteDataChunk(),
+                  j * filterValues[i].length, filterValues[i].length, filterValues[i], 0,
+                  filterValues[i].length) == 0) {
             bitSet.set(columnIndex[j]);
             last++;
           } else {
@@ -164,6 +168,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
           break;
         }
       }
+
     }
     return bitSet;
   }
@@ -178,6 +183,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
         int start = 0;
         int last = 0;
         int startIndex = 0;
+        int[] rle = dimensionColumnDataChunk.getAttributes().getRle();
         byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
         for (int k = 0; k < filterValues.length; k++) {
           start = CarbonUtil.getFirstIndexUsingBinarySearch(
@@ -186,21 +192,30 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
           if (start == -1) {
             continue;
           }
-          bitSet.set(start);
-          last = start;
-          for (int j = start + 1; j < numerOfRows; j++) {
-            if (ByteUtil.UnsafeComparer.INSTANCE
-                .compareTo(fixedDimensionChunk.getCompleteDataChunk(), j * filterValues[k].length,
-                    filterValues[k].length, filterValues[k], 0, filterValues[k].length) == 0) {
+          if (rle != null) {
+            // take advantage of rle
+            int rleIndexSize = rle[(start*2) + 1];
+            int size = CarbonUtil.calculateRleIndexSize(start, rle);
+            for (int j = size; j < size + rleIndexSize; j++) {
               bitSet.set(j);
-              last++;
-            } else {
+            }
+          } else {
+            bitSet.set(start);
+            last = start;
+            for (int j = start + 1; j < numerOfRows; j++) {
+              if (ByteUtil.UnsafeComparer.INSTANCE
+                  .compareTo(fixedDimensionChunk.getCompleteDataChunk(), j * filterValues[k].length,
+                      filterValues[k].length, filterValues[k], 0, filterValues[k].length) == 0) {
+                bitSet.set(j);
+                last++;
+              } else {
+                break;
+              }
+            }
+            startIndex = last;
+            if (startIndex >= numerOfRows) {
               break;
             }
-          }
-          startIndex = last;
-          if (startIndex >= numerOfRows) {
-            break;
           }
         }
       }

--- a/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
@@ -704,7 +704,7 @@ public final class FilterUtil {
     List<CarbonDimension> listOfCarbonDimPartOfKeyGen =
         new ArrayList<CarbonDimension>(carbonDimensions.size());
     for (CarbonDimension carbonDim : carbonDimensions) {
-      if (CarbonUtil.hasEncoding(carbonDim.getEncoder(), Encoding.DICTIONARY)) {
+      if (carbonDim.hasEncoding(Encoding.DICTIONARY)) {
         listOfCarbonDimPartOfKeyGen.add(carbonDim);
       }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/cubemodel/cubeSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/cubemodel/cubeSchema.scala
@@ -222,12 +222,14 @@ class CubeNewProcessor(cm: tableModel, sqlContext: SQLContext) {
     updateColumnGroupsInFields(cm.columnGroups, allColumns)
 
     for (column <- allColumns) {
+      val encodingList = column.getEncodingList
       if (highCardinalityDims.contains(column.getColumnName)) {
-        column.getEncodingList.remove(Encoding.DICTIONARY)
+        encodingList.remove(Encoding.DICTIONARY)
       }
       if (column.getDataType == DataType.TIMESTAMP && isDirectDictionary) {
-        column.getEncodingList.add(Encoding.DIRECT_DICTIONARY)
+        encodingList.add(Encoding.DIRECT_DICTIONARY)
       }
+      column.setEncodingList(encodingList)
     }
 
     var newOrderedDims = scala.collection.mutable.ListBuffer[ColumnSchema]()

--- a/processing/src/main/java/org/carbondata/processing/graphgenerator/GraphGenerator.java
+++ b/processing/src/main/java/org/carbondata/processing/graphgenerator/GraphGenerator.java
@@ -1885,7 +1885,7 @@ public class GraphGenerator {
         break;
       }
 
-      if (!dimension.getEncoder().contains(Encoding.DICTIONARY)) {
+      if (!dimension.hasEncoding(Encoding.DICTIONARY)) {
         noDictionaryMapping.add(true);
         //NoDictionaryMapping[index] = true;
       } else {

--- a/processing/src/main/java/org/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -353,8 +353,8 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     for (int i = 0; i < wrapperColumnSchemaList.size(); i++) {
       columnSchemaList
           .add(schemaConverter.fromWrapperToExternalColumnSchema(wrapperColumnSchemaList.get(i)));
-      if (CarbonUtil.hasEncoding(wrapperColumnSchemaList.get(i).getEncodingList(),
-          org.carbondata.core.carbon.metadata.encoder.Encoding.DICTIONARY)) {
+      if (wrapperColumnSchemaList.get(i)
+          .hasEncoding(org.carbondata.core.carbon.metadata.encoder.Encoding.DICTIONARY)) {
         cardinality.add(dictionaryColumnCardinality[counter]);
         counter++;
       } else if (!wrapperColumnSchemaList.get(i).isDimensionColumn()) {

--- a/processing/src/main/java/org/carbondata/processing/util/CarbonSchemaParser.java
+++ b/processing/src/main/java/org/carbondata/processing/util/CarbonSchemaParser.java
@@ -551,7 +551,7 @@ public final class CarbonSchemaParser {
   public static int getDimensionString(List<CarbonDimension> dimensions, StringBuilder dimString,
       int counter, CarbonDataLoadSchema carbonDataLoadSchema) {
     for (CarbonDimension cDimension : dimensions) {
-      if (!cDimension.getEncoder().contains(Encoding.DICTIONARY)) {
+      if (!cDimension.hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
 
@@ -739,7 +739,7 @@ public final class CarbonSchemaParser {
     String hierStr = "";
 
     for (CarbonDimension cDimension : dimensions) {
-      if (cDimension.getEncoder().contains(Encoding.DICTIONARY)) {
+      if (cDimension.hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
       String tableName = extractDimensionTableName(cDimension.getColName(), carbonDataLoadSchema);
@@ -879,7 +879,7 @@ public final class CarbonSchemaParser {
     List<String> list = new ArrayList<String>(CarbonCommonConstants.CONSTANT_SIZE_TEN);
     for (CarbonDimension cDimension : dimensions) {
       // Ignoring the dimensions which are high cardinality dimension
-      if (!cDimension.getEncoder().contains(Encoding.DICTIONARY)) {
+      if (!cDimension.hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
       list.add(extractDimensionTableName(cDimension.getColName(), carbonDataLoadSchema) + "_"
@@ -1778,7 +1778,7 @@ public final class CarbonSchemaParser {
     String hierStr = "";
 
     for (CarbonDimension cDimension : dimensions) {
-      if (cDimension.getEncoder().contains(Encoding.DICTIONARY)) {
+      if (cDimension.hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
       String tableName = extractDimensionTableName(cDimension.getColName(), carbonDataLoadSchema);
@@ -2079,7 +2079,7 @@ public final class CarbonSchemaParser {
   public static String getActualDimensions(List<CarbonDimension> dimensions) {
     StringBuilder actualDim = new StringBuilder();
     for (CarbonDimension cDimension : dimensions) {
-      if (!cDimension.getEncoder().contains(Encoding.DICTIONARY)) {
+      if (!cDimension.hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
       actualDim.append(cDimension.getColName());
@@ -2319,7 +2319,7 @@ public final class CarbonSchemaParser {
     StringBuffer buff = new StringBuffer();
     int counter = 0;
     for (CarbonDimension cDimension : dimensions) {
-      if (cDimension.getEncoder().contains(Encoding.DIRECT_DICTIONARY)) {
+      if (cDimension.hasEncoding(Encoding.DIRECT_DICTIONARY)) {
         buff.append(cDimension.getOrdinal());
         buff.append(CarbonCommonConstants.COLON_SPC_CHARACTER);
         buff.append(cDimension.getDataType());
@@ -2341,7 +2341,7 @@ public final class CarbonSchemaParser {
   public static int getNoDictionaryDimensionString(List<CarbonDimension> dimensions,
       StringBuilder dimString, int counter, CarbonDataLoadSchema carbonDataLoadSchema) {
     for (CarbonDimension cDimension : dimensions) {
-      if (cDimension.getEncoder().contains(Encoding.DICTIONARY)) {
+      if (cDimension.hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
 


### PR DESCRIPTION
When RLE encoding is enabled, we no need to decompress it while doing the include and exclude filters. It makes the filter query faster if we apply filters on rle data.

And also optimized the encoding lookup and used bitset instead of using list.contains.