### PR TITLE
[WIP] Optimized Filter Query and Fixed Non Filter EndKey Issue

### DIFF
--- a/core/src/main/java/org/carbondata/query/evaluators/DimColumnResolvedFilterInfo.java
+++ b/core/src/main/java/org/carbondata/query/evaluators/DimColumnResolvedFilterInfo.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.carbondata.core.carbon.datastore.IndexKey;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
-import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
-import org.carbondata.core.metadata.CarbonMetadata.Dimension;
 import org.carbondata.query.complex.querytypes.GenericQueryType;
 import org.carbondata.query.schema.metadata.DimColumnFilterInfo;
 
@@ -42,15 +40,6 @@ public class DimColumnResolvedFilterInfo implements Serializable {
    * column index in file
    */
   private int columnIndex = -1;
-
-  /**
-   * need compressed data from file
-   */
-  private boolean needCompressedData;
-
-  private Dimension dims;
-
-  private Dimension[] dimensions;
 
   /**
    * rowIndex
@@ -85,11 +74,8 @@ public class DimColumnResolvedFilterInfo implements Serializable {
 
   private Map<CarbonDimension, List<DimColumnFilterInfo>> dimensionResolvedFilter;
 
-  private Map<CarbonMeasure, List<DimColumnFilterInfo>> measureResolvedFilter;
-
   public DimColumnResolvedFilterInfo() {
     dimensionResolvedFilter = new HashMap<CarbonDimension, List<DimColumnFilterInfo>>(20);
-    measureResolvedFilter = new HashMap<CarbonMeasure, List<DimColumnFilterInfo>>(20);
   }
 
   public IndexKey getStarIndexKey() {
@@ -141,28 +127,12 @@ public class DimColumnResolvedFilterInfo implements Serializable {
     this.dimension = dimension;
   }
 
-  public Dimension[] getDimensions() {
-    return dimensions;
-  }
-
-  public void setDimensions(Dimension[] dimensions) {
-    this.dimensions = dimensions;
-  }
-
   public int getColumnIndex() {
     return columnIndex;
   }
 
   public void setColumnIndex(int columnIndex) {
     this.columnIndex = columnIndex;
-  }
-
-  public boolean isNeedCompressedData() {
-    return needCompressedData;
-  }
-
-  public void setNeedCompressedData(boolean needCompressedData) {
-    this.needCompressedData = needCompressedData;
   }
 
   public DimColumnFilterInfo getFilterValues() {
@@ -179,14 +149,6 @@ public class DimColumnResolvedFilterInfo implements Serializable {
 
   public void setRowIndex(int rowIndex) {
     this.rowIndex = rowIndex;
-  }
-
-  public Dimension getDims() {
-    return dims;
-  }
-
-  public void setDims(Dimension dims) {
-    this.dims = dims;
   }
 
   public boolean isDimensionExistsInCurrentSilce() {

--- a/core/src/main/java/org/carbondata/query/filter/resolver/ConditionalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/ConditionalFilterResolverImpl.java
@@ -21,8 +21,6 @@ package org.carbondata.query.filter.resolver;
 import java.util.List;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
-import org.carbondata.core.carbon.datastore.IndexKey;
-import org.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.carbondata.query.carbon.executor.exception.QueryExecutionException;
 import org.carbondata.query.carbonfilterinterface.FilterExecuterType;
@@ -178,55 +176,6 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
    */
   public DimColumnResolvedFilterInfo getDimColResolvedFilterInfo() {
     return dimColResolvedFilterInfo;
-  }
-
-  /**
-   * method will get the start key based on the filter surrogates
-   *
-   * @return start IndexKey
-   */
-  @Override public IndexKey getstartKey(SegmentProperties segmentProperties) {
-    IndexKey startIndexKey = null;
-    if (null == dimColResolvedFilterInfo.getStarIndexKey()) {
-      long[] startKey = FilterUtil.getStartKey(dimColResolvedFilterInfo, segmentProperties);
-      byte[] startKeyForNoDictDimension = FilterUtil
-          .getStartKeyForNoDictionaryDimension(dimColResolvedFilterInfo, segmentProperties);
-      startIndexKey = FilterUtil.createIndexKeyFromResolvedFilterVal(startKey,
-          segmentProperties.getDimensionKeyGenerator(), startKeyForNoDictDimension);
-      dimColResolvedFilterInfo.setStarIndexKey(startIndexKey);
-    } else {
-      return dimColResolvedFilterInfo.getStarIndexKey();
-    }
-    return startIndexKey;
-  }
-
-  /**
-   * method will get the start key based on the filter surrogates
-   *
-   * @return end IndexKey
-   */
-  @Override public IndexKey getEndKey(SegmentProperties segmentProperties,
-      AbsoluteTableIdentifier absoluteTableIdentifier) {
-    long[] endKey = new long[segmentProperties.getDimensionKeyGenerator().getDimCount()];
-    IndexKey endIndexKey = null;
-    byte[] endKeyForNoDictDimension = null;
-    if (null == dimColResolvedFilterInfo.getEndIndexKey()) {
-      try {
-        endKey = FilterUtil.getEndKey(dimColResolvedFilterInfo.getDimensionResolvedFilterInstance(),
-            absoluteTableIdentifier, endKey, segmentProperties.getDimensions());
-        endKeyForNoDictDimension = FilterUtil
-            .getEndKeyForNoDictionaryDimension(dimColResolvedFilterInfo, segmentProperties);
-      } catch (QueryExecutionException e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
-      }
-      endIndexKey = FilterUtil
-          .createIndexKeyFromResolvedFilterVal(endKey, segmentProperties.getDimensionKeyGenerator(),
-              endKeyForNoDictDimension);
-    } else {
-      return dimColResolvedFilterInfo.getEndIndexKey();
-    }
-    return endIndexKey;
   }
 
   /**

--- a/core/src/main/java/org/carbondata/query/filter/resolver/FilterResolverIntf.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/FilterResolverIntf.java
@@ -21,8 +21,6 @@ package org.carbondata.query.filter.resolver;
 import java.io.Serializable;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
-import org.carbondata.core.carbon.datastore.IndexKey;
-import org.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.carbondata.query.carbon.executor.exception.QueryExecutionException;
 import org.carbondata.query.carbonfilterinterface.FilterExecuterType;
 import org.carbondata.query.evaluators.DimColumnResolvedFilterInfo;
@@ -61,22 +59,6 @@ public interface FilterResolverIntf extends Serializable {
    * @return DimColumnResolvedFilterInfo object
    */
   DimColumnResolvedFilterInfo getDimColResolvedFilterInfo();
-
-  /**
-   * API will get the start key based on the filter applied
-   * based on the key generator
-   *
-   * @return long[], array of start keys.
-   */
-  IndexKey getstartKey(SegmentProperties segmentProperties);
-
-  /**
-   * API will read the end key based on the max surrogate of
-   * particular dimension column
-   *
-   * @return
-   */
-  IndexKey getEndKey(SegmentProperties segmentProperties, AbsoluteTableIdentifier tableIdentifier);
 
   /**
    * API will return the filter executer type which will be used to evaluate

--- a/core/src/main/java/org/carbondata/query/filter/resolver/LogicalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/LogicalFilterResolverImpl.java
@@ -19,8 +19,6 @@
 package org.carbondata.query.filter.resolver;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
-import org.carbondata.core.carbon.datastore.IndexKey;
-import org.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.carbondata.query.carbonfilterinterface.ExpressionType;
 import org.carbondata.query.carbonfilterinterface.FilterExecuterType;
 import org.carbondata.query.evaluators.DimColumnResolvedFilterInfo;
@@ -75,16 +73,6 @@ public class LogicalFilterResolverImpl implements FilterResolverIntf {
   }
 
   @Override public DimColumnResolvedFilterInfo getDimColResolvedFilterInfo() {
-    return null;
-  }
-
-  @Override public IndexKey getstartKey(SegmentProperties segmentProperties) {
-    return null;
-  }
-
-  @Override
-  public IndexKey getEndKey(SegmentProperties segmentProperties,
-      AbsoluteTableIdentifier tableIdentifier) {
     return null;
   }
 

--- a/core/src/main/java/org/carbondata/query/filter/resolver/RestructureFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/RestructureFilterResolverImpl.java
@@ -21,8 +21,6 @@ package org.carbondata.query.filter.resolver;
 import java.util.List;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
-import org.carbondata.core.carbon.datastore.IndexKey;
-import org.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.carbondata.query.carbonfilterinterface.FilterExecuterType;
 import org.carbondata.query.evaluators.DimColumnResolvedFilterInfo;
 import org.carbondata.query.expression.ColumnExpression;
@@ -172,29 +170,6 @@ public class RestructureFilterResolverImpl implements FilterResolverIntf {
    */
   public DimColumnResolvedFilterInfo getDimColResolvedFilterInfo() {
     return dimColumnResolvedFilterInfo;
-  }
-
-  /**
-   * For restructure resolver no implementation is required for getting
-   * the start key since it already has default values
-   *
-   * @return IndexKey.
-   */
-  @Override public IndexKey getstartKey(SegmentProperties segmentProperties) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  /**
-   * For restructure resolver no implementation is required for getting
-   * the end  key since it already has default values
-   *
-   * @return IndexKey.
-   */
-  @Override public IndexKey getEndKey(SegmentProperties segmentProperties,
-      AbsoluteTableIdentifier tableIdentifier) {
-    // TODO Auto-generated method stub
-    return null;
   }
 
   /**


### PR DESCRIPTION
1)Optimized Fixed filter issue when filter is on multiple dimension
default start and key was getting created and in btree jump
it was giving all the nodes of btree
2) Now in case of filter query end key will be created based on cardinality removed getting the
max key from dictionary this is to optimize filter creation
3) Fixed No filter end key issue