### PR TITLE
Filter optimization with range index in fwd dictionary cache lookup

### DIFF
--- a/core/src/main/java/org/carbondata/core/cache/dictionary/ForwardDictionary.java
+++ b/core/src/main/java/org/carbondata/core/cache/dictionary/ForwardDictionary.java
@@ -20,6 +20,8 @@
 package org.carbondata.core.cache.dictionary;
 
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Stack;
 
 import org.carbondata.core.constants.CarbonCommonConstants;
@@ -131,11 +133,21 @@ public class ForwardDictionary implements Dictionary {
 
   /**
    * This method will read the surrogates based on search range.
+   *
+   * @param surrogates
    */
-  public Integer getSurrogateKeyByIncrementalSearch(String value,
-      Stack<Integer> startIndexContainer) {
-    byte[] keyData = value.getBytes(Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
-    return columnDictionaryInfo
-        .getIncrementalSurrogateKeyFromDictionary(keyData, startIndexContainer);
+  public void getSurrogateKeyByIncrementalSearch(List<String> evaluateResultList,
+      Stack<Integer> startIndexContainer, List<Integer> surrogates) {
+    List<byte[]> byteValuesOfFilterMembers = new ArrayList<byte[]>(evaluateResultList.size());
+    byte[] keyData = null;
+    for (int i = 0; i < evaluateResultList.size(); i++) {
+      keyData = evaluateResultList.get(i)
+          .getBytes(Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+      byteValuesOfFilterMembers.add(keyData);
+    }
+
+    columnDictionaryInfo
+        .getIncrementalSurrogateKeyFromDictionary(byteValuesOfFilterMembers, startIndexContainer,
+            surrogates);
   }
 }

--- a/core/src/main/java/org/carbondata/core/cache/dictionary/ForwardDictionary.java
+++ b/core/src/main/java/org/carbondata/core/cache/dictionary/ForwardDictionary.java
@@ -19,6 +19,11 @@
 
 package org.carbondata.core.cache.dictionary;
 
+import java.nio.charset.Charset;
+import java.util.Stack;
+
+import org.carbondata.core.constants.CarbonCommonConstants;
+
 /**
  * This class will be used for dictionary key and value look up
  */
@@ -124,4 +129,13 @@ public class ForwardDictionary implements Dictionary {
     columnDictionaryInfo = null;
   }
 
+  /**
+   * This method will read the surrogates based on search range.
+   */
+  public Integer getSurrogateKeyByIncrementalSearch(String value,
+      Stack<Integer> startIndexContainer) {
+    byte[] keyData = value.getBytes(Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+    return columnDictionaryInfo
+        .getIncrementalSurrogateKeyFromDictionary(keyData, startIndexContainer);
+  }
 }

--- a/core/src/main/java/org/carbondata/core/carbon/datastore/SegmentTaskIndexStore.java
+++ b/core/src/main/java/org/carbondata/core/carbon/datastore/SegmentTaskIndexStore.java
@@ -39,6 +39,8 @@ import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.util.CarbonUtil;
 import org.carbondata.core.util.CarbonUtilException;
 
+import org.apache.hadoop.fs.Path;
+
 /**
  * Singleton Class to handle loading, unloading,clearing,storing of the table
  * blocks
@@ -81,6 +83,12 @@ public class SegmentTaskIndexStore {
    */
   public static SegmentTaskIndexStore getInstance() {
     return SEGMENTTASKINDEXSTORE;
+  }
+
+  public static void main(String[] args) {
+    Path p = new Path("file:/D:/file");
+    Path pathWithoutSchemeAndAuthority = Path.getPathWithoutSchemeAndAuthority(p);
+    System.out.println(pathWithoutSchemeAndAuthority);
   }
 
   /**

--- a/core/src/main/java/org/carbondata/query/expression/ExpressionResult.java
+++ b/core/src/main/java/org/carbondata/query/expression/ExpressionResult.java
@@ -31,7 +31,7 @@ import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.util.CarbonProperties;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
-public class ExpressionResult {
+public class ExpressionResult implements Comparable<ExpressionResult> {
 
   private static final long serialVersionUID = 1L;
   protected DataType dataType;
@@ -377,4 +377,37 @@ public class ExpressionResult {
   public boolean isNull() {
     return value == null;
   }
+
+  @Override public int compareTo(ExpressionResult o) {
+    try {
+      switch (o.dataType) {
+        case IntegerType:
+        case LongType:
+        case DoubleType:
+
+          Double d1 = this.getDouble();
+          Double d2 = o.getDouble();
+          return d1.compareTo(d2);
+        case DecimalType:
+          java.math.BigDecimal val1 = this.getDecimal();
+          java.math.BigDecimal val2 = o.getDecimal();
+          return val1.compareTo(val2);
+        case TimestampType:
+          SimpleDateFormat parser = new SimpleDateFormat(CarbonProperties.getInstance()
+              .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+                  CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
+          Date date1 = null;
+          Date date2 = null;
+          date1 = parser.parse(this.getString());
+          date2 = parser.parse(o.getString());
+          return date1.compareTo(date2);
+        case StringType:
+        default:
+          return this.getString().compareTo(o.getString());
+      }
+    } catch (Exception e) {
+      return -1;
+    }
+  }
+
 }

--- a/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
@@ -248,15 +248,9 @@ public final class FilterUtil {
     List<Integer> surrogates = new ArrayList<Integer>(20);
     Stack<Integer> startIndexContainer = new Stack<Integer>();
     startIndexContainer.push(0);
-    for (String resultVal : evaluateResultList) {
-      // Reading the dictionary value from cache.
-      Integer dictionaryVal =
-          getDictionaryValue(resultVal, tableIdentifier, columnExpression.getDimension(),
-              startIndexContainer);
-      if (null != dictionaryVal) {
-        surrogates.add(dictionaryVal);
-      }
-    }
+    // Reading the dictionary value from cache.
+    getDictionaryValue(evaluateResultList, tableIdentifier, columnExpression.getDimension(),
+        startIndexContainer, surrogates);
     Collections.sort(surrogates);
     DimColumnFilterInfo columnFilterInfo = null;
     if (surrogates.size() > 0) {
@@ -271,20 +265,21 @@ public final class FilterUtil {
    * This API will get the Dictionary value for the respective filter member
    * string.
    *
-   * @param value           filter value
+   * @param evaluateResultList filter value
    * @param tableIdentifier
-   * @param dim             , column expression dimension type.
+   * @param dim                , column expression dimension type.
+   * @param surrogates
    * @return the dictionary value.
    * @throws QueryExecutionException
    */
-  private static Integer getDictionaryValue(String value, AbsoluteTableIdentifier tableIdentifier,
-      CarbonDimension dim, Stack<Integer> startIndexContainer) throws QueryExecutionException {
+  private static void getDictionaryValue(List<String> evaluateResultList,
+      AbsoluteTableIdentifier tableIdentifier, CarbonDimension dim,
+      Stack<Integer> startIndexContainer, List<Integer> surrogates) throws QueryExecutionException {
     Dictionary forwardDictionary = getForwardDictionaryCache(tableIdentifier, dim);
     if (null != forwardDictionary) {
-      return ((ForwardDictionary) forwardDictionary)
-          .getSurrogateKeyByIncrementalSearch(value, startIndexContainer);
+      ((ForwardDictionary) forwardDictionary)
+          .getSurrogateKeyByIncrementalSearch(evaluateResultList, startIndexContainer, surrogates);
     }
-    return null;
   }
 
   /**

--- a/core/src/main/java/org/carbondata/query/util/DataTypeConverter.java
+++ b/core/src/main/java/org/carbondata/query/util/DataTypeConverter.java
@@ -21,6 +21,7 @@ package org.carbondata.query.util;
 
 //import java.sql.Timestamp;
 
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -86,7 +87,7 @@ public final class DataTypeConverter {
             return dateToStr.getTime() * 1000;
           } catch (ParseException e) {
             LOGGER.error("Cannot convert" + TIMESTAMP.toString() + " to Time/Long type value" + e
-                    .getMessage());
+                .getMessage());
             return null;
           }
         case DECIMAL:
@@ -155,7 +156,7 @@ public final class DataTypeConverter {
             return dateToStr.getTime() * 1000;
           } catch (ParseException e) {
             LOGGER.error("Cannot convert" + TIMESTAMP.toString() + " to Time/Long type value" + e
-                    .getMessage());
+                .getMessage());
             return null;
           }
         case DECIMAL:
@@ -216,4 +217,36 @@ public final class DataTypeConverter {
 
   }
 
+  public static int compareFilterMembersBasedOnActualDataType(String filterMember1,
+      String filterMember2, org.carbondata.query.expression.DataType dataType) {
+    try {
+      switch (dataType) {
+        case IntegerType:
+        case LongType:
+        case DoubleType:
+
+          Double d1 = Double.parseDouble(filterMember1);
+          Double d2 = Double.parseDouble(filterMember2);
+          return d1.compareTo(d2);
+        case DecimalType:
+          java.math.BigDecimal val1 = new BigDecimal(filterMember1);
+          java.math.BigDecimal val2 = new BigDecimal(filterMember2);
+          return val1.compareTo(val2);
+        case TimestampType:
+          SimpleDateFormat parser = new SimpleDateFormat(CarbonProperties.getInstance()
+              .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+                  CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
+          Date date1 = null;
+          Date date2 = null;
+          date1 = parser.parse(filterMember1);
+          date2 = parser.parse(filterMember2);
+          return date1.compareTo(date2);
+        case StringType:
+        default:
+          return filterMember1.compareTo(filterMember2);
+      }
+    } catch (Exception e) {
+      return -1;
+    }
+  }
 }

--- a/integration/spark/src/main/scala/org/carbondata/integration/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark/src/main/scala/org/carbondata/integration/spark/thriftserver/CarbonThriftServer.scala
@@ -21,7 +21,6 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.CarbonContext
 import org.apache.spark.sql.hive.thriftserver.HiveThriftServer2
 
-import org.carbondata.common.logging.LogServiceFactory
 import org.carbondata.core.util.CarbonProperties
 
 object CarbonThriftServer {
@@ -35,15 +34,16 @@ object CarbonThriftServer {
       System.setProperty("carbon.properties.filepath",
         sparkHome + '/' + "conf" + '/' + "carbon.properties")
     }
-    val sc = new SparkContext(conf)
+    val sc = new SparkContext(conf);
     val warmUpTime = CarbonProperties.getInstance().getProperty("carbon.spark.warmUpTime", "5000");
     try {
-      Thread.sleep(Integer.parseInt(warmUpTime))
+      Thread.sleep(Integer.parseInt(warmUpTime));
     } catch {
       case _ =>
-        val LOG = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
-        LOG.error("Wrong value for carbon.spark.warmUpTime " + warmUpTime +
-          "Using default Value and proceeding")
+        // scalastyle:off
+        println("Wrong value for carbon.spark.warmUpTime " + warmUpTime +
+          "Using default Value and proceeding");
+        // scalastyle:on
         Thread.sleep(30000);
     }
 


### PR DESCRIPTION
Below implementation is been done for providing optimization in forward dictionary cache look up while applying filters, a range based index is provided for faster look up so that always the dictionary look up will start based on provided range