### PR TITLE
[Issue-324]Data loading performance optimization: optimize FileHolderImpl

### DIFF
--- a/core/src/main/java/org/carbondata/core/datastorage/store/impl/FileHolderImpl.java
+++ b/core/src/main/java/org/carbondata/core/datastorage/store/impl/FileHolderImpl.java
@@ -31,7 +31,6 @@ import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.FileHolder;
-import org.carbondata.core.datastorage.store.filesystem.CarbonFile;
 
 public class FileHolderImpl implements FileHolder {
   /**
@@ -155,13 +154,12 @@ public class FileHolderImpl implements FileHolder {
    * @return channel
    */
   private FileChannel updateCache(String filePath) {
-    CarbonFile carbonFile = FileFactory.getCarbonFile(filePath, FileFactory.getFileType(filePath));
-    FileChannel fileChannel = fileNameAndStreamCache.get(carbonFile.getAbsolutePath());
+    FileChannel fileChannel = fileNameAndStreamCache.get(filePath);
     try {
       if (null == fileChannel) {
-        FileInputStream stream = new FileInputStream(carbonFile.getAbsolutePath());
+        FileInputStream stream = new FileInputStream(filePath);
         fileChannel = stream.getChannel();
-        fileNameAndStreamCache.put(carbonFile.getAbsolutePath(), fileChannel);
+        fileNameAndStreamCache.put(filePath, fileChannel);
       }
     } catch (IOException e) {
       LOGGER.error(e, e.getMessage());


### PR DESCRIPTION
1 The filePath parameter of updateCache method is  absolute path, So I think we don't need to use CarbonFile.getAbsolutePath()

2 During data loading, we invoke the updateCache method frequently, maybe reach a million times. So we should not new a instance of CarbonFile in the updataCache method.

link [Issue-324](https://github.com/HuaweiBigData/carbondata/issues/324)