### PR TITLE
[Issue- 408] Data Load is failing when no measure is used in create cube command

### DIFF
--- a/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/column/ColumnSchema.java
@@ -100,6 +100,11 @@ public class ColumnSchema implements Serializable {
   private byte[] defaultValue;
 
   /**
+   * used to define the column visibility of column default is false
+   */
+  private boolean invisible = false;
+
+  /**
    * @return the columnName
    */
   public String getColumnName() {
@@ -324,6 +329,22 @@ public class ColumnSchema implements Serializable {
     } else {
       return false;
     }
+  }
+
+  /**
+   * return the visibility
+   * @return
+   */
+  public boolean isInvisible() {
+    return invisible;
+  }
+
+  /**
+   * set the visibility
+   * @param invisible
+   */
+  public void setInvisible(boolean invisible) {
+    this.invisible = invisible;
   }
 
 }

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -85,6 +85,10 @@ struct ColumnSchema{
 	11: optional string aggregate_function;
 
 	12: optional binary default_value;
+	/**
+	* To specify the visibily of the column by default its false
+	*/
+	13: optional bool invisible;
 }
 
 /**

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
@@ -175,7 +175,7 @@ case class CarbonRelation(schemaName: String,
     val sett = new LinkedHashSet(
       cubeMeta.carbonTable.getDimensionByTableName(cubeMeta.carbonTableIdentifier.getTableName)
         .asScala.asJava)
-    sett.asScala.toSeq.map(dim => {
+    sett.asScala.toSeq.filter(!_.getColumnSchema.isInvisible).map(dim => {
       val output: DataType = metaData.carbonTable
         .getDimensionByName(metaData.carbonTable.getFactTableName, dim.getColName).getDataType
         .toString.toLowerCase match {
@@ -198,9 +198,8 @@ case class CarbonRelation(schemaName: String,
     new LinkedHashSet(
       cubeMeta.carbonTable.
         getMeasureByTableName(cubeMeta.carbonTable.getFactTableName).
-        asScala.asJava).asScala.toSeq.map(x => AttributeReference(
-      x.getColName,
-      CarbonMetastoreTypes.toDataType(
+        asScala.asJava).asScala.toSeq.filter(!_.getColumnSchema.isInvisible)
+        .map(x => AttributeReference(x.getColName, CarbonMetastoreTypes.toDataType(
         metaData.carbonTable.getMeasureByName(factTable, x.getColName).getDataType.toString
           .toLowerCase match {
           case "int" => "double"

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -262,7 +262,6 @@ class TableNewProcessor(cm: tableModel, sqlContext: SQLContext) {
     // Adding dummy measure if no measure is provided
     if (measures.size < 1) {
       val encoders = new java.util.ArrayList[Encoding]()
-      encoders.add(Encoding.DICTIONARY)
       val coloumnSchema: ColumnSchema = getColumnSchema(DataType.DOUBLE,
         CarbonCommonConstants.DEFAULT_INVISIBLE_DUMMY_MEASURE,
         index,
@@ -270,8 +269,10 @@ class TableNewProcessor(cm: tableModel, sqlContext: SQLContext) {
         encoders,
         isDimensionCol = false,
         -1)
+      coloumnSchema.setInvisible(true)
       val measureColumn = coloumnSchema
       measures += measureColumn
+      allColumns = allColumns ++ measures
     }
 
     newOrderedDims = newOrderedDims ++ complexDims ++ measures

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestLoadDataWithNoMeasure.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestLoadDataWithNoMeasure.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.carbondata.spark.testsuite.dataload
+
+import java.io.File
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Test Class for data loading with hive syntax and old syntax
+ *
+ */
+class TestLoadDataWithNoMeasure extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("CREATE TABLE nomeasureTest (empno String, doj String) STORED BY 'org.apache.carbondata.format'")
+    val currentDirectory = new File(this.getClass.getResource("/").getPath + "/../../")
+      .getCanonicalPath
+    val testData = currentDirectory + "/src/test/resources/datasample.csv"
+    sql("LOAD DATA LOCAL INPATH '"+ testData +"' into table nomeasureTest")
+  }
+
+  test("test data loading and validate query output") {
+
+    checkAnswer(
+      sql("select empno from nomeasureTest"),
+      Seq(Row("11"),Row("12"))
+    )
+  }
+
+  override def afterAll {
+    sql("drop table nomeasureTest")
+  }
+}

--- a/processing/src/main/java/org/carbondata/processing/csvload/GraphExecutionUtil.java
+++ b/processing/src/main/java/org/carbondata/processing/csvload/GraphExecutionUtil.java
@@ -231,7 +231,9 @@ public final class GraphExecutionUtil {
 
       List<CarbonMeasure> measures = schema.getCarbonTable().getMeasureByTableName(factTableName);
       for (CarbonMeasure msr : measures) {
-        columnNames.add(msr.getColName());
+        if (!msr.getColumnSchema().isInvisible()) {
+          columnNames.add(msr.getColName());
+        }
       }
     } else {
       List<CarbonDimension> dimensions = schema.getCarbonTable().getDimensionByTableName(tableName);


### PR DESCRIPTION
Loading data with measure column was failing, to fix the same added added the dummy measure when no measure is defined the create table DDL.

Select * from TableName;
Output
![image](https://cloud.githubusercontent.com/assets/17875433/15444840/ffec36d2-1f12-11e6-8c72-b876029ef833.png)

Must be merged after PR  #425 