### PR TITLE
[Issue 421]Formatted Scala code and added code style template

### DIFF
--- a/dev/java-code-format-template.xml
+++ b/dev/java-code-format-template.xml
@@ -32,8 +32,26 @@
     <option name="RIGHT_MARGIN" value="72" />
   </MultiMarkdownCodeStyleSettings>
   <ScalaCodeStyleSettings>
+    <option name="classCountToUseImportOnDemand" value="6" />
+    <option name="importLayout">
+      <array>
+        <option value="java" />
+        <option value="javax" />
+        <option value="_______ blank line _______" />
+        <option value="scala" />
+        <option value="_______ blank line _______" />
+        <option value="all other imports" />
+        <option value="_______ blank line _______" />
+        <option value="org.carbondata" />
+      </array>
+    </option>
+    <option name="METHOD_BRACE_FORCE" value="1" />
     <option name="NOT_CONTINUATION_INDENT_FOR_PARAMS" value="true" />
+    <option name="USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS" value="true" />
     <option name="INDENT_BRACED_FUNCTION_ARGS" value="false" />
+    <option name="USE_SCALADOC2_FORMATTING" value="false" />
+    <option name="SPACES_IN_ONE_LINE_BLOCKS" value="true" />
+    <option name="KEEP_XML_FORMATTING" value="true" />
   </ScalaCodeStyleSettings>
   <XML>
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -80,14 +98,23 @@
   </codeStyleSettings>
   <codeStyleSettings language="Scala">
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="5" />
-    <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
     <option name="METHOD_PARAMETERS_WRAP" value="5" />
     <option name="EXTENDS_LIST_WRAP" value="5" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
     <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
     <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
     <option name="WRAP_LONG_LINES" value="true" />
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+    <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
   </codeStyleSettings>
   <codeStyleSettings language="XML">
     <indentOptions>

--- a/integration/spark/src/main/scala/org/apache/spark/rdd/DummyLoadRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/rdd/DummyLoadRDD.scala
@@ -26,6 +26,7 @@ import org.carbondata.core.load.BlockDetails
 /**
  * this RDD use to combine blocks in node level
  * return (host,Array[BlockDetails])
+ *
  * @param prev
  */
 class DummyLoadRDD(prev: NewHadoopRDD[LongWritable, Text])
@@ -34,13 +35,14 @@ class DummyLoadRDD(prev: NewHadoopRDD[LongWritable, Text])
   override def getPartitions: Array[Partition] = firstParent[(LongWritable, Text)].partitions
 
   override def compute(theSplit: Partition,
-                       context: TaskContext): Iterator[(String, BlockDetails)] = {
+      context: TaskContext): Iterator[(String, BlockDetails)] = {
     new Iterator[(String, BlockDetails)] {
       val split = theSplit.asInstanceOf[NewHadoopPartition]
       var finished = false
       // added to make sure spark distributes tasks not to single node
       // giving sufficient time for spark to schedule
       Thread.sleep(5000)
+
       override def hasNext: Boolean = {
         if (!finished) {
           finished = true

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
@@ -30,11 +30,11 @@ case class CarbonBoundReference(colExp: ColumnExpression, dataType: DataType, nu
 
   type EvaluatedType = Any
 
-  override def toString: String = s"input[" + colExp.getColIndex() + "]"
+  override def toString: String = s"input[" + colExp.getColIndex + "]"
 
-  override def eval(input: InternalRow): Any = input.get(colExp.getColIndex(), dataType)
+  override def eval(input: InternalRow): Any = input.get(colExp.getColIndex, dataType)
 
-  override def name: String = colExp.getColumnName()
+  override def name: String = colExp.getColumnName
 
   override def toAttribute: Attribute = throw new UnsupportedOperationException
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -26,13 +26,13 @@ import org.apache.spark.sql.execution.command.tableModel
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.types.{BooleanType, StringType, TimestampType}
 
-import org.carbondata.spark.agg.{AverageCarbon, CountCarbon, CountDistinctCarbon, MaxCarbon, MeasureAggregatorUDT, MinCarbon, PositionLiteral, SumCarbon, SumDistinctCarbon}
+import org.carbondata.spark.agg._
 
 /**
  * Top command
  */
 case class Top(count: Int, topOrBottom: Int, dim: NamedExpression, msr: NamedExpression,
-               child: LogicalPlan) extends UnaryNode {
+    child: LogicalPlan) extends UnaryNode {
   def output: Seq[Attribute] = child.output
 
   override def references: AttributeSet = {
@@ -43,8 +43,9 @@ case class Top(count: Int, topOrBottom: Int, dim: NamedExpression, msr: NamedExp
 
 object getDB {
 
-  def getDatabaseName(dbName: Option[String], sqlContext: SQLContext): String =
+  def getDatabaseName(dbName: Option[String], sqlContext: SQLContext): String = {
     dbName.getOrElse(sqlContext.asInstanceOf[HiveContext].catalog.client.currentDatabase)
+  }
 
 }
 
@@ -54,8 +55,9 @@ object getDB {
 case class ShowSchemaCommand(cmd: Option[String]) extends LogicalPlan with Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[Attribute] =
+  override def output: Seq[Attribute] = {
     Seq(AttributeReference("result", StringType, nullable = false)())
+  }
 }
 
 /**
@@ -64,8 +66,9 @@ case class ShowSchemaCommand(cmd: Option[String]) extends LogicalPlan with Comma
 case class ShowCreateCubeCommand(cm: tableModel) extends LogicalPlan with Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[Attribute] =
+  override def output: Seq[Attribute] = {
     Seq(AttributeReference("createCubeCmd", StringType, nullable = false)())
+  }
 }
 
 /**
@@ -75,8 +78,9 @@ case class ShowAggregateTablesCommand(schemaNameOp: Option[String])
   extends LogicalPlan with Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[Attribute] =
+  override def output: Seq[Attribute] = {
     Seq(AttributeReference("tableName", StringType, nullable = false)())
+  }
 }
 
 /**
@@ -85,9 +89,10 @@ case class ShowAggregateTablesCommand(schemaNameOp: Option[String])
 case class ShowCubeCommand(schemaNameOp: Option[String]) extends LogicalPlan with Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[Attribute] =
+  override def output: Seq[Attribute] = {
     Seq(AttributeReference("cubeName", StringType, nullable = false)(),
       AttributeReference("isRegisteredWithSpark", BooleanType, nullable = false)())
+  }
 }
 
 
@@ -97,22 +102,24 @@ case class ShowCubeCommand(schemaNameOp: Option[String]) extends LogicalPlan wit
 case class ShowAllCubeCommand() extends LogicalPlan with Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[Attribute] =
+  override def output: Seq[Attribute] = {
     Seq(AttributeReference("schemaName", StringType, nullable = false)(),
       AttributeReference("cubeName", StringType, nullable = false)(),
       AttributeReference("isRegisteredWithSpark", BooleanType, nullable = false)())
+  }
 }
 
 case class SuggestAggregateCommand(
-                                    script: Option[String],
-                                    sugType: Option[String],
-                                    schemaName: Option[String],
-                                    cubeName: String) extends LogicalPlan with Command {
+    script: Option[String],
+    sugType: Option[String],
+    schemaName: Option[String],
+    cubeName: String) extends LogicalPlan with Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[Attribute] =
+  override def output: Seq[Attribute] = {
     Seq(AttributeReference("SuggestionType", StringType, nullable = false)(),
       AttributeReference("Suggestion", StringType, nullable = false)())
+  }
 }
 
 /**
@@ -122,12 +129,13 @@ case class ShowTablesDetailedCommand(schemaNameOp: Option[String])
   extends LogicalPlan with Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[Attribute] =
+  override def output: Seq[Attribute] = {
     Seq(AttributeReference("TABLE_CAT", StringType, nullable = true)(),
       AttributeReference("TABLE_SCHEM", StringType, nullable = false)(),
       AttributeReference("TABLE_NAME", StringType, nullable = false)(),
       AttributeReference("TABLE_TYPE", StringType, nullable = false)(),
       AttributeReference("REMARKS", StringType, nullable = false)())
+  }
 }
 
 /**
@@ -138,11 +146,12 @@ case class ShowLoadsCommand(schemaNameOp: Option[String], cube: String, limit: O
 
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[Attribute] =
+  override def output: Seq[Attribute] = {
     Seq(AttributeReference("LoadSequenceId", StringType, nullable = false)(),
       AttributeReference("Status", StringType, nullable = false)(),
       AttributeReference("Load Start Time", TimestampType, nullable = false)(),
       AttributeReference("Load End Time", TimestampType, nullable = false)())
+  }
 }
 
 /**
@@ -152,10 +161,11 @@ case class DescribeFormattedCommand(sql: String, tblIdentifier: Seq[String])
   extends LogicalPlan with Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
-  override def output: Seq[AttributeReference] =
+  override def output: Seq[AttributeReference] = {
     Seq(AttributeReference("col_name", StringType, nullable = false)(),
       AttributeReference("data_type", StringType, nullable = false)(),
       AttributeReference("comment", StringType, nullable = false)())
+  }
 }
 
 /**
@@ -170,7 +180,7 @@ object PhysicalOperation1 extends PredicateHelper {
     Option[Seq[SortOrder]], Option[Expression], LogicalPlan)
 
   def apply(plan: LogicalPlan): Option[ReturnType] = {
-    val (fields, filters, child, aliases, groupby, sortOrder, limit) =
+    val (fields, filters, child, _, groupby, sortOrder, limit) =
       collectProjectsAndFilters(plan)
 
     Some((fields.getOrElse(child.output), filters, groupby, sortOrder, limit, child))
@@ -192,7 +202,7 @@ object PhysicalOperation1 extends PredicateHelper {
   def collectProjectsAndFilters(plan: LogicalPlan):
   (Option[Seq[NamedExpression]], Seq[Expression], LogicalPlan,
     Map[Attribute, Expression], Option[Seq[Expression]],
-    Option[Seq[SortOrder]], Option[Expression]) =
+    Option[Seq[SortOrder]], Option[Expression]) = {
     plan match {
       case Project(fields, child) =>
         val (_, filters, other, aliases, groupby, sortOrder, limit) = collectProjectsAndFilters(
@@ -231,6 +241,7 @@ object PhysicalOperation1 extends PredicateHelper {
       case other =>
         (None, Nil, other, Map.empty, None, None, None)
     }
+  }
 
   def findAggreagateExpression(expr: Expression): Seq[AggregateExpression1] = {
     val exprList = expr match {
@@ -250,7 +261,7 @@ object PhysicalOperation1 extends PredicateHelper {
 
   def collectProjectsAndFilters1(plan: LogicalPlan):
   (Option[Seq[NamedExpression]], Seq[Expression], LogicalPlan, Map[Attribute, Expression],
-    Option[Seq[Expression]], Option[Seq[SortOrder]], Option[Expression]) =
+    Option[Seq[Expression]], Option[Seq[SortOrder]], Option[Expression]) = {
     plan match {
       case Project(fields, child) =>
         val (_, filters, other, aliases, groupby, sortOrder, limit) = collectProjectsAndFilters(
@@ -271,7 +282,7 @@ object PhysicalOperation1 extends PredicateHelper {
           child)
         val aggExps = aggregateExpressions.map {
           case Alias(ref, name) => ref
-          case other => other
+          case others => others
         }.filter {
           case d: AggregateExpression1 => true
           case _ => false
@@ -289,17 +300,22 @@ object PhysicalOperation1 extends PredicateHelper {
       case other =>
         (None, Nil, other, Map.empty, None, None, None)
     }
+  }
 
-  private def collectAliases(fields: Seq[Expression]) = fields.collect {
-    case a@Alias(child, _) => a.toAttribute.asInstanceOf[Attribute] -> child
-  }.toMap
+  private def collectAliases(fields: Seq[Expression]) = {
+    fields.collect {
+      case a@Alias(child, _) => a.toAttribute -> child
+    }.toMap
+  }
 
-  private def substitute(aliases: Map[Attribute, Expression])(expr: Expression) = expr.transform {
-    case a@Alias(ref: AttributeReference, name) =>
-      aliases.get(ref).map(Alias(_, name)(a.exprId, a.qualifiers)).getOrElse(a)
+  private def substitute(aliases: Map[Attribute, Expression])(expr: Expression) = {
+    expr.transform {
+      case a@Alias(ref: AttributeReference, name) =>
+        aliases.get(ref).map(Alias(_, name)(a.exprId, a.qualifiers)).getOrElse(a)
 
-    case a: AttributeReference =>
-      aliases.get(a).map(Alias(_, a.name)(a.exprId, a.qualifiers)).getOrElse(a)
+      case a: AttributeReference =>
+        aliases.get(a).map(Alias(_, a.name)(a.exprId, a.qualifiers)).getOrElse(a)
+    }
   }
 }
 
@@ -323,7 +339,7 @@ object PartialAggregation {
   (Seq[Attribute], Seq[NamedExpression], Seq[Expression], Seq[NamedExpression], LogicalPlan)
 
   private def convertAggregatesForPushdown(convertUnknown: Boolean,
-                                   rewrittenAggregateExpressions: Seq[Expression]) = {
+      rewrittenAggregateExpressions: Seq[Expression]) = {
     var counter: Int = 0
     var updatedExpressions = MutableList[Expression]()
     rewrittenAggregateExpressions.foreach(v => {
@@ -331,7 +347,7 @@ object PartialAggregation {
       updatedExpressions += updated
       counter = counter + 1
     })
-    updatedExpressions.toSeq
+    updatedExpressions
   }
 
   def makePositionLiteral(expr: Expression, index: Int): PositionLiteral = {
@@ -340,7 +356,7 @@ object PartialAggregation {
     posLiteral
   }
 
-  def convertAggregate(current: Expression, index: Int, convertUnknown: Boolean): Expression =
+  def convertAggregate(current: Expression, index: Int, convertUnknown: Boolean): Expression = {
     if (convertUnknown) {
       current.transform {
         case a@SumCarbon(_, _) => a
@@ -372,8 +388,8 @@ object PartialAggregation {
           makePositionLiteral(attr, index), cast.dataType)
         case a@CountDistinct(attr: AttributeReference) => CountDistinctCarbon(
           makePositionLiteral(attr, index))
-        case a@CountDistinct(childSeq) if (childSeq.size == 1) =>
-          childSeq(0) match {
+        case a@CountDistinct(childSeq) if childSeq.size == 1 =>
+          childSeq.head match {
             case attr: AttributeReference => CountDistinctCarbon(makePositionLiteral(attr, index))
             case _ => a
           }
@@ -387,75 +403,86 @@ object PartialAggregation {
           }
       }
     }
+  }
 
   def unapply(plan: LogicalPlan): Option[ReturnType] = unapply((plan, false))
 
-  def unapply(combinedPlan: (LogicalPlan, Boolean)): Option[ReturnType] = combinedPlan._1 match {
-    case Aggregate(groupingExpressions, aggregateExpressionsOrig, child) =>
+  def unapply(combinedPlan: (LogicalPlan, Boolean)): Option[ReturnType] = {
+    combinedPlan._1 match {
+      case Aggregate(groupingExpressions, aggregateExpressionsOrig, child) =>
 
-      // if detailed query dont convert aggregate expressions to Carbon Aggregate expressions
-      val aggregateExpressions =
-        if (combinedPlan._2) aggregateExpressionsOrig
-        else convertAggregatesForPushdown(false, aggregateExpressionsOrig)
-      // Collect all aggregate expressions.
-      val allAggregates =
-        aggregateExpressions.flatMap(_ collect { case a: AggregateExpression1 => a })
-      // Collect all aggregate expressions that can be computed partially.
-      val partialAggregates =
-        aggregateExpressions.flatMap(_ collect { case p: PartialAggregate1 => p })
+        // if detailed query dont convert aggregate expressions to Carbon Aggregate expressions
+        val aggregateExpressions =
+          if (combinedPlan._2) {
+            aggregateExpressionsOrig
+          }
+          else {
+            convertAggregatesForPushdown(false, aggregateExpressionsOrig)
+          }
+        // Collect all aggregate expressions.
+        val allAggregates =
+          aggregateExpressions.flatMap(_ collect { case a: AggregateExpression1 => a })
+        // Collect all aggregate expressions that can be computed partially.
+        val partialAggregates =
+          aggregateExpressions.flatMap(_ collect { case p: PartialAggregate1 => p })
 
-      // Only do partial aggregation if supported by all aggregate expressions.
-      if (allAggregates.size == partialAggregates.size) {
-        // Create a map of expressions to their partial evaluations for all aggregate expressions.
-        val partialEvaluations: Map[TreeNodeRef, SplitEvaluation] =
-          partialAggregates.map(a => (new TreeNodeRef(a), a.asPartial)).toMap
+        // Only do partial aggregation if supported by all aggregate expressions.
+        if (allAggregates.size == partialAggregates.size) {
+          // Create a map of expressions to their partial evaluations for all aggregate expressions.
+          val partialEvaluations: Map[TreeNodeRef, SplitEvaluation] =
+            partialAggregates.map(a => (new TreeNodeRef(a), a.asPartial)).toMap
 
-        // We need to pass all grouping expressions though so the grouping can happen a second
-        // time. However some of them might be unnamed so we alias them allowing them to be
-        // referenced in the second aggregation.
-        val namedGroupingExpressions: Map[Expression, NamedExpression] = groupingExpressions.map {
-          case n: NamedExpression => (n, n)
-          case other => (other, Alias(other, "PartialGroup")())
-        }.toMap
+          // We need to pass all grouping expressions though so the grouping can happen a second
+          // time. However some of them might be unnamed so we alias them allowing them to be
+          // referenced in the second aggregation.
+          val namedGroupingExpressions: Map[Expression, NamedExpression] = groupingExpressions.map {
+            case n: NamedExpression => (n, n)
+            case other => (other, Alias(other, "PartialGroup")())
+          }.toMap
 
-        // Replace aggregations with a new expression that computes the result from the already
-        // computed partial evaluations and grouping values.
-        val rewrittenAggregateExpressions = aggregateExpressions.map(_.transformUp {
-          case e: Expression if partialEvaluations.contains(new TreeNodeRef(e)) =>
-            partialEvaluations(new TreeNodeRef(e)).finalEvaluation
+          // Replace aggregations with a new expression that computes the result from the already
+          // computed partial evaluations and grouping values.
+          val rewrittenAggregateExpressions = aggregateExpressions.map(_.transformUp {
+            case e: Expression if partialEvaluations.contains(new TreeNodeRef(e)) =>
+              partialEvaluations(new TreeNodeRef(e)).finalEvaluation
 
-          case e: Expression =>
-            // Should trim aliases around `GetField`s. These aliases are introduced while
-            // resolving struct field accesses, because `GetField` is not a `NamedExpression`.
-            // (Should we just turn `GetField` into a `NamedExpression`?)
-            namedGroupingExpressions.collectFirst {
-              case (expr, ne) if expr semanticEquals e => ne.toAttribute
-            }.getOrElse(e)
-        }).asInstanceOf[Seq[NamedExpression]]
+            case e: Expression =>
+              // Should trim aliases around `GetField`s. These aliases are introduced while
+              // resolving struct field accesses, because `GetField` is not a `NamedExpression`.
+              // (Should we just turn `GetField` into a `NamedExpression`?)
+              namedGroupingExpressions.collectFirst {
+                case (expr, ne) if expr semanticEquals e => ne.toAttribute
+              }.getOrElse(e)
+          }).asInstanceOf[Seq[NamedExpression]]
 
-        val partialComputation =
-          (namedGroupingExpressions.values ++
-            partialEvaluations.values.flatMap(_.partialEvaluations)).toSeq
+          val partialComputation =
+            (namedGroupingExpressions.values ++
+             partialEvaluations.values.flatMap(_.partialEvaluations)).toSeq
 
-        // Convert the other aggregations for push down to Carbon layer. Here don't touch earlier
-        // converted native carbon aggregators.
-        val convertedPartialComputation =
-          if (combinedPlan._2) partialComputation
-          else convertAggregatesForPushdown(true, partialComputation)
-            .asInstanceOf[Seq[NamedExpression]]
+          // Convert the other aggregations for push down to Carbon layer. Here don't touch earlier
+          // converted native carbon aggregators.
+          val convertedPartialComputation =
+            if (combinedPlan._2) {
+              partialComputation
+            }
+            else {
+              convertAggregatesForPushdown(true, partialComputation)
+                .asInstanceOf[Seq[NamedExpression]]
+            }
 
-        val namedGroupingAttributes = namedGroupingExpressions.values.map(_.toAttribute).toSeq
+          val namedGroupingAttributes = namedGroupingExpressions.values.map(_.toAttribute).toSeq
 
-        Some(
-          (namedGroupingAttributes,
-            rewrittenAggregateExpressions,
-            groupingExpressions,
-            convertedPartialComputation,
-            child))
-      } else {
-        None
-      }
-    case _ => None
+          Some(
+            (namedGroupingAttributes,
+              rewrittenAggregateExpressions,
+              groupingExpressions,
+              convertedPartialComputation,
+              child))
+        } else {
+          None
+        }
+      case _ => None
+    }
   }
 }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -48,6 +48,7 @@ class CarbonContext(val sc: SparkContext, val storePath: String) extends HiveCon
 
   experimental.extraStrategies = CarbonStrategy.getStrategy(self) :: Nil
 
+  @transient
   val LOGGER = LogServiceFactory.getLogService(CarbonContext.getClass.getName)
 
   override def sql(sql: String): SchemaRDD = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.hive.{CarbonMetastoreCatalog, HiveContext}
 /**
  * Carbon Environment for unified context
  */
-case class CarbonEnv(val carbonContext: HiveContext, val carbonCatalog: CarbonMetastoreCatalog)
+case class CarbonEnv(carbonContext: HiveContext, carbonCatalog: CarbonMetastoreCatalog)
 
 object CarbonEnv {
   val className = classOf[CarbonEnv].getCanonicalName

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonOperators.scala
@@ -54,15 +54,14 @@ import org.carbondata.spark.rdd.CarbonQueryRDD
 import org.carbondata.spark.util.{CarbonQueryUtil, CarbonScalaUtil, QueryPlanUtil}
 
 case class CarbonCubeScan(
-
-                           var attributes: Seq[Attribute],
-                           relation: CarbonRelation,
-                           dimensionPredicates: Seq[Expression],
-                           aggExprs: Option[Seq[Expression]],
-                           sortExprs: Option[Seq[SortOrder]],
-                           limitExpr: Option[Expression],
-                           isGroupByPresent: Boolean,
-                           detailQuery: Boolean = false)(@transient val oc: SQLContext)
+    var attributes: Seq[Attribute],
+    relation: CarbonRelation,
+    dimensionPredicates: Seq[Expression],
+    aggExprs: Option[Seq[Expression]],
+    sortExprs: Option[Seq[SortOrder]],
+    limitExpr: Option[Expression],
+    isGroupByPresent: Boolean,
+    detailQuery: Boolean = false)(@transient val oc: SQLContext)
   extends LeafNode {
 
   val cubeName = relation.cubeName
@@ -76,19 +75,19 @@ case class CarbonCubeScan(
   @transient val carbonCatalog = sqlContext.catalog.asInstanceOf[CarbonMetastoreCatalog]
 
   def processAggregateExpr(plan: CarbonQueryPlan, currentAggregate: AggregateExpression1,
-                           queryOrder: Int): Int = {
+      queryOrder: Int): Int = {
 
     currentAggregate match {
       case SumCarbon(posLiteral@PositionLiteral(attr: AttributeReference, _), _) =>
         val msrs = selectedMsrs.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-        if (msrs.length > 0) {
+        if (msrs.nonEmpty) {
           val m1 = new QueryMeasure(attr.name)
           m1.setAggregateFunction(CarbonCommonConstants.SUM)
           m1.setQueryOrder(queryOrder)
           plan.addMeasure(m1)
         } else {
           val dims = selectedDims.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-          if (dims.length > 0) {
+          if (dims.nonEmpty) {
             val d1 = new QueryDimension(attr.name)
             d1.setQueryOrder(queryOrder)
             plan.addAggDimAggInfo(d1.getColumnName, "sum", d1.getQueryOrder)
@@ -99,14 +98,14 @@ case class CarbonCubeScan(
 
       case CountCarbon(posLiteral@PositionLiteral(attr: AttributeReference, _)) =>
         val msrs = selectedMsrs.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-        if (msrs.length > 0) {
+        if (msrs.nonEmpty) {
           val m1 = new QueryMeasure(attr.name)
           m1.setAggregateFunction(CarbonCommonConstants.COUNT)
           m1.setQueryOrder(queryOrder)
           plan.addMeasure(m1)
         } else {
           val dims = selectedDims.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-          if (dims.length > 0) {
+          if (dims.nonEmpty) {
             val d1 = new QueryDimension(attr.name)
             d1.setQueryOrder(queryOrder)
             plan.addAggDimAggInfo(d1.getColumnName, "count", d1.getQueryOrder)
@@ -136,14 +135,14 @@ case class CarbonCubeScan(
         queryOrder + 1
       case CountDistinctCarbon(posLiteral@PositionLiteral(attr: AttributeReference, _)) =>
         val msrs = selectedMsrs.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-        if (msrs.length > 0) {
+        if (msrs.nonEmpty) {
           val m1 = new QueryMeasure(attr.name)
           m1.setAggregateFunction(CarbonCommonConstants.DISTINCT_COUNT)
           m1.setQueryOrder(queryOrder)
           plan.addMeasure(m1)
         } else {
           val dims = selectedDims.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-          if (dims.length > 0) {
+          if (dims.nonEmpty) {
             val d1 = new QueryDimension(attr.name)
             d1.setQueryOrder(queryOrder)
             plan.addAggDimAggInfo(d1.getColumnName, "distinct-count", d1.getQueryOrder)
@@ -154,14 +153,14 @@ case class CarbonCubeScan(
 
       case AverageCarbon(posLiteral@PositionLiteral(attr: AttributeReference, _), _) =>
         val msrs = selectedMsrs.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-        if (msrs.length > 0) {
+        if (msrs.nonEmpty) {
           val m1 = new QueryMeasure(attr.name)
           m1.setAggregateFunction(CarbonCommonConstants.AVERAGE)
           m1.setQueryOrder(queryOrder)
           plan.addMeasure(m1)
         } else {
           val dims = selectedDims.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-          if (dims.length > 0) {
+          if (dims.nonEmpty) {
             val d1 = new QueryDimension(attr.name)
             d1.setQueryOrder(queryOrder)
             plan.addAggDimAggInfo(d1.getColumnName, "avg", d1.getQueryOrder)
@@ -172,7 +171,7 @@ case class CarbonCubeScan(
 
       case MinCarbon(posLiteral@PositionLiteral(attr: AttributeReference, _), _) =>
         val msrs = selectedMsrs.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-        if (msrs.length > 0) {
+        if (msrs.nonEmpty) {
           val m1 = new QueryMeasure(attr.name)
           m1.setAggregateFunction(CarbonCommonConstants.MIN)
           m1.setQueryOrder(queryOrder)
@@ -190,14 +189,14 @@ case class CarbonCubeScan(
 
       case MaxCarbon(posLiteral@PositionLiteral(attr: AttributeReference, _), _) =>
         val msrs = selectedMsrs.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-        if (msrs.length > 0) {
+        if (msrs.nonEmpty) {
           val m1 = new QueryMeasure(attr.name)
           m1.setAggregateFunction(CarbonCommonConstants.MAX)
           m1.setQueryOrder(queryOrder)
           plan.addMeasure(m1)
         } else {
           val dims = selectedDims.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-          if (dims.length > 0) {
+          if (dims.nonEmpty) {
             val d1 = new QueryDimension(attr.name)
             d1.setQueryOrder(queryOrder)
             plan.addAggDimAggInfo(d1.getColumnName, "max", d1.getQueryOrder)
@@ -208,7 +207,7 @@ case class CarbonCubeScan(
 
       case SumDistinctCarbon(posLiteral@PositionLiteral(attr: AttributeReference, _), _) =>
         val msrs = selectedMsrs.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-        if (msrs.length > 0) {
+        if (msrs.nonEmpty) {
           val m1 = new QueryMeasure(attr.name)
           m1.setAggregateFunction(CarbonCommonConstants.SUM_DISTINCT)
           m1.setQueryOrder(queryOrder)
@@ -239,7 +238,7 @@ case class CarbonCubeScan(
     attributes.map(
       attr => {
         val carbonDimension = carbonTable.getDimensionByName(carbonTable.getFactTableName
-            , attr.name)
+          , attr.name)
         if (carbonDimension != null) {
           // TODO if we can add ordina in carbonDimension, it will be good
           allDims += attr.name
@@ -248,8 +247,8 @@ case class CarbonCubeScan(
           queryOrder = queryOrder + 1
           selectedDims += dim
         } else {
-          val carbonMeasure = carbonTable.getMeasureByName(carbonTable.getFactTableName()
-              , attr.name)
+          val carbonMeasure = carbonTable.getMeasureByName(carbonTable.getFactTableName
+            , attr.name)
           if (carbonMeasure != null) {
             val m1 = new QueryMeasure(attr.name)
             m1.setQueryOrder(queryOrder)
@@ -264,12 +263,12 @@ case class CarbonCubeScan(
     // measure and dimensions
     // Unknown aggregates & Expressions will use custom aggregator
     aggExprs match {
-      case Some(a: Seq[Expression]) if (!forceDetailedQuery) =>
+      case Some(a: Seq[Expression]) if !forceDetailedQuery =>
         a.foreach {
           case attr@AttributeReference(_, _, _, _) => // Add all the references to carbon query
             val carbonDimension = selectedDims
               .filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-            if (carbonDimension.size > 0) {
+            if (carbonDimension.nonEmpty) {
               val dim = new QueryDimension(attr.name)
               dim.setQueryOrder(queryOrder)
               plan.addDimension(dim)
@@ -277,7 +276,7 @@ case class CarbonCubeScan(
             } else {
               val carbonMeasure = selectedMsrs
                 .filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-              if (carbonMeasure.size > 0) {
+              if (carbonMeasure.nonEmpty) {
                 // added by vishal as we are adding for dimension so need to add to measure list
                 // Carbon does not support group by on measure column so throwing exception to
                 // make it detail query
@@ -289,14 +288,14 @@ case class CarbonCubeScan(
                 // So, let's fall back to detailed query flow
                 throw new Exception(
                   "Some attributes referred looks derived columns. So, force to detailequery " +
-                    attr.name)
+                  attr.name)
               }
             }
             outputColumns += attr
-          case par: Alias if par.children(0).isInstanceOf[AggregateExpression1] =>
+          case par: Alias if par.children.head.isInstanceOf[AggregateExpression1] =>
             outputColumns += par.toAttribute
             queryOrder = processAggregateExpr(plan,
-              par.children(0).asInstanceOf[AggregateExpression1], queryOrder)
+              par.children.head.asInstanceOf[AggregateExpression1], queryOrder)
 
           case _ => forceDetailedQuery = true
         }
@@ -305,18 +304,18 @@ case class CarbonCubeScan(
 
     if (forceDetailedQuery) {
       // First clear the model if Msrs, Expressions and AggDimAggInfo filled
-      plan.getDimensions().clear()
-      plan.getMeasures().clear()
-      plan.getDimAggregatorInfos().clear()
-      plan.getExpressions().clear()
+      plan.getDimensions.clear()
+      plan.getMeasures.clear()
+      plan.getDimAggregatorInfos.clear()
+      plan.getExpressions.clear()
 
       // Fill the selected dimensions & measures obtained from
       // attributes to query plan  for detailed query
-      selectedDims.foreach(plan.addDimension(_))
-      selectedMsrs.foreach(plan.addMeasure(_))
+      selectedDims.foreach(plan.addDimension)
+      selectedMsrs.foreach(plan.addMeasure)
     }
     else {
-      attributes = outputColumns.toSeq
+      attributes = outputColumns
     }
 
     val orderList = new ArrayList[QueryDimension]()
@@ -325,28 +324,28 @@ case class CarbonCubeScan(
     sortExprs match {
       case Some(a: Seq[SortOrder]) =>
         a.foreach {
-          case SortOrder(SumCarbon(attr: AttributeReference, _), order) => plan.getMeasures()
-            .asScala.filter(m => m.getColumnName().equalsIgnoreCase(attr.name))(0)
+          case SortOrder(SumCarbon(attr: AttributeReference, _), order) => plan.getMeasures
+            .asScala.filter(m => m.getColumnName.equalsIgnoreCase(attr.name)).head
             .setSortOrder(getSortDirection(order))
-          case SortOrder(CountCarbon(attr: AttributeReference), order) => plan.getMeasures()
-            .asScala.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))(0)
+          case SortOrder(CountCarbon(attr: AttributeReference), order) => plan.getMeasures
+            .asScala.filter(m => m.getColumnName.equalsIgnoreCase(attr.name)).head
             .setSortOrder(getSortDirection(order))
-          case SortOrder(CountDistinctCarbon(attr: AttributeReference), order) => plan.getMeasures()
-            .asScala.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))(0)
+          case SortOrder(CountDistinctCarbon(attr: AttributeReference), order) => plan.getMeasures
+            .asScala.filter(m => m.getColumnName.equalsIgnoreCase(attr.name)).head
             .setSortOrder(getSortDirection(order))
-          case SortOrder(AverageCarbon(attr: AttributeReference, _), order) => plan.getMeasures()
-            .asScala.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))(0)
+          case SortOrder(AverageCarbon(attr: AttributeReference, _), order) => plan.getMeasures
+            .asScala.filter(m => m.getColumnName.equalsIgnoreCase(attr.name)).head
             .setSortOrder(getSortDirection(order))
           case SortOrder(attr: AttributeReference, order) =>
             val dim = plan.getDimensions
               .asScala.filter(m => m.getColumnName.equalsIgnoreCase(attr.name))
-            if (!dim.isEmpty) {
-              dim(0).setSortOrder(getSortDirection(order))
-              orderList.add(dim(0))
+            if (dim.nonEmpty) {
+              dim.head.setSortOrder(getSortDirection(order))
+              orderList.add(dim.head)
             } else {
               allSortExprPushed = false
             }
-          case _ => allSortExprPushed = false
+          case _ => allSortExprPushed = false;
         }
       case _ =>
     }
@@ -354,18 +353,20 @@ case class CarbonCubeScan(
     plan.setSortedDimemsions(orderList)
 
     // limit can be pushed down only if sort is not present or all sort expressions are pushed
-    if (sortExprs.isEmpty && forceDetailedQuery) limitExpr match {
-      case Some(IntegerLiteral(limit)) =>
-        // if (plan.getMeasures.size() == 0 && plan.getDimAggregatorInfos.size() == 0) {
-        plan.setLimit(limit)
+    if (sortExprs.isEmpty && forceDetailedQuery) {
+      limitExpr match {
+        case Some(IntegerLiteral(limit)) =>
+          // if (plan.getMeasures.size() == 0 && plan.getDimAggregatorInfos.size() == 0) {
+          plan.setLimit(limit)
         // }
-      case _ =>
+        case _ =>
+      }
     }
     plan.setDetailQuery(forceDetailedQuery)
     plan.setOutLocationPath(
       CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION_HDFS))
     plan.setQueryId(System.nanoTime() + "")
-    if (!dimensionPredicates.isEmpty) {
+    if (dimensionPredicates.nonEmpty) {
       val exps = preProcessExpressions(dimensionPredicates)
       val expressionVal = transformExpression(exps.head)
       // adding dimension used in expression in querystats
@@ -421,7 +422,7 @@ case class CarbonCubeScan(
         CarbonScalaUtil.convertSparkToCarbonDataType(dataType))
       case Literal(name, dataType) => new
           CarbonLiteralExpression(name, CarbonScalaUtil.convertSparkToCarbonDataType(dataType))
-      case Cast(left, right) if (!left.isInstanceOf[Literal]) => transformExpression(left)
+      case Cast(left, right) if !left.isInstanceOf[Literal] => transformExpression(left)
       case _ =>
         new SparkUnknownExpression(expr.transform {
           case AttributeReference(name, dataType, _, _) =>
@@ -440,7 +441,7 @@ case class CarbonCubeScan(
 
 
   def addPushdownFilters(keys: Seq[Expression], filters: Array[Array[Expression]],
-                         conditions: Option[Expression]) {
+      conditions: Option[Expression]) {
 
     // TODO Values in the IN filter is duplicate. replace the list with set
     val buffer = new ArrayBuffer[Expression]
@@ -463,10 +464,10 @@ case class CarbonCubeScan(
   def inputRdd: CarbonQueryRDD[CarbonKey, CarbonValue] = {
     val LOG = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
     // Update the FilterExpressions with extra conditions added through join pushdown
-    if (!extraPreds.isEmpty) {
-      val exps = preProcessExpressions(extraPreds.toSeq)
+    if (extraPreds.nonEmpty) {
+      val exps = preProcessExpressions(extraPreds)
       val expressionVal = transformExpression(exps.head)
-      val oldExpressionVal = buildCarbonPlan.getFilterExpression()
+      val oldExpressionVal = buildCarbonPlan.getFilterExpression
       if (null == oldExpressionVal) {
         buildCarbonPlan.setFilterExpression(expressionVal)
       } else {
@@ -485,27 +486,29 @@ case class CarbonCubeScan(
     buildCarbonPlan.setQueryId(oc.getConf("queryId", System.nanoTime() + ""))
 
     LOG.info("Selected Table to Query ****** "
-        + model.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableName)
+             + model.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableName)
 
     val cubeCreationTime = carbonCatalog.getCubeCreationTime(relation.schemaName, cubeName)
     val schemaLastUpdatedTime =
       carbonCatalog.getSchemaLastUpdatedTime(relation.schemaName, cubeName)
     val big = new CarbonQueryRDD(
-        oc.sparkContext,
-        model,
-        buildCarbonPlan.getFilterExpression,
-        kv,
-        conf,
-        cubeCreationTime,
-        schemaLastUpdatedTime,
-        carbonCatalog.storePath)
+      oc.sparkContext,
+      model,
+      buildCarbonPlan.getFilterExpression,
+      kv,
+      conf,
+      cubeCreationTime,
+      schemaLastUpdatedTime,
+      carbonCatalog.storePath)
     big
   }
 
   def doExecute(): RDD[InternalRow] = {
-    def toType(obj: Any): Any = obj match {
-      case s: String => UTF8String.fromString(s)
-      case _ => obj
+    def toType(obj: Any): Any = {
+      obj match {
+        case s: String => UTF8String.fromString(s)
+        case _ => obj
+      }
     }
     // count(*) query executed in driver by querying from Btree
     if (buildCarbonPlan.isCountStarQuery && null == buildCarbonPlan.getFilterExpression) {
@@ -524,7 +527,7 @@ case class CarbonCubeScan(
     } else {
       // all the other queries are sent to executor
       inputRdd.map { row =>
-        val dims = row._1.getKey.map(toType).toArray
+        val dims = row._1.getKey.map(toType)
         val values = dims
         new GenericMutableRow(values.asInstanceOf[Array[Any]])
       }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql
 import java.util.regex.{Matcher, Pattern}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.LinkedHashSet
 import scala.language.implicitConversions
-import scala.util.control.Breaks.{break, breakable}
 
 import org.apache.hadoop.hive.ql.lib.Node
 import org.apache.hadoop.hive.ql.parse._
@@ -33,7 +33,6 @@ import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.execution.command.{DimensionRelation, _}
 import org.apache.spark.sql.execution.datasources.DescribeCommand
 import org.apache.spark.sql.hive.HiveQlWrapper
-import scala.collection.mutable.LinkedHashSet
 
 
 /**

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -313,9 +313,8 @@ class TableNewProcessor(cm: tableModel, sqlContext: SQLContext) {
         }
         else {
 
-          try { {
+          try {
             Class.forName(part.partitionClass).newInstance()
-          }
           } catch {
             case e: Exception =>
               val cl = part.partitionClass
@@ -656,9 +655,8 @@ class TableProcessor(cm: tableModel, sqlContext: SQLContext) {
         }
         else {
 
-          try { {
+          try {
             Class.forName(part.partitionClass).newInstance()
-          }
           } catch {
             case e: Exception =>
               val cl = part.partitionClass
@@ -1047,9 +1045,8 @@ private[sql] case class ShowCreateTable(cm: tableModel, override val output: Seq
           }
         }
 
-        try { {
+        try {
           Class.forName(part.partitionClass).newInstance()
-        }
         } catch {
           case e: Exception =>
             val cl = part.partitionClass
@@ -1176,11 +1173,10 @@ private[sql] case class CreateCube(cm: tableModel) extends RunnableCommand {
       val catalog = CarbonEnv.getInstance(sqlContext).carbonCatalog
       // Need to fill partitioner class when we support partition
       val cubePath = catalog.createCubeFromThrift(tableInfo, dbName, cubeName, null)(sqlContext)
-      try { {
+      try {
         sqlContext.sql(
           s"""CREATE TABLE $dbName.$cubeName USING org.apache.spark.sql.CarbonSource""" +
           s""" OPTIONS (cubename "$dbName.$cubeName", path "$cubePath") """).collect
-      }
       } catch {
         case e: Exception =>
 
@@ -1302,7 +1298,7 @@ private[sql] case class LoadCube(
     val carbonLock = CarbonLockFactory.getCarbonLockObj(org.carbondata.core.
       carbon.metadata.CarbonMetadata.getInstance().getCarbonTable(schemaName + "_" + cubeName).
       getMetaDataFilepath, LockUsage.METADATA_LOCK)
-    try { {
+    try {
       if (carbonLock.lockWithRetries()) {
         logInfo("Successfully able to get the cube metadata file lock")
       }
@@ -1382,44 +1378,42 @@ private[sql] case class LoadCube(
       var partitionStatus = CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS
       try {
         // First system has to partition the data first and then call the load data
-        {
-          if (null == relation.cubeMeta.partitioner.partitionColumn ||
-              relation.cubeMeta.partitioner.partitionColumn(0).isEmpty) {
-            LOGGER.info("Initiating Direct Load for the Cube : (" +
-                        schemaName + "." + cubeName + ")")
-            carbonLoadModel.setFactFilePath(factPath)
-            carbonLoadModel.setCsvDelimiter(CarbonUtil.unescapeChar(delimiter))
-            carbonLoadModel.setCsvHeader(fileHeader)
-            carbonLoadModel.setDirectLoad(true)
-          }
-          else {
-            val fileType = FileFactory.getFileType(partitionLocation)
-            if (FileFactory.isFileExist(partitionLocation, fileType)) {
-              val file = FileFactory.getCarbonFile(partitionLocation, fileType)
-              CarbonUtil.deleteFoldersAndFiles(file)
-            }
-            partitionLocation += System.currentTimeMillis()
-            FileFactory.mkdirs(partitionLocation, fileType)
-            LOGGER.info("Initiating Data Partitioning for the Cube : (" +
-                        schemaName + "." + cubeName + ")")
-            carbonLoadModel.setFactFilePath(partitionLocation)
-            partitionStatus = CarbonContext.partitionData(
-              schemaName,
-              cubeName,
-              factPath,
-              partitionLocation,
-              delimiter,
-              quoteChar,
-              fileHeader,
-              escapeChar, booleanValForMultiLine)(sqlContext.asInstanceOf[HiveContext])
-          }
-          GlobalDictionaryUtil
-            .generateGlobalDictionary(sqlContext, carbonLoadModel, relation.cubeMeta.dataPath)
-          CarbonDataRDDFactory
-            .loadCarbonData(sqlContext, carbonLoadModel, storeLocation, relation.cubeMeta.dataPath,
-              kettleHomePath,
-              relation.cubeMeta.partitioner, columinar, isAgg = false, partitionStatus)
+        if (null == relation.cubeMeta.partitioner.partitionColumn ||
+            relation.cubeMeta.partitioner.partitionColumn(0).isEmpty) {
+          LOGGER.info("Initiating Direct Load for the Cube : (" +
+                      schemaName + "." + cubeName + ")")
+          carbonLoadModel.setFactFilePath(factPath)
+          carbonLoadModel.setCsvDelimiter(CarbonUtil.unescapeChar(delimiter))
+          carbonLoadModel.setCsvHeader(fileHeader)
+          carbonLoadModel.setDirectLoad(true)
         }
+        else {
+          val fileType = FileFactory.getFileType(partitionLocation)
+          if (FileFactory.isFileExist(partitionLocation, fileType)) {
+            val file = FileFactory.getCarbonFile(partitionLocation, fileType)
+            CarbonUtil.deleteFoldersAndFiles(file)
+          }
+          partitionLocation += System.currentTimeMillis()
+          FileFactory.mkdirs(partitionLocation, fileType)
+          LOGGER.info("Initiating Data Partitioning for the Cube : (" +
+                      schemaName + "." + cubeName + ")")
+          carbonLoadModel.setFactFilePath(partitionLocation)
+          partitionStatus = CarbonContext.partitionData(
+            schemaName,
+            cubeName,
+            factPath,
+            partitionLocation,
+            delimiter,
+            quoteChar,
+            fileHeader,
+            escapeChar, booleanValForMultiLine)(sqlContext.asInstanceOf[HiveContext])
+        }
+        GlobalDictionaryUtil
+          .generateGlobalDictionary(sqlContext, carbonLoadModel, relation.cubeMeta.dataPath)
+        CarbonDataRDDFactory
+          .loadCarbonData(sqlContext, carbonLoadModel, storeLocation, relation.cubeMeta.dataPath,
+            kettleHomePath,
+            relation.cubeMeta.partitioner, columinar, isAgg = false, partitionStatus)
       }
       catch {
         case ex: Exception =>
@@ -1429,14 +1423,13 @@ private[sql] case class LoadCube(
       }
       finally {
         // Once the data load is successful delete the unwanted partition files
-        try { {
+        try {
           val fileType = FileFactory.getFileType(partitionLocation)
           if (FileFactory.isFileExist(partitionLocation, fileType)) {
             val file = FileFactory
               .getCarbonFile(partitionLocation, fileType)
             CarbonUtil.deleteFoldersAndFiles(file)
           }
-        }
         } catch {
           case ex: Exception =>
             LOGGER.error(ex)
@@ -1445,7 +1438,6 @@ private[sql] case class LoadCube(
         }
 
       }
-    }
     } finally {
       if (carbonLock != null) {
         if (carbonLock.unlock()) {
@@ -1644,10 +1636,9 @@ private[sql] case class DropCubeCommand(ifExistsSet: Boolean, schemaNameOp: Opti
       }
       if (sqlContext.tableNames(schemaName).map(x => x.toLowerCase())
         .contains(cubeName.toLowerCase())) {
-        try { {
+        try {
           sqlContext.asInstanceOf[HiveContext].catalog.client.
             runSqlHive(s"DROP TABLE IF EXISTS $schemaName.$cubeName")
-        }
         } catch {
           case e: RuntimeException =>
             LOGGER.audit(
@@ -1661,7 +1652,7 @@ private[sql] case class DropCubeCommand(ifExistsSet: Boolean, schemaNameOp: Opti
       CarbonProperties.getInstance().addProperty("zookeeper.enable.lock", "false")
       val carbonLock = CarbonLockFactory
         .getCarbonLockObj(tmpCube.getMetaDataFilepath, LockUsage.METADATA_LOCK)
-      try { {
+      try {
         if (carbonLock.lockWithRetries()) {
           logInfo("Successfully able to get the cube metadata file lock")
         } else {
@@ -1693,7 +1684,6 @@ private[sql] case class DropCubeCommand(ifExistsSet: Boolean, schemaNameOp: Opti
 
           LOGGER.audit(s"Deleted cube [$cubeName] under schema [$schemaName]")
         }
-      }
       }
       finally {
         if (carbonLock != null) {
@@ -1768,10 +1758,9 @@ private[sql] case class ShowLoads(
         loadMetadataDetailsSortedArray = loadMetadataDetailsSortedArray
           .filter(load => load.getVisibility.equalsIgnoreCase("true"))
         val limitLoads = limit.get
-        try { {
+        try {
           val lim = Integer.parseInt(limitLoads)
           loadMetadataDetailsSortedArray = loadMetadataDetailsSortedArray.slice(0, lim)
-        }
         }
         catch {
           case ex: NumberFormatException => sys.error(s" Entered limit is not a valid Number")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/joins/CarbonJoins.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/joins/CarbonJoins.scala
@@ -29,12 +29,12 @@ import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.unsafe.types.UTF8String
 
 case class FilterPushJoin(
-                           leftKeys: Seq[Expression],
-                           rightKeys: Seq[Expression],
-                           buildSide: BuildSide,
-                           left: SparkPlan,
-                           right: SparkPlan,
-                           condition: Option[Expression]) extends BinaryNode with HashJoin {
+    leftKeys: Seq[Expression],
+    rightKeys: Seq[Expression],
+    buildSide: BuildSide,
+    left: SparkPlan,
+    right: SparkPlan,
+    condition: Option[Expression]) extends BinaryNode with HashJoin {
 
   override private[sql] lazy val metrics = Map(
     "numLeftRows" -> SQLMetrics.createLongMetric(sparkContext, "number of left rows"),

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -211,7 +211,7 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
             val resolvedTable = sqlContext.executePlan(CarbonHiveSyntax.parse(d.sql)).analyzed
             planLater(resolvedTable) :: Nil
           } catch {
-            case Exception => ExecutedCommand(d) :: Nil
+            case e: Exception => ExecutedCommand(d) :: Nil
           }
         case DescribeFormattedCommand(sql, tblIdentifier) =>
           val isCube = CarbonEnv.getInstance(sqlContext).carbonCatalog
@@ -258,7 +258,7 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
           carbonScan(projectList, predicates, carbonRelation.carbonRelation,
             Some(partialComputation), substitutesortExprs, limitExpr, groupingExpressions.nonEmpty)
         } catch {
-          case Exception => null
+          case e: Exception => null
         }
 
       if (s != null) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.{DescribeCommand => LogicalDescribeCommand, LogicalRelation}
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, FilterPushJoin}
 import org.apache.spark.sql.hive.execution.{DescribeHiveTableCommand, DropTable, HiveNativeCommand}
-import org.apache.spark.sql.types.{IntegerType, LongType}
 
 import org.carbondata.common.logging.LogServiceFactory
 
@@ -41,7 +40,7 @@ object CarbonHiveSyntax {
   protected val sqlParser = new CarbonSqlParser
 
   def parse(sqlText: String): LogicalPlan = {
-      sqlParser.parse(sqlText)
+    sqlParser.parse(sqlText)
   }
 }
 
@@ -61,184 +60,205 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
    */
   private[sql] object CarbonCubeScans extends Strategy {
 
-    def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-      case PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)) =>
-        carbonScan(projectList, predicates, carbonRelation.carbonRelation, None, None, None, false,
-          true) :: Nil
+    def apply(plan: LogicalPlan): Seq[SparkPlan] = {
+      plan match {
+        case PhysicalOperation(projectList, predicates,
+        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)) =>
+          carbonScan(projectList,
+            predicates,
+            carbonRelation.carbonRelation,
+            None,
+            None,
+            None,
+            isGroupByPresent = false,
+            detailQuery = true) :: Nil
 
-      case Limit(IntegerLiteral(limit),
-      Sort(order, _, p@PartialAggregation(
-      namedGroupingAttributes,
-      rewrittenAggregateExpressions,
-      groupingExpressions,
-      partialComputation,
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _))))) =>
-        val aggPlan = handleAggregation(plan, p, projectList, predicates, carbonRelation,
-          partialComputation, groupingExpressions, namedGroupingAttributes,
-          rewrittenAggregateExpressions)
-        org.apache.spark.sql.execution.TakeOrderedAndProject(limit,
-          order,
-          None,
-          aggPlan(0)) :: Nil
+        case Limit(IntegerLiteral(limit),
+        Sort(order, _,
+        p@PartialAggregation(namedGroupingAttributes,
+        rewrittenAggregateExpressions,
+        groupingExpressions,
+        partialComputation,
+        PhysicalOperation(
+        projectList,
+        predicates,
+        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _))))) =>
+          val aggPlan = handleAggregation(plan, p, projectList, predicates, carbonRelation,
+            partialComputation, groupingExpressions, namedGroupingAttributes,
+            rewrittenAggregateExpressions)
+          org.apache.spark.sql.execution.TakeOrderedAndProject(limit,
+            order,
+            None,
+            aggPlan.head) :: Nil
 
-      case Limit(IntegerLiteral(limit), p@PartialAggregation(
-      namedGroupingAttributes,
-      rewrittenAggregateExpressions,
-      groupingExpressions,
-      partialComputation,
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)))) =>
-        val aggPlan = handleAggregation(plan, p, projectList, predicates, carbonRelation,
-          partialComputation, groupingExpressions, namedGroupingAttributes,
-          rewrittenAggregateExpressions)
-        org.apache.spark.sql.execution.Limit(limit, aggPlan(0)) :: Nil
+        case Limit(IntegerLiteral(limit), p@PartialAggregation(
+        namedGroupingAttributes,
+        rewrittenAggregateExpressions,
+        groupingExpressions,
+        partialComputation,
+        PhysicalOperation(projectList, predicates,
+        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)))) =>
+          val aggPlan = handleAggregation(plan, p, projectList, predicates, carbonRelation,
+            partialComputation, groupingExpressions, namedGroupingAttributes,
+            rewrittenAggregateExpressions)
+          org.apache.spark.sql.execution.Limit(limit, aggPlan.head) :: Nil
 
-      case PartialAggregation(
-      namedGroupingAttributes,
-      rewrittenAggregateExpressions,
-      groupingExpressions,
-      partialComputation,
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _))) =>
-        handleAggregation(plan, plan, projectList, predicates, carbonRelation,
-          partialComputation, groupingExpressions, namedGroupingAttributes,
-          rewrittenAggregateExpressions)
+        case PartialAggregation(
+        namedGroupingAttributes,
+        rewrittenAggregateExpressions,
+        groupingExpressions,
+        partialComputation,
+        PhysicalOperation(projectList, predicates,
+        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _))) =>
+          handleAggregation(plan, plan, projectList, predicates, carbonRelation,
+            partialComputation, groupingExpressions, namedGroupingAttributes,
+            rewrittenAggregateExpressions)
 
-      case Limit(IntegerLiteral(limit),
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _))) =>
-        val (_, _, _, aliases, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
-        val s = carbonScan(projectList, predicates, carbonRelation.carbonRelation, groupExprs,
-          substitutesortExprs, limitExpr, false, true)
-        org.apache.spark.sql.execution.Limit(limit, s) :: Nil
+        case Limit(IntegerLiteral(limit),
+        PhysicalOperation(projectList, predicates,
+        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _))) =>
+          val (_, _, _, _, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
+          val s = carbonScan(projectList, predicates, carbonRelation.carbonRelation, groupExprs,
+            substitutesortExprs, limitExpr, isGroupByPresent = false, detailQuery = true)
+          org.apache.spark.sql.execution.Limit(limit, s) :: Nil
 
+        case Limit(IntegerLiteral(limit),
+        Sort(order, _,
+        PhysicalOperation(projectList, predicates,
+        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)))) =>
+          val (_, _, _, _, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
+          val s = carbonScan(projectList, predicates, carbonRelation.carbonRelation, groupExprs,
+            substitutesortExprs, limitExpr, isGroupByPresent = false, detailQuery = true)
+          org.apache.spark.sql.execution.TakeOrderedAndProject(limit,
+            order,
+            None,
+            s) :: Nil
 
-      case Limit(IntegerLiteral(limit),
-      Sort(order, _,
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)))) =>
-        val (_, _, _, aliases, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
-        val s = carbonScan(projectList, predicates, carbonRelation.carbonRelation, groupExprs,
-          substitutesortExprs, limitExpr, false, true)
-        org.apache.spark.sql.execution.TakeOrderedAndProject(limit,
-          order,
-          None,
-          s) :: Nil
+        case ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, condition,
+        PhysicalOperation(projectList, predicates,
+        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)), right)
+          if canPushDownJoin(right, condition) =>
+          LOGGER.info(s"pushing down for ExtractEquiJoinKeys:right")
+          val carbon = carbonScan(projectList,
+            predicates,
+            carbonRelation.carbonRelation,
+            None,
+            None,
+            None,
+            isGroupByPresent = false,
+            detailQuery = true)
+          val pushedDownJoin = FilterPushJoin(
+            leftKeys: Seq[Expression],
+            rightKeys: Seq[Expression],
+            BuildRight,
+            carbon,
+            planLater(right),
+            condition)
 
-      case ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, condition,
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)), right)
-        if (canPushDownJoin(right, condition)) =>
-        LOGGER.info(s"pushing down for ExtractEquiJoinKeys:right")
-        val carbon = carbonScan(projectList, predicates, carbonRelation.carbonRelation, None, None,
-          None, false, true)
-        val pushedDownJoin = FilterPushJoin(
-          leftKeys: Seq[Expression],
-          rightKeys: Seq[Expression],
-          BuildRight,
-          carbon,
-          planLater(right),
-          condition)
+          condition.map(Filter(_, pushedDownJoin)).getOrElse(pushedDownJoin) :: Nil
 
-        condition.map(Filter(_, pushedDownJoin)).getOrElse(pushedDownJoin) :: Nil
+        case ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, condition, left,
+        PhysicalOperation(projectList, predicates,
+        l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)))
+          if canPushDownJoin(left, condition) =>
+          LOGGER.info(s"pushing down for ExtractEquiJoinKeys:left")
+          val carbon = carbonScan(projectList,
+            predicates,
+            carbonRelation.carbonRelation,
+            None,
+            None,
+            None,
+            isGroupByPresent = false,
+            detailQuery = true)
 
-      case ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, condition, left,
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)))
-        if (canPushDownJoin(left, condition)) =>
-        LOGGER.info(s"pushing down for ExtractEquiJoinKeys:left")
-        val carbon = carbonScan(projectList, predicates, carbonRelation.carbonRelation, None, None,
-          None, false, true)
+          val pushedDownJoin = FilterPushJoin(
+            leftKeys: Seq[Expression],
+            rightKeys: Seq[Expression],
+            BuildLeft,
+            planLater(left),
+            carbon,
+            condition)
+          condition.map(Filter(_, pushedDownJoin)).getOrElse(pushedDownJoin) :: Nil
 
-        val pushedDownJoin = FilterPushJoin(
-          leftKeys: Seq[Expression],
-          rightKeys: Seq[Expression],
-          BuildLeft,
-          planLater(left),
-          carbon,
-          condition)
-        condition.map(Filter(_, pushedDownJoin)).getOrElse(pushedDownJoin) :: Nil
-
-      case ShowCubeCommand(schemaName) =>
-        ExecutedCommand(ShowAllTablesInSchema(schemaName, plan.output)) :: Nil
-      case c@ShowAllCubeCommand() =>
-        ExecutedCommand(ShowAllTables(plan.output)) :: Nil
-      case ShowCreateCubeCommand(cm) =>
-        ExecutedCommand(ShowCreateTable(cm, plan.output)) :: Nil
-      case ShowTablesDetailedCommand(schemaName) =>
-        ExecutedCommand(ShowAllTablesDetail(schemaName, plan.output)) :: Nil
-      case DropTable(tableName, ifNotExists)
-        if (CarbonEnv.getInstance(sqlContext).carbonCatalog.cubeExists(Seq(tableName))
-        (sqlContext)) =>
-        ExecutedCommand(DropCubeCommand(ifNotExists, None, tableName)) :: Nil
-      case ShowAggregateTablesCommand(schemaName) =>
-        ExecutedCommand(ShowAggregateTables(schemaName, plan.output)) :: Nil
-      case ShowLoadsCommand(schemaName, cube, limit) =>
-        ExecutedCommand(ShowLoads(schemaName, cube, limit, plan.output)) :: Nil
-      case LoadCube(schemaNameOp, cubeName, factPathFromUser, dimFilesPath,
+        case ShowCubeCommand(schemaName) =>
+          ExecutedCommand(ShowAllTablesInSchema(schemaName, plan.output)) :: Nil
+        case c@ShowAllCubeCommand() =>
+          ExecutedCommand(ShowAllTables(plan.output)) :: Nil
+        case ShowCreateCubeCommand(cm) =>
+          ExecutedCommand(ShowCreateTable(cm, plan.output)) :: Nil
+        case ShowTablesDetailedCommand(schemaName) =>
+          ExecutedCommand(ShowAllTablesDetail(schemaName, plan.output)) :: Nil
+        case DropTable(tableName, ifNotExists)
+          if CarbonEnv.getInstance(sqlContext).carbonCatalog
+            .cubeExists(Seq(tableName))(sqlContext) =>
+          ExecutedCommand(DropCubeCommand(ifNotExists, None, tableName)) :: Nil
+        case ShowAggregateTablesCommand(schemaName) =>
+          ExecutedCommand(ShowAggregateTables(schemaName, plan.output)) :: Nil
+        case ShowLoadsCommand(schemaName, cube, limit) =>
+          ExecutedCommand(ShowLoads(schemaName, cube, limit, plan.output)) :: Nil
+        case LoadCube(schemaNameOp, cubeName, factPathFromUser, dimFilesPath,
         partionValues, isOverwriteExist, inputSqlString) =>
-        val isCarbonTable = CarbonEnv.getInstance(sqlContext).carbonCatalog
-          .cubeExists(schemaNameOp, cubeName)(sqlContext)
-        if (isCarbonTable) {
-          ExecutedCommand(LoadCube(schemaNameOp, cubeName, factPathFromUser,
-            dimFilesPath, partionValues, isOverwriteExist, inputSqlString)) :: Nil
-        } else {
-          ExecutedCommand(HiveNativeCommand(inputSqlString)) :: Nil
-        }
-      case d: HiveNativeCommand =>
-        try {
-          val resolvedTable = sqlContext.executePlan(CarbonHiveSyntax.parse(d.sql)).analyzed
-          planLater(resolvedTable) :: Nil
-        } catch {
-          case _ => ExecutedCommand(d) :: Nil
-        }
-      case DescribeFormattedCommand(sql, tblIdentifier) =>
-        val isCube = CarbonEnv.getInstance(sqlContext).carbonCatalog
-          .cubeExists(tblIdentifier)(sqlContext)
-        if (isCube) {
-          val describe = LogicalDescribeCommand(UnresolvedRelation(tblIdentifier, None), false)
+          val isCarbonTable = CarbonEnv.getInstance(sqlContext).carbonCatalog
+            .cubeExists(schemaNameOp, cubeName)(sqlContext)
+          if (isCarbonTable) {
+            ExecutedCommand(LoadCube(schemaNameOp, cubeName, factPathFromUser,
+              dimFilesPath, partionValues, isOverwriteExist, inputSqlString)) :: Nil
+          } else {
+            ExecutedCommand(HiveNativeCommand(inputSqlString)) :: Nil
+          }
+        case d: HiveNativeCommand =>
+          try {
+            val resolvedTable = sqlContext.executePlan(CarbonHiveSyntax.parse(d.sql)).analyzed
+            planLater(resolvedTable) :: Nil
+          } catch {
+            case Exception => ExecutedCommand(d) :: Nil
+          }
+        case DescribeFormattedCommand(sql, tblIdentifier) =>
+          val isCube = CarbonEnv.getInstance(sqlContext).carbonCatalog
+            .cubeExists(tblIdentifier)(sqlContext)
+          if (isCube) {
+            val describe =
+              LogicalDescribeCommand(UnresolvedRelation(tblIdentifier, None), isExtended = false)
+            val resolvedTable = sqlContext.executePlan(describe.table).analyzed
+            val resultPlan = sqlContext.executePlan(resolvedTable).executedPlan
+            ExecutedCommand(DescribeCommandFormatted(resultPlan, plan.output, tblIdentifier)) :: Nil
+          }
+          else {
+            ExecutedCommand(DescribeNativeCommand(sql, plan.output)) :: Nil
+          }
+        case describe@LogicalDescribeCommand(table, isExtended) =>
           val resolvedTable = sqlContext.executePlan(describe.table).analyzed
-          val resultPlan = sqlContext.executePlan(resolvedTable).executedPlan
-          ExecutedCommand(DescribeCommandFormatted(resultPlan, plan.output, tblIdentifier)) :: Nil
-        }
-        else {
-          ExecutedCommand(DescribeNativeCommand(sql, plan.output)) :: Nil
-        }
-      case describe@LogicalDescribeCommand(table, isExtended) =>
-        val resolvedTable = sqlContext.executePlan(describe.table).analyzed
-        resolvedTable match {
-          case t: MetastoreRelation =>
-            ExecutedCommand(DescribeHiveTableCommand(t, describe.output, describe.isExtended)) ::
-              Nil
-          case o: LogicalPlan =>
-            val resultPlan = sqlContext.executePlan(o).executedPlan
-            ExecutedCommand(
-              RunnableDescribeCommand(resultPlan, describe.output, describe.isExtended)) :: Nil
-        }
-      case _ =>
-        Nil
+          resolvedTable match {
+            case t: MetastoreRelation =>
+              ExecutedCommand(
+                DescribeHiveTableCommand(t, describe.output, describe.isExtended)) :: Nil
+            case o: LogicalPlan =>
+              val resultPlan = sqlContext.executePlan(o).executedPlan
+              ExecutedCommand(
+                RunnableDescribeCommand(resultPlan, describe.output, describe.isExtended)) :: Nil
+          }
+        case _ => Nil
+      }
     }
 
     def handleAggregation(plan: LogicalPlan,
-                          aggPlan: LogicalPlan,
-                          projectList: Seq[NamedExpression],
-                          predicates: Seq[Expression],
-                          carbonRelation: CarbonDatasourceRelation,
-                          partialComputation: Seq[NamedExpression],
-                          groupingExpressions: Seq[Expression],
-                          namedGroupingAttributes: Seq[Attribute],
-                          rewrittenAggregateExpressions: Seq[NamedExpression]):
+        aggPlan: LogicalPlan,
+        projectList: Seq[NamedExpression],
+        predicates: Seq[Expression],
+        carbonRelation: CarbonDatasourceRelation,
+        partialComputation: Seq[NamedExpression],
+        groupingExpressions: Seq[Expression],
+        namedGroupingAttributes: Seq[Attribute],
+        rewrittenAggregateExpressions: Seq[NamedExpression]):
     Seq[SparkPlan] = {
-      val (_, _, _, aliases, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
+      val (_, _, _, _, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
 
       val s =
         try {
           carbonScan(projectList, predicates, carbonRelation.carbonRelation,
-            Some(partialComputation), substitutesortExprs, limitExpr, !groupingExpressions.isEmpty)
+            Some(partialComputation), substitutesortExprs, limitExpr, groupingExpressions.nonEmpty)
         } catch {
-          case _ => null
+          case Exception => null
         }
 
       if (s != null) {
@@ -261,12 +281,12 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
           partialComputation,
           PhysicalOperation(projectList, predicates,
           l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _))) =>
-            val (_, _, _, aliases, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
+            val (_, _, _, _, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
 
 
             val s = carbonScan(projectList, predicates, carbonRelation.carbonRelation,
               Some(partialComputation), substitutesortExprs, limitExpr,
-              !groupingExpressions.isEmpty, true)
+              groupingExpressions.nonEmpty, detailQuery = true)
 
             CarbonAggregate(
               partial = false,
@@ -281,23 +301,14 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
       }
     }
 
-    private def canBeCodeGened(aggs: Seq[AggregateExpression]) = !aggs.exists {
-      case _: Sum | _: Count | _: Max | _: CombineSetsAndCount => false
-      // The generated set implementation is pretty limited ATM.
-      case CollectHashSet(exprs) if exprs.size == 1 &&
-        Seq(IntegerType, LongType).contains(exprs.head.dataType) => false
-      case _ => true
-    }
-
-    private def allAggregates(exprs: Seq[Expression]) =
-      exprs.flatMap(_.collect { case a: AggregateExpression => a })
-
     private def canPushDownJoin(otherRDDPlan: LogicalPlan,
-                                joinCondition: Option[Expression]): Boolean = {
+        joinCondition: Option[Expression]): Boolean = {
       val pushdowmJoinEnabled = sqlContext.sparkContext.conf
-        .getBoolean("spark.carbon.pushdown.join.as.filter", true)
+        .getBoolean("spark.carbon.pushdown.join.as.filter", defaultValue = true)
 
-      if (!pushdowmJoinEnabled) return false
+      if (!pushdowmJoinEnabled) {
+        return false
+      }
 
       val isJoinOnCarbonCube = otherRDDPlan match {
         case other@PhysicalOperation(projectList, predicates,
@@ -313,10 +324,9 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
       otherRDDPlan match {
         case BroadcastHint(p) => true
         case p if sqlContext.conf.autoBroadcastJoinThreshold > 0 &&
-          p.statistics.sizeInBytes <= sqlContext.conf.autoBroadcastJoinThreshold => {
+                  p.statistics.sizeInBytes <= sqlContext.conf.autoBroadcastJoinThreshold =>
           LOGGER.info("canPushDownJoin statistics:" + p.statistics.sizeInBytes)
           true
-        }
         case _ => false
       }
     }
@@ -325,15 +335,15 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
      * Create carbon scan
      */
     private def carbonScan(projectList: Seq[NamedExpression],
-                   predicates: Seq[Expression],
-                   relation: CarbonRelation,
-                   groupExprs: Option[Seq[Expression]],
-                   substitutesortExprs: Option[Seq[SortOrder]],
-                   limitExpr: Option[Expression],
-                   isGroupByPresent: Boolean,
-                   detailQuery: Boolean = false) = {
+        predicates: Seq[Expression],
+        relation: CarbonRelation,
+        groupExprs: Option[Seq[Expression]],
+        substitutesortExprs: Option[Seq[SortOrder]],
+        limitExpr: Option[Expression],
+        isGroupByPresent: Boolean,
+        detailQuery: Boolean = false) = {
 
-      if (detailQuery == false) {
+      if (!detailQuery) {
         val projectSet = AttributeSet(projectList.flatMap(_.references))
         CarbonCubeScan(
           projectSet.toSeq,
@@ -368,7 +378,7 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
           Some(sort.map {
             case SortOrder(a: Alias, direction) =>
               val ref = aliases.getOrElse(a.toAttribute, a) match {
-                case Alias(ref, name) => ref
+                case Alias(reference, name) => reference
                 case others => others
               }
               SortOrder(ref, direction)

--- a/integration/spark/src/main/scala/org/apache/spark/util/FileUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/FileUtils.scala
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-
-
 package org.apache.spark.util
 
 import org.carbondata.core.datastorage.store.filesystem.CarbonFile
@@ -25,15 +23,13 @@ import org.carbondata.core.datastorage.store.impl.FileFactory
 object FileUtils {
   /**
    * append all csv file path to a String, file path separated by comma
-   * @param carbonFile
-   * @return
    */
   def getPathsFromCarbonFile(carbonFile: CarbonFile): String = {
-    if (carbonFile.isDirectory()) {
+    if (carbonFile.isDirectory) {
       val files = carbonFile.listFiles()
       val stringBuilder = new StringBuilder()
       for (j <- 0 until files.size) {
-        if (files(j).getName().endsWith(".csv")) {
+        if (files(j).getName.endsWith(".csv")) {
           stringBuilder.append(getPathsFromCarbonFile(files(j))).append(",")
         }
       }
@@ -46,8 +42,7 @@ object FileUtils {
 
   /**
    * append all file path to a String, inputPath path separated by comma
-   * @param inputPath
-   * @return
+   *
    */
   def getPaths(inputPath: String): String = {
     if (inputPath == null || inputPath.isEmpty) {

--- a/integration/spark/src/main/scala/org/apache/spark/util/SplitUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/SplitUtils.scala
@@ -34,9 +34,6 @@ object SplitUtils {
   /**
    * get file splits,return Array[BlockDetails], if file path is empty,then return empty Array
    *
-   * @param path
-   * @param sc
-   * @return
    */
   def getSplits(path: String, sc: SparkContext): Array[BlockDetails] = {
     val filePath = FileUtils.getPaths(path)

--- a/integration/spark/src/main/scala/org/carbondata/spark/CarbonOption.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/CarbonOption.scala
@@ -29,7 +29,9 @@ class CarbonOption(options: Map[String, String]) {
 
   def partitionCount: String = options.getOrElse("partitionCount", "1")
 
-  def partitionClass: String = options.getOrElse("partitionClass",
-    "org.carbondata.spark.partition.api.impl.SampleDataPartitionerImpl")
+  def partitionClass: String = {
+    options.getOrElse("partitionClass",
+      "org.carbondata.spark.partition.api.impl.SampleDataPartitionerImpl")
+  }
 
 }

--- a/integration/spark/src/main/scala/org/carbondata/spark/KeyVal.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/KeyVal.scala
@@ -43,8 +43,9 @@ trait Result[K, V] extends Serializable {
 }
 
 class ResultImpl extends Result[Int, LoadMetadataDetails] {
-  override def getKey(key: Int, value: LoadMetadataDetails): (Int, LoadMetadataDetails) =
+  override def getKey(key: Int, value: LoadMetadataDetails): (Int, LoadMetadataDetails) = {
     (key, value)
+  }
 }
 
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
@@ -358,9 +358,9 @@ case class AverageFunctionCarbon(expr: Expression, base: AggregateExpression1, f
         null
       } else {
         avg match {
-          case AvgBigDecimalAggregator =>
+          case avg: AvgBigDecimalAggregator =>
             Cast(Literal(avg.getBigDecimalValue), base.dataType).eval(null)
-          case AvgLongAggregator =>
+          case avg: AvgLongAggregator =>
             Cast(Literal(avg.getLongValue), base.dataType).eval(null)
           case _ =>
             Cast(Literal(avg.getDoubleValue), base.dataType).eval(null)
@@ -437,11 +437,11 @@ case class SumFunctionCarbon(expr: Expression, base: AggregateExpression1, final
         var dc: MeasureAggregator = null
         if (s != null) {
           s match {
-            case java.math.BigDecimal =>
+            case bd: java.math.BigDecimal =>
               dc = new SumBigDecimalAggregator
               dc.agg(new java.math.BigDecimal(s.toString))
               dc.setNewValue(new java.math.BigDecimal(s.toString))
-            case Long =>
+            case l: Long =>
               dc = new SumLongAggregator
               dc.agg(s.toString.toLong)
               dc.setNewValue(s.toString.toLong)
@@ -469,9 +469,9 @@ case class SumFunctionCarbon(expr: Expression, base: AggregateExpression1, final
         null
       } else {
         sum match {
-          case SumBigDecimalAggregator =>
+          case s: SumBigDecimalAggregator =>
             Cast(Literal(sum.getBigDecimalValue), base.dataType).eval(input)
-          case SumLongAggregator =>
+          case s: SumLongAggregator =>
             Cast(Literal(sum.getLongValue), base.dataType).eval(input)
           case _ =>
             Cast(Literal(sum.getDoubleValue), base.dataType).eval(input)
@@ -600,7 +600,7 @@ case class SumDisctinctFunctionCarbon(expr: Expression, base: AggregateExpressio
           case Int =>
             dc = new SumDistinctLongAggregator
             dc.setNewValue(s.toString.toLong)
-          case java.math.BigDecimal =>
+          case bd: java.math.BigDecimal =>
             dc = new SumDistinctBigDecimalAggregator
             dc.setNewValue(new java.math.BigDecimal(s.toString))
           case _ =>

--- a/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
@@ -90,10 +90,11 @@ case class CountDistinctCarbonFinal(inputSet: Expression, origDataType: DataType
 
   override def dataType: DataType = origDataType
 
-  override def toString: String = s"COUNTFINAL(DISTINCT ${inputSet}})"
+  override def toString: String = s"COUNTFINAL(DISTINCT ${ inputSet }})"
 
-  override def newInstance(): AggregateFunction1 =
+  override def newInstance(): AggregateFunction1 = {
     new CountDistinctFunctionCarbonFinal(inputSet, this)
+  }
 }
 
 case class AverageCarbon(child: Expression, castedDataType: DataType = null)
@@ -255,12 +256,17 @@ case class SumDistinctCarbon(child: Expression, castedDataType: DataType = null)
     val partialSum = Alias(SumDistinctCarbon(child), "PartialSumDistinct")()
     SplitEvaluation(
       SumDistinctFinalCarbon(partialSum.toAttribute,
-        if (castedDataType != null) castedDataType else child.dataType),
+        if (castedDataType != null) {
+          castedDataType
+        } else {
+          child.dataType
+        }),
       partialSum :: Nil)
   }
 
-  override def newInstance(): AggregateFunction1 =
+  override def newInstance(): AggregateFunction1 = {
     new SumDisctinctFunctionCarbon(child, this, false)
+  }
 }
 
 case class SumDistinctFinalCarbon(child: Expression, origDataType: DataType)
@@ -319,20 +325,19 @@ case class AverageFunctionCarbon(expr: Expression, base: AggregateExpression1, f
       case s =>
         var dc: MeasureAggregator = null
         if (s != null) {
-          if (s.isInstanceOf[java.math.BigDecimal]) {
-            dc = new AvgBigDecimalAggregator
-            dc.agg(new java.math.BigDecimal(s.toString))
-            dc.setNewValue(new java.math.BigDecimal(s.toString))
-          }
-          else if (s.isInstanceOf[Long]) {
-            dc = new AvgLongAggregator
-            dc.agg(s.toString.toLong)
-            dc.setNewValue(s.toString.toLong)
-          }
-          else {
-            dc = new AvgDoubleAggregator
-            dc.agg(s.toString.toDouble)
-            dc.setNewValue(s.toString.toDouble)
+          s match {
+            case v: java.math.BigDecimal =>
+              dc = new AvgBigDecimalAggregator
+              dc.agg(new java.math.BigDecimal(s.toString))
+              dc.setNewValue(new java.math.BigDecimal(s.toString))
+            case l: Long =>
+              dc = new AvgLongAggregator
+              dc.agg(s.toString.toLong)
+              dc.setNewValue(s.toString.toLong)
+            case _ =>
+              dc = new AvgDoubleAggregator
+              dc.agg(s.toString.toDouble)
+              dc.setNewValue(s.toString.toDouble)
           }
         }
         else {
@@ -340,27 +345,31 @@ case class AverageFunctionCarbon(expr: Expression, base: AggregateExpression1, f
         }
         dc
     }
-    if (avg == null) avg = agg else avg.merge(agg)
+    if (avg == null) {
+      avg = agg
+    } else {
+      avg.merge(agg)
+    }
   }
 
-  override def eval(input: InternalRow): Any =
+  override def eval(input: InternalRow): Any = {
     if (finalAgg) {
-      if (avg.isFirstTime()) {
+      if (avg.isFirstTime) {
         null
       } else {
-        if (avg.isInstanceOf[AvgBigDecimalAggregator]) {
-          Cast(Literal(avg.getBigDecimalValue), base.dataType).eval(null)
-        }
-        else if (avg.isInstanceOf[AvgLongAggregator]) {
-          Cast(Literal(avg.getLongValue), base.dataType).eval(null)
-        }
-        else {
-          Cast(Literal(avg.getDoubleValue), base.dataType).eval(null)
+        avg match {
+          case AvgBigDecimalAggregator =>
+            Cast(Literal(avg.getBigDecimalValue), base.dataType).eval(null)
+          case AvgLongAggregator =>
+            Cast(Literal(avg.getLongValue), base.dataType).eval(null)
+          case _ =>
+            Cast(Literal(avg.getDoubleValue), base.dataType).eval(null)
         }
       }
     } else {
       avg
     }
+  }
 }
 
 case class CountFunctionCarbon(expr: Expression, base: AggregateExpression1, finalAgg: Boolean)
@@ -386,12 +395,16 @@ case class CountFunctionCarbon(expr: Expression, base: AggregateExpression1, fin
         }
         agg1
     }
-    if (count == null) count = agg else count.merge(agg)
+    if (count == null) {
+      count = agg
+    } else {
+      count.merge(agg)
+    }
   }
 
-  override def eval(input: InternalRow): Any =
+  override def eval(input: InternalRow): Any = {
     if (finalAgg && count != null) {
-      if (count.isFirstTime()) {
+      if (count.isFirstTime) {
         0L
       } else {
         Cast(Literal(count.getDoubleValue), base.dataType).eval(null)
@@ -399,6 +412,7 @@ case class CountFunctionCarbon(expr: Expression, base: AggregateExpression1, fin
     } else {
       count
     }
+  }
 
 }
 
@@ -422,20 +436,19 @@ case class SumFunctionCarbon(expr: Expression, base: AggregateExpression1, final
       case s =>
         var dc: MeasureAggregator = null
         if (s != null) {
-          if (s.isInstanceOf[java.math.BigDecimal]) {
-            dc = new SumBigDecimalAggregator
-            dc.agg(new java.math.BigDecimal(s.toString))
-            dc.setNewValue(new java.math.BigDecimal(s.toString))
-          }
-          else if (s.isInstanceOf[Long]) {
-            dc = new SumLongAggregator
-            dc.agg(s.toString.toLong)
-            dc.setNewValue(s.toString.toLong)
-          }
-          else {
-            dc = new SumDoubleAggregator
-            dc.agg(s.toString.toDouble)
-            dc.setNewValue(s.toString.toDouble)
+          s match {
+            case java.math.BigDecimal =>
+              dc = new SumBigDecimalAggregator
+              dc.agg(new java.math.BigDecimal(s.toString))
+              dc.setNewValue(new java.math.BigDecimal(s.toString))
+            case Long =>
+              dc = new SumLongAggregator
+              dc.agg(s.toString.toLong)
+              dc.setNewValue(s.toString.toLong)
+            case _ =>
+              dc = new SumDoubleAggregator
+              dc.agg(s.toString.toDouble)
+              dc.setNewValue(s.toString.toDouble)
           }
         }
         else {
@@ -443,27 +456,31 @@ case class SumFunctionCarbon(expr: Expression, base: AggregateExpression1, final
         }
         dc
     }
-    if (sum == null) sum = agg else sum.merge(agg)
+    if (sum == null) {
+      sum = agg
+    } else {
+      sum.merge(agg)
+    }
   }
 
-  override def eval(input: InternalRow): Any =
+  override def eval(input: InternalRow): Any = {
     if (finalAgg && sum != null) {
-      if (sum.isFirstTime()) {
+      if (sum.isFirstTime) {
         null
       } else {
-        if (sum.isInstanceOf[SumBigDecimalAggregator]) {
-          Cast(Literal(sum.getBigDecimalValue), base.dataType).eval(input)
-        }
-        else if (sum.isInstanceOf[SumLongAggregator]) {
-          Cast(Literal(sum.getLongValue), base.dataType).eval(input)
-        }
-        else {
-          Cast(Literal(sum.getDoubleValue), base.dataType).eval(input)
+        sum match {
+          case SumBigDecimalAggregator =>
+            Cast(Literal(sum.getBigDecimalValue), base.dataType).eval(input)
+          case SumLongAggregator =>
+            Cast(Literal(sum.getLongValue), base.dataType).eval(input)
+          case _ =>
+            Cast(Literal(sum.getDoubleValue), base.dataType).eval(input)
         }
       }
     } else {
       sum
     }
+  }
 }
 
 case class MaxFunctionCarbon(expr: Expression, base: AggregateExpression1, finalAgg: Boolean)
@@ -487,8 +504,8 @@ case class MaxFunctionCarbon(expr: Expression, base: AggregateExpression1, final
         if (s != null) {
           dc.agg(s.toString.toDouble)
           dc.setNewValue(s.toString.toDouble)
-      }
-      dc
+        }
+        dc
     }
     if (max == null) {
       max = agg
@@ -497,9 +514,9 @@ case class MaxFunctionCarbon(expr: Expression, base: AggregateExpression1, final
     }
   }
 
-  override def eval(input: InternalRow): Any =
+  override def eval(input: InternalRow): Any = {
     if (finalAgg && max != null) {
-      if (max.isFirstTime()) {
+      if (max.isFirstTime) {
         null
       } else {
         Cast(Literal(max.getValueObject), base.dataType).eval(null)
@@ -507,6 +524,7 @@ case class MaxFunctionCarbon(expr: Expression, base: AggregateExpression1, final
     } else {
       max
     }
+  }
 }
 
 case class MinFunctionCarbon(expr: Expression, base: AggregateExpression1, finalAgg: Boolean)
@@ -530,8 +548,8 @@ case class MinFunctionCarbon(expr: Expression, base: AggregateExpression1, final
         if (s != null) {
           dc.agg(s.toString.toDouble)
           dc.setNewValue(s.toString.toDouble)
-      }
-      dc
+        }
+        dc
     }
     if (min == null) {
       min = agg
@@ -542,9 +560,11 @@ case class MinFunctionCarbon(expr: Expression, base: AggregateExpression1, final
 
   override def eval(input: InternalRow): Any = {
     if (finalAgg && min != null) {
-      if (min.isFirstTime()) {
+      if (min.isFirstTime) {
         null
-      } else Cast(Literal(min.getValueObject), base.dataType).eval(null)
+      } else {
+        Cast(Literal(min.getValueObject), base.dataType).eval(null)
+      }
     } else {
       min
     }
@@ -552,7 +572,7 @@ case class MinFunctionCarbon(expr: Expression, base: AggregateExpression1, final
 }
 
 case class SumDisctinctFunctionCarbon(expr: Expression, base: AggregateExpression1,
-                                      isFinal: Boolean)
+    isFinal: Boolean)
   extends AggregateFunction1 {
 
   def this() = this(null, null, false) // Required for serialization.
@@ -573,23 +593,21 @@ case class SumDisctinctFunctionCarbon(expr: Expression, base: AggregateExpressio
       case null => null
       case s =>
         var dc: MeasureAggregator = null
-        if (s.isInstanceOf[Double]) {
-          dc = new SumDistinctDoubleAggregator
-          dc.setNewValue(s.toString.toDouble)
-        }
-        else if (s.isInstanceOf[Int]) {
-          dc = new SumDistinctLongAggregator
-          dc.setNewValue(s.toString.toLong)
-        }
-        else if (s.isInstanceOf[java.math.BigDecimal]) {
-          dc = new SumDistinctBigDecimalAggregator
-          dc.setNewValue(new java.math.BigDecimal(s.toString))
+        s match {
+          case Double =>
+            dc = new SumDistinctDoubleAggregator
+            dc.setNewValue(s.toString.toDouble)
+          case Int =>
+            dc = new SumDistinctLongAggregator
+            dc.setNewValue(s.toString.toLong)
+          case java.math.BigDecimal =>
+            dc = new SumDistinctBigDecimalAggregator
+            dc.setNewValue(new java.math.BigDecimal(s.toString))
+          case _ =>
         }
         dc
     }
-    if (agg == null) {
-      distinct
-    } else if (distinct == null) {
+    if (distinct == null) {
       distinct = agg
     } else {
       distinct.merge(agg)
@@ -597,13 +615,15 @@ case class SumDisctinctFunctionCarbon(expr: Expression, base: AggregateExpressio
   }
 
   override def eval(input: InternalRow): Any =
-    // in case of empty load it was failing so added null check.
+  // in case of empty load it was failing so added null check.
+  {
     if (isFinal && distinct != null) {
       Cast(Literal(distinct.getValueObject), base.dataType).eval(null)
     }
     else {
       distinct
     }
+  }
 }
 
 case class CountDistinctFunctionCarbon(expr: Expression, base: AggregateExpression1)
@@ -629,9 +649,7 @@ case class CountDistinctFunctionCarbon(expr: Expression, base: AggregateExpressi
         dc.setNewValue(s.toString)
         dc
     }
-    if (agg == null) {
-      count
-    } else if (count == null) {
+    if (count == null) {
       count = agg
     } else {
       count.merge(agg)
@@ -664,23 +682,22 @@ case class CountDistinctFunctionCarbonFinal(expr: Expression, base: AggregateExp
         dc.setNewValue(s.toString)
         dc
     }
-    if (agg == null) {
-      count
-    } else if (count == null) {
+    if (count == null) {
       count = agg
     } else {
       count.merge(agg)
     }
   }
 
-  override def eval(input: InternalRow): Any =
+  override def eval(input: InternalRow): Any = {
     if (count == null) {
       Cast(Literal(0), base.dataType).eval(null)
-    } else if (count.isFirstTime()) {
+    } else if (count.isFirstTime) {
       Cast(Literal(0), base.dataType).eval(null)
     } else {
       Cast(Literal(count.getDoubleValue), base.dataType).eval(null)
     }
+  }
 }
 
 case class FirstFunctionCarbon(expr: Expression, base: AggregateExpression1)
@@ -725,7 +742,7 @@ case class FlattenExpr(expr: Expression) extends Expression with CodegenFallback
 
   override def eval(input: InternalRow): Any = {
     expr.eval(input) match {
-      case d: MeasureAggregator => d.getDoubleValue()
+      case d: MeasureAggregator => d.getDoubleValue
       case others => others
     }
   }
@@ -751,7 +768,7 @@ case class FlatAggregatorsExpr(expr: Expression) extends Expression with Codegen
   override def eval(input: InternalRow): Any = {
     expr.eval(input) match {
       case d: MeasureAggregator =>
-        d.setNewValue(d.getDoubleValue())
+        d.setNewValue(d.getDoubleValue)
         d
       case others => others
     }

--- a/integration/spark/src/main/scala/org/carbondata/spark/agg/MeasureAggregatorUDT.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/agg/MeasureAggregatorUDT.scala
@@ -29,7 +29,9 @@ import org.carbondata.query.aggregator.MeasureAggregator
 class MeasureAggregatorUDT extends UserDefinedType[MeasureAggregator] {
   // the default DoubleType is Ok as we are not going to pass to spark sql to
   // evaluate,need to add this for compilation errors
-  override def sqlType: DataType = ArrayType(DoubleType, false)
+  override def sqlType: DataType = {
+    ArrayType(DoubleType, containsNull = false)
+  }
 
   override def serialize(obj: Any): Any = {
     obj match {

--- a/integration/spark/src/main/scala/org/carbondata/spark/package.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/package.scala
@@ -44,10 +44,10 @@ package object spark {
       // temporary solution: write to csv file, then load the csv into carbon
       val tempCSVFolder = s"$storePath/$dbName/$tableName/tempCSV"
       dataFrame.write
-          .format(csvPackage)
-          .option("header", "true")
-          .mode(SaveMode.Overwrite)
-          .save(tempCSVFolder)
+        .format(csvPackage)
+        .option("header", "true")
+        .mode(SaveMode.Overwrite)
+        .save(tempCSVFolder)
 
       val cc = CarbonContext.getInstance(dataFrame.sqlContext.sparkContext)
       val tempCSVPath = new Path(tempCSVFolder)
@@ -61,9 +61,9 @@ package object spark {
         while (itor.hasNext) {
           val f = itor.next()
           if (f.getPath.getName.startsWith("part-")) {
-            val newPath = s"${f.getPath.getParent}/${f.getPath.getName}.csv"
+            val newPath = s"${ f.getPath.getParent }/${ f.getPath.getName }.csv"
             if (!fs.rename(f.getPath, new Path(newPath))) {
-              cc.sql(s"DROP CUBE ${options.tableName}")
+              cc.sql(s"DROP CUBE ${ options.tableName }")
               throw new RuntimeException("File system rename failed when loading data into carbon")
             }
           }
@@ -94,12 +94,12 @@ package object spark {
     private def makeCreateTableString(schema: StructType, option: CarbonOption): String = {
       val tableName = option.tableName
       val carbonSchema = schema.map { field =>
-            s"${field.name} ${convertToCarbonType(field.dataType)}"
-          }
+        s"${ field.name } ${ convertToCarbonType(field.dataType) }"
+      }
       s"""
           CREATE TABLE IF NOT EXISTS $tableName
-          (${carbonSchema.mkString(", ")})
-          STORED BY '${CarbonContext.datasourceName}'
+          (${ carbonSchema.mkString(", ") })
+          STORED BY '${ CarbonContext.datasourceName }'
       """
     }
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonCleanFilesRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonCleanFilesRDD.scala
@@ -40,11 +40,7 @@ class CarbonCleanFilesRDD[K, V](
 
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
-    val result = new Array[Partition](splits.length)
-    for (i <- result.indices) {
-      result(i) = new CarbonLoadPartition(id, i, splits(i))
-    }
-    result
+    splits.zipWithIndex.map(s => new CarbonLoadPartition(id, s._2, s._1))
   }
 
   override def compute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonCleanFilesRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonCleanFilesRDD.scala
@@ -29,11 +29,11 @@ import org.carbondata.spark.util.CarbonQueryUtil
 
 
 class CarbonCleanFilesRDD[K, V](
-                                 sc: SparkContext,
-                                 keyClass: KeyVal[K, V],
-                                 schemaName: String,
-                                 cubeName: String,
-                                 partitioner: Partitioner)
+    sc: SparkContext,
+    keyClass: KeyVal[K, V],
+    schemaName: String,
+    cubeName: String,
+    partitioner: Partitioner)
   extends RDD[(K, V)](sc, Nil) with Logging {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
@@ -41,7 +41,7 @@ class CarbonCleanFilesRDD[K, V](
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
     val result = new Array[Partition](splits.length)
-    for (i <- 0 until result.length) {
+    for (i <- result.indices) {
       result(i) = new CarbonLoadPartition(id, i, splits(i))
     }
     result
@@ -59,7 +59,7 @@ class CarbonCleanFilesRDD[K, V](
 
       override def hasNext: Boolean = {
         if (!finished && !havePair) {
-          finished = !false
+          finished = true
           havePair = !finished
         }
         !finished

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataLoadRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataLoadRDD.scala
@@ -124,21 +124,17 @@ class CarbonDataLoadRDD[K, V](
             carbonLoadModel.getTableName, null, partitioner)
         }
 
-        val result = new Array[Partition](splits.length)
-        for (i <- result.indices) {
+        splits.zipWithIndex.map {s =>
           // filter the same partition unique id, because only one will match, so get 0 element
           val blocksDetails: Array[BlockDetails] = blocksGroupBy.filter(p =>
-            p._1 == splits(i).getPartition.getUniqueID)(0)._2
-          result(i) = new CarbonTableSplitPartition(id, i, splits(i), blocksDetails)
+            p._1 == s._1.getPartition.getUniqueID)(0)._2
+          new CarbonTableSplitPartition(id, s._2, s._1, blocksDetails)
         }
-        result
       case false =>
         // for node partition
-        val result = new Array[Partition](blocksGroupBy.length)
-        for (i <- result.indices) {
-          result(i) = new CarbonNodePartition(id, i, blocksGroupBy(i)._1, blocksGroupBy(i)._2)
+        blocksGroupBy.zipWithIndex.map{b =>
+          new CarbonNodePartition(id, b._2, b._1._1, b._1._2)
         }
-        result
     }
   }
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataPartitionRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataPartitionRDD.scala
@@ -47,19 +47,19 @@ class CarbonSparkRawDataPartition(rddId: Int, val idx: Int, @transient val table
  * .
  */
 class CarbonDataPartitionRDD[K, V](
-                                    sc: SparkContext,
-                                    results: PartitionResult[K, V],
-                                    schemaName: String,
-                                    cubeName: String,
-                                    sourcePath: String,
-                                    targetFolder: String,
-                                    requiredColumns: Array[String],
-                                    headers: String,
-                                    delimiter: String,
-                                    quoteChar: String,
-                                    escapeChar: String,
-                                    multiLine: Boolean,
-                                    partitioner: Partitioner)
+    sc: SparkContext,
+    results: PartitionResult[K, V],
+    schemaName: String,
+    cubeName: String,
+    sourcePath: String,
+    targetFolder: String,
+    requiredColumns: Array[String],
+    headers: String,
+    delimiter: String,
+    quoteChar: String,
+    escapeChar: String,
+    multiLine: Boolean,
+    partitioner: Partitioner)
   extends RDD[(K, V)](sc, Nil) with Logging {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
@@ -69,7 +69,7 @@ class CarbonDataPartitionRDD[K, V](
       .getPartitionSplits(sourcePath, partitioner.nodeList, partitioner.partitionCount)
     //
     val result = new Array[Partition](splits.length)
-    for (i <- 0 until result.length) {
+    for (i <- result.indices) {
       result(i) = new CarbonSparkRawDataPartition(id, i, splits(i))
     }
     result
@@ -79,12 +79,12 @@ class CarbonDataPartitionRDD[K, V](
     new Iterator[(K, V)] {
       val split = theSplit.asInstanceOf[CarbonSparkRawDataPartition]
       StandardLogService
-        .setThreadName(split.serializableHadoopSplit.value.getPartition().getUniqueID(), null)
+        .setThreadName(split.serializableHadoopSplit.value.getPartition.getUniqueID, null)
       logInfo("Input split: " + split.serializableHadoopSplit.value)
 
       val csvPart = new CSVFilePartitioner(partitioner.partitionClass, sourcePath)
       csvPart.splitFile(schemaName, cubeName,
-        split.serializableHadoopSplit.value.getPartition().getFilesPath, targetFolder,
+        split.serializableHadoopSplit.value.getPartition.getFilesPath, targetFolder,
         partitioner.nodeList.toList.asJava, partitioner.partitionCount, partitioner.partitionColumn,
         requiredColumns, delimiter, quoteChar, headers, escapeChar, multiLine)
 
@@ -109,7 +109,7 @@ class CarbonDataPartitionRDD[K, V](
   override def getPreferredLocations(split: Partition): Seq[String] = {
     val theSplit = split.asInstanceOf[CarbonSparkRawDataPartition]
     val s = theSplit.serializableHadoopSplit.value.getLocations.asScala
-    logInfo("Host Name : " + s(0) + s.length)
+    logInfo("Host Name : " + s.head + s.length)
     s
   }
 }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataPartitionRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataPartitionRDD.scala
@@ -67,12 +67,9 @@ class CarbonDataPartitionRDD[K, V](
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil
       .getPartitionSplits(sourcePath, partitioner.nodeList, partitioner.partitionCount)
-    //
-    val result = new Array[Partition](splits.length)
-    for (i <- result.indices) {
-      result(i) = new CarbonSparkRawDataPartition(id, i, splits(i))
+    splits.zipWithIndex.map {s =>
+      new CarbonSparkRawDataPartition(id, s._2, s._1)
     }
-    result
   }
 
   override def compute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -52,7 +52,7 @@ import org.carbondata.spark.util.{CarbonQueryUtil, LoadMetadataUtil}
  */
 object CarbonDataRDDFactory extends Logging {
 
-  val logger = LogServiceFactory.getLogService(CarbonDataRDDFactory.getClass().getName())
+  val logger = LogServiceFactory.getLogService(CarbonDataRDDFactory.getClass.getName)
 
   // scalastyle:off
   def partitionCarbonData(sc: SparkContext,
@@ -77,7 +77,7 @@ object CarbonDataRDDFactory extends Logging {
     var loadStatus = CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS
     status.foreach {
       case (key, value) =>
-        if (value == true) {
+        if (value) {
           loadStatus = CarbonCommonConstants.STORE_LOADSTATUS_PARTIAL_SUCCESS
         }
     }
@@ -90,10 +90,9 @@ object CarbonDataRDDFactory extends Logging {
       storeLocation: String,
       hdfsStoreLocation: String,
       partitioner: Partitioner) {
-    val kv: KeyVal[CarbonKey, CarbonValue] = new KeyValImpl()
     val cube = CarbonMetadata.getInstance()
-      .getCarbonTable(carbonLoadModel.getDatabaseName() + "_" + carbonLoadModel.getTableName())
-    val metaDataPath: String = cube.getMetaDataFilepath()
+      .getCarbonTable(carbonLoadModel.getDatabaseName + "_" + carbonLoadModel.getTableName)
+    val metaDataPath: String = cube.getMetaDataFilepath
     var currentRestructNumber = CarbonUtil
       .checkAndReturnCurrentRestructFolderNumber(metaDataPath, "RS_", false)
     if (-1 == currentRestructNumber) {
@@ -115,15 +114,15 @@ object CarbonDataRDDFactory extends Logging {
 
     val sc = sqlContext
     // Delete the records based on data
-    var cube = org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance
+    val cube = org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance
       .getCarbonTable(schemaName + "_" + cubeName)
 
     var currentRestructNumber = CarbonUtil
-      .checkAndReturnCurrentRestructFolderNumber(cube.getMetaDataFilepath(), "RS_", false)
+      .checkAndReturnCurrentRestructFolderNumber(cube.getMetaDataFilepath, "RS_", false)
     if (-1 == currentRestructNumber) {
       currentRestructNumber = 0
     }
-    val loadMetadataDetailsArray = CarbonUtil.readLoadMetadata(cube.getMetaDataFilepath()).toList
+    val loadMetadataDetailsArray = CarbonUtil.readLoadMetadata(cube.getMetaDataFilepath).toList
     val resultMap = new CarbonDeleteLoadByDateRDD(
       sc.sparkContext,
       new DeletedLoadResultImpl(),
@@ -137,10 +136,10 @@ object CarbonDataRDDFactory extends Logging {
       tableName,
       hdfsStoreLocation,
       loadMetadataDetailsArray,
-      currentRestructNumber).collect.groupBy(_._1).toMap
+      currentRestructNumber).collect.groupBy(_._1)
 
     var updatedLoadMetadataDetailsList = new ListBuffer[LoadMetadataDetails]()
-    if (!resultMap.isEmpty) {
+    if (resultMap.nonEmpty) {
       if (resultMap.size == 1) {
         if (resultMap.contains("")) {
           logError("Delete by Date request is failed")
@@ -149,13 +148,13 @@ object CarbonDataRDDFactory extends Logging {
         }
       }
       val updatedloadMetadataDetails = loadMetadataDetailsArray.map { elem => {
-        var statusList = resultMap.get(elem.getLoadName())
+        var statusList = resultMap.get(elem.getLoadName)
         // check for the merged load folder.
-        if (statusList == None && null != elem.getMergedLoadName()) {
-          statusList = resultMap.get(elem.getMergedLoadName())
+        if (statusList.isEmpty && null != elem.getMergedLoadName) {
+          statusList = resultMap.get(elem.getMergedLoadName)
         }
 
-        if (statusList != None) {
+        if (statusList.isDefined) {
           elem.setModificationOrdeletionTimesStamp(CarbonLoaderUtil.readCurrentTime())
           // if atleast on CarbonCommonConstants.MARKED_FOR_UPDATE status exist,
           // use MARKED_FOR_UPDATE
@@ -175,12 +174,12 @@ object CarbonDataRDDFactory extends Logging {
       }
 
       // Save the load metadata
-      var carbonLock = CarbonLockFactory
-        .getCarbonLockObj(cube.getMetaDataFilepath(), LockUsage.METADATA_LOCK)
-      try { {
+      val carbonLock = CarbonLockFactory
+        .getCarbonLockObj(cube.getMetaDataFilepath, LockUsage.METADATA_LOCK)
+      try {
         if (carbonLock.lockWithRetries()) {
           logInfo("Successfully got the cube metadata file lock")
-          if (!updatedLoadMetadataDetailsList.isEmpty) {
+          if (updatedLoadMetadataDetailsList.nonEmpty) {
             LoadAggregateTabAfterRetention(schemaName, cube.getFactTableName, cube.getFactTableName,
               sqlContext, schema, updatedLoadMetadataDetailsList)
           }
@@ -192,7 +191,6 @@ object CarbonDataRDDFactory extends Logging {
             cube.getDatabaseName,
             updatedloadMetadataDetails.asJava)
         }
-      }
       } finally {
         if (carbonLock.unlock()) {
           logInfo("unlock the cube metadata file successfully")
@@ -252,7 +250,7 @@ object CarbonDataRDDFactory extends Logging {
         storeLocation,
         relation.cubeMeta.dataPath,
         kettleHomePath,
-        relation.cubeMeta.partitioner, columinar, true)
+        relation.cubeMeta.partitioner, columinar, isAgg = true)
     }
   }
 
@@ -267,11 +265,11 @@ object CarbonDataRDDFactory extends Logging {
       partitionStatus: String = CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS) {
     val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
     var currentRestructNumber = -1
-    try { {
+    try {
       logger.audit("The data load request has been received.")
 
       currentRestructNumber = CarbonUtil
-        .checkAndReturnCurrentRestructFolderNumber(carbonTable.getMetaDataFilepath(), "RS_", false)
+        .checkAndReturnCurrentRestructFolderNumber(carbonTable.getMetaDataFilepath, "RS_", false)
       if (-1 == currentRestructNumber) {
         currentRestructNumber = 0
       }
@@ -285,9 +283,9 @@ object CarbonDataRDDFactory extends Logging {
       }
 
       var currentLoadCount = -1
-      if (carbonLoadModel.getLoadMetadataDetails().size() > 0) {
-        for (eachLoadMetaData <- carbonLoadModel.getLoadMetadataDetails().asScala) {
-          val loadCount = Integer.parseInt(eachLoadMetaData.getLoadName())
+      if (carbonLoadModel.getLoadMetadataDetails.size() > 0) {
+        for (eachLoadMetaData <- carbonLoadModel.getLoadMetadataDetails.asScala) {
+          val loadCount = Integer.parseInt(eachLoadMetaData.getLoadName)
           if (currentLoadCount < loadCount) {
             currentLoadCount = loadCount
           }
@@ -324,9 +322,9 @@ object CarbonDataRDDFactory extends Logging {
            * 3) output Array[(partitionID,Array[BlockDetails])] to blocksGroupBy
            */
           var splits = Array[TableSplit]()
-          if (carbonLoadModel.isDirectLoad()) {
+          if (carbonLoadModel.isDirectLoad) {
             // get all table Splits, this part means files were divide to different partitions
-            splits = CarbonQueryUtil.getTableSplitsForDirectLoad(carbonLoadModel.getFactFilePath(),
+            splits = CarbonQueryUtil.getTableSplitsForDirectLoad(carbonLoadModel.getFactFilePath,
               partitioner.nodeList, partitioner.partitionCount)
             // get all partition blocks from file list
             blocksGroupBy = splits.map {
@@ -335,7 +333,7 @@ object CarbonDataRDDFactory extends Logging {
                 for (path <- split.getPartition.getFilesPath.asScala) {
                   pathBuilder.append(path).append(",")
                 }
-                if (pathBuilder.size > 0) {
+                if (pathBuilder.nonEmpty) {
                   pathBuilder.substring(0, pathBuilder.size - 1)
                 }
                 (split.getPartition.getUniqueID, SplitUtils.getSplits(pathBuilder.toString(),
@@ -371,7 +369,7 @@ object CarbonDataRDDFactory extends Logging {
            */
           val hadoopConfiguration = new Configuration(sc.sparkContext.hadoopConfiguration)
           // FileUtils will skip file which is no csv, and return all file path which split by ','
-          val filePaths = FileUtils.getPaths(carbonLoadModel.getFactFilePath())
+          val filePaths = FileUtils.getPaths(carbonLoadModel.getFactFilePath)
           hadoopConfiguration.set("mapreduce.input.fileinputformat.inputdir", filePaths)
           hadoopConfiguration.set("mapreduce.input.fileinputformat.input.dir.recursive", "true")
           val newHadoopRDD = new NewHadoopRDD[LongWritable, Text](
@@ -394,13 +392,14 @@ object CarbonDataRDDFactory extends Logging {
       val newStatusMap = scala.collection.mutable.Map.empty[String, String]
       status.foreach { eachLoadStatus =>
         val state = newStatusMap.get(eachLoadStatus._2.getPartitionCount)
-        if (null == state || None == state ||
-            state == CarbonCommonConstants.STORE_LOADSTATUS_FAILURE) {
-          newStatusMap.put(eachLoadStatus._2.getPartitionCount, eachLoadStatus._2.getLoadStatus)
-        } else if (state == CarbonCommonConstants.STORE_LOADSTATUS_PARTIAL_SUCCESS &&
-                   eachLoadStatus._2.getLoadStatus ==
-                   CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS) {
-          newStatusMap.put(eachLoadStatus._2.getPartitionCount, eachLoadStatus._2.getLoadStatus)
+        state match {
+          case Some(CarbonCommonConstants.STORE_LOADSTATUS_FAILURE) =>
+            newStatusMap.put(eachLoadStatus._2.getPartitionCount, eachLoadStatus._2.getLoadStatus)
+          case Some(CarbonCommonConstants.STORE_LOADSTATUS_PARTIAL_SUCCESS)
+            if eachLoadStatus._2.getLoadStatus == CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS =>
+            newStatusMap.put(eachLoadStatus._2.getPartitionCount, eachLoadStatus._2.getLoadStatus)
+          case _ =>
+            newStatusMap.put(eachLoadStatus._2.getPartitionCount, eachLoadStatus._2.getLoadStatus)
         }
       }
 
@@ -429,7 +428,7 @@ object CarbonDataRDDFactory extends Logging {
             currentRestructNumber)
           message = "Aggregate table creation failure"
         } else {
-          val (result, metadataDetails) = status(0)
+          val (result, _) = status(0)
           val newSlice = CarbonCommonConstants.LOAD_FOLDER + result
           CarbonLoaderUtil.deleteSlice(partitioner.partitionCount, carbonLoadModel.getDatabaseName,
             carbonLoadModel.getTableName, carbonLoadModel.getTableName, hdfsStoreLocation,
@@ -454,18 +453,18 @@ object CarbonDataRDDFactory extends Logging {
         if (!isAgg) {
           CarbonLoaderUtil
             .recordLoadMetadata(result, metadataDetails, carbonLoadModel, loadStatus, loadStartTime)
-        } else if (!carbonLoadModel.isRetentionRequest()) {
+        } else if (!carbonLoadModel.isRetentionRequest) {
           // TODO : Handle it
           logInfo("********schema updated**********")
         }
         logger.audit("The data loading is successful.")
         if (CarbonDataMergerUtil
-          .checkIfLoadMergingRequired(carbonTable.getMetaDataFilepath(), carbonLoadModel,
+          .checkIfLoadMergingRequired(carbonTable.getMetaDataFilepath, carbonLoadModel,
             hdfsStoreLocation, partitioner.partitionCount, currentRestructNumber)) {
 
           val loadsToMerge = CarbonDataMergerUtil.getLoadsToMergeFromHDFS(
             hdfsStoreLocation, FileFactory.getFileType(hdfsStoreLocation),
-            carbonTable.getMetaDataFilepath(), carbonLoadModel, currentRestructNumber,
+            carbonTable.getMetaDataFilepath, carbonLoadModel, currentRestructNumber,
             partitioner.partitionCount)
 
           if (loadsToMerge.size() == 2) {
@@ -479,7 +478,7 @@ object CarbonDataRDDFactory extends Logging {
               hdfsStoreLocation,
               partitioner,
               currentRestructNumber,
-              carbonTable.getMetaDataFilepath(),
+              carbonTable.getMetaDataFilepath,
               loadsToMerge,
               MergedLoadName,
               kettleHomePath,
@@ -493,13 +492,12 @@ object CarbonDataRDDFactory extends Logging {
             }
             if (finalMergeStatus) {
               CarbonDataMergerUtil
-                .updateLoadMetadataWithMergeStatus(loadsToMerge, carbonTable.getMetaDataFilepath(),
+                .updateLoadMetadataWithMergeStatus(loadsToMerge, carbonTable.getMetaDataFilepath,
                   MergedLoadName, carbonLoadModel)
             }
           }
         }
       }
-    }
     }
 
   }
@@ -527,7 +525,7 @@ object CarbonDataRDDFactory extends Logging {
         .deleteLoadFoldersFromFileSystem(carbonLoadModel, partitioner.partitionCount,
           hdfsStoreLocation, isForceDeletion, currentRestructNumber, details)
 
-      if (isUpdationRequired == true) {
+      if (isUpdationRequired) {
         // Update load metadate file after cleaning deleted nodes
         CarbonLoaderUtil.writeLoadMetadata(
           carbonLoadModel.getCarbonDataLoadSchema,
@@ -567,20 +565,23 @@ object CarbonDataRDDFactory extends Logging {
       partitioner: Partitioner) {
     val cube = org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance
       .getCarbonTable(carbonLoadModel.getDatabaseName + "_" + carbonLoadModel.getTableName)
-    val metaDataPath: String = cube.getMetaDataFilepath()
+    val metaDataPath: String = cube.getMetaDataFilepath
     var currentRestructNumber = CarbonUtil
       .checkAndReturnCurrentRestructFolderNumber(metaDataPath, "RS_", false)
     if (-1 == currentRestructNumber) {
       currentRestructNumber = 0
     }
     var carbonLock = CarbonLockFactory
-      .getCarbonLockObj(cube.getMetaDataFilepath(), LockUsage.METADATA_LOCK)
-    try { {
+      .getCarbonLockObj(cube.getMetaDataFilepath, LockUsage.METADATA_LOCK)
+    try {
       if (carbonLock.lockWithRetries()) {
-        deleteLoadsAndUpdateMetadata(carbonLoadModel, cube, partitioner, hdfsStoreLocation, true,
+        deleteLoadsAndUpdateMetadata(carbonLoadModel,
+          cube,
+          partitioner,
+          hdfsStoreLocation,
+          isForceDeletion = true,
           currentRestructNumber)
       }
-    }
     }
     finally {
       if (carbonLock.unlock()) {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -283,9 +283,10 @@ object CarbonDataRDDFactory extends Logging {
       }
 
       var currentLoadCount = -1
-      if (carbonLoadModel.getLoadMetadataDetails.size() > 0) {
-        for (eachLoadMetaData <- carbonLoadModel.getLoadMetadataDetails.asScala) {
-          val loadCount = Integer.parseInt(eachLoadMetaData.getLoadName)
+      val convLoadDetails = carbonLoadModel.getLoadMetadataDetails.asScala
+      if (convLoadDetails.nonEmpty) {
+        convLoadDetails.foreach { l =>
+          val loadCount = Integer.parseInt(l.getLoadName)
           if (currentLoadCount < loadCount) {
             currentLoadCount = loadCount
           }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDeleteLoadByDateRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDeleteLoadByDateRDD.scala
@@ -50,11 +50,9 @@ class CarbonDeleteLoadByDateRDD[K, V](
 
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
-    val result = new Array[Partition](splits.length)
-    for (i <- result.indices) {
-      result(i) = new CarbonLoadPartition(id, i, splits(i))
+    splits.zipWithIndex.map {s =>
+      new CarbonLoadPartition(id, s._2, s._1)
     }
-    result
   }
 
   override def compute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDeleteLoadByDateRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDeleteLoadByDateRDD.scala
@@ -51,7 +51,7 @@ class CarbonDeleteLoadByDateRDD[K, V](
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
     val result = new Array[Partition](splits.length)
-    for (i <- 0 until result.length) {
+    for (i <- result.indices) {
       result(i) = new CarbonLoadPartition(id, i, splits(i))
     }
     result
@@ -64,15 +64,13 @@ class CarbonDeleteLoadByDateRDD[K, V](
       logInfo("Input split: " + split.serializableHadoopSplit.value)
 
       logInfo("Input split: " + split.serializableHadoopSplit.value)
-      val partitionID = split.serializableHadoopSplit.value.getPartition().getUniqueID()
+      val partitionID = split.serializableHadoopSplit.value.getPartition.getUniqueID
 
       // TODO call CARBON delete API
       logInfo("Applying data retention as per date value " + dateValue)
       var dateFormat = ""
-      try { {
-        val dateValueAsDate = DateTimeUtils.stringToTime(dateValue)
+      try {
         dateFormat = CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT
-      }
       } catch {
         case e: Exception => logInfo("Unable to parse with default time format " + dateValue)
       }
@@ -92,7 +90,7 @@ class CarbonDeleteLoadByDateRDD[K, V](
   override def getPreferredLocations(split: Partition): Seq[String] = {
     val theSplit = split.asInstanceOf[CarbonLoadPartition]
     val s = theSplit.serializableHadoopSplit.value.getLocations.asScala
-    logInfo("Host Name : " + s(0) + s.length)
+    logInfo("Host Name : " + s.head + s.length)
     s
   }
 }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropAggregateTableRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropAggregateTableRDD.scala
@@ -40,11 +40,9 @@ class CarbonDropAggregateTableRDD[K, V](
 
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
-    val result = new Array[Partition](splits.length)
-    for (i <- result.indices) {
-      result(i) = new CarbonLoadPartition(id, i, splits(i))
+    splits.zipWithIndex.map { s=>
+      new CarbonLoadPartition(id, s._2, s._1)
     }
-    result
   }
 
   override def compute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropAggregateTableRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropAggregateTableRDD.scala
@@ -40,7 +40,7 @@ class CarbonDropAggregateTableRDD[K, V](
 
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
-    splits.zipWithIndex.map { s=>
+    splits.zipWithIndex.map { s =>
       new CarbonLoadPartition(id, s._2, s._1)
     }
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropCubeRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropCubeRDD.scala
@@ -37,7 +37,7 @@ class CarbonDropCubeRDD[K, V](
 
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
-    splits.zipWithIndex.map { s=>
+    splits.zipWithIndex.map { s =>
       new CarbonLoadPartition(id, s._2, s._1)
     }
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropCubeRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropCubeRDD.scala
@@ -37,11 +37,9 @@ class CarbonDropCubeRDD[K, V](
 
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
-    val result = new Array[Partition](splits.length)
-    for (i <- result.indices) {
-      result(i) = new CarbonLoadPartition(id, i, splits(i))
+    splits.zipWithIndex.map { s=>
+      new CarbonLoadPartition(id, s._2, s._1)
     }
-    result
   }
 
   override def compute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropCubeRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropCubeRDD.scala
@@ -21,7 +21,6 @@ import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.command.Partitioner
 
-import org.carbondata.core.carbon.metadata.CarbonMetadata
 import org.carbondata.query.scanner.impl.{CarbonKey, CarbonValue}
 import org.carbondata.spark.KeyVal
 import org.carbondata.spark.util.CarbonQueryUtil
@@ -39,7 +38,7 @@ class CarbonDropCubeRDD[K, V](
   override def getPartitions: Array[Partition] = {
     val splits = CarbonQueryUtil.getTableSplits(schemaName, cubeName, null, partitioner)
     val result = new Array[Partition](splits.length)
-    for (i <- 0 until result.length) {
+    for (i <- result.indices) {
       result(i) = new CarbonLoadPartition(id, i, splits(i))
     }
     result
@@ -52,8 +51,6 @@ class CarbonDropCubeRDD[K, V](
 
       val partitionCount = partitioner.partitionCount
       for (a <- 0 until partitionCount) {
-        val cubeUniqueName = schemaName + "_" + a + "_" + cubeName + "_" + a
-        val carbonTable = CarbonMetadata.getInstance().getCarbonTable(cubeUniqueName)
         // TODO: Clear Btree from memory
       }
 
@@ -62,7 +59,7 @@ class CarbonDropCubeRDD[K, V](
 
       override def hasNext: Boolean = {
         if (!finished && !havePair) {
-          finished = !false
+          finished = true
           havePair = !finished
         }
         !finished

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropCubeRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDropCubeRDD.scala
@@ -48,9 +48,7 @@ class CarbonDropCubeRDD[K, V](
       val split = theSplit.asInstanceOf[CarbonLoadPartition]
 
       val partitionCount = partitioner.partitionCount
-      for (a <- 0 until partitionCount) {
-        // TODO: Clear Btree from memory
-      }
+      // TODO: Clear Btree from memory
 
       var havePair = false
       var finished = false

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
@@ -82,8 +82,8 @@ case class ArrayParser(dimension: CarbonDimension, format: DataFormat) extends G
     if (StringUtils.isNotEmpty(input)) {
       val splits = format.getSplits(input)
       if (ArrayUtils.isNotEmpty(splits)) {
-        for (i <- splits.indices) {
-          children.parseString(splits(i))
+        splits.foreach { s =>
+          children.parseString(s)
         }
       }
     }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -205,11 +205,9 @@ class CarbonMergerRDD[K, V](
     val splits = CarbonQueryUtil
       .getTableSplits(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName, null,
         partitioner)
-    val result = new Array[Partition](splits.length)
-    for (i <- result.indices) {
-      result(i) = new CarbonLoadPartition(id, i, splits(i))
+    splits.zipWithIndex.map { s=>
+      new CarbonLoadPartition(id, s._2, s._1)
     }
-    result
   }
 
   override def checkpoint() {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -205,7 +205,7 @@ class CarbonMergerRDD[K, V](
     val splits = CarbonQueryUtil
       .getTableSplits(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName, null,
         partitioner)
-    splits.zipWithIndex.map { s=>
+    splits.zipWithIndex.map { s =>
       new CarbonLoadPartition(id, s._2, s._1)
     }
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
@@ -18,9 +18,7 @@
 
 package org.carbondata.spark.rdd
 
-import java.text.SimpleDateFormat
 import java.util
-import java.util.Date
 
 import scala.collection.JavaConverters._
 
@@ -43,36 +41,34 @@ import org.carbondata.spark.load.CarbonLoaderUtil
 import org.carbondata.spark.util.QueryPlanUtil
 
 class CarbonSparkPartition(rddId: Int, val idx: Int,
-   val locations: Array[String],
-   val tableBlockInfos: util.List[TableBlockInfo])
+    val locations: Array[String],
+    val tableBlockInfos: util.List[TableBlockInfo])
   extends Partition {
 
   override val index: Int = idx
+
   // val serializableHadoopSplit = new SerializableWritable[Array[String]](locations)
-  override def hashCode(): Int = 41 * (41 + rddId) + idx
+  override def hashCode(): Int = {
+    41 * (41 + rddId) + idx
+  }
 }
 
 
- /**
-  * This RDD is used to perform query.
-  */
-  class CarbonQueryRDD[K, V](
-  sc: SparkContext,
-  queryModel: QueryModel,
-  filterExpression: Expression,
-  keyClass: KeyVal[K, V],
-  @transient conf: Configuration,
-  cubeCreationTime: Long,
-  schemaLastUpdatedTime: Long,
-  baseStoreLocation: String)
+/**
+ * This RDD is used to perform query.
+ */
+class CarbonQueryRDD[K, V](
+    sc: SparkContext,
+    queryModel: QueryModel,
+    filterExpression: Expression,
+    keyClass: KeyVal[K, V],
+    @transient conf: Configuration,
+    cubeCreationTime: Long,
+    schemaLastUpdatedTime: Long,
+    baseStoreLocation: String)
   extends RDD[(K, V)](sc, Nil) with Logging {
 
   val defaultParallelism = sc.defaultParallelism
-
-  private val jobtrackerId: String = {
-    val formatter = new SimpleDateFormat("yyyyMMddHHmm")
-    formatter.format(new Date())
-  }
 
   override def getPartitions: Array[Partition] = {
     val startTime = System.currentTimeMillis()
@@ -81,7 +77,7 @@ class CarbonSparkPartition(rddId: Int, val idx: Int,
 
     val result = new util.ArrayList[Partition](defaultParallelism)
     val validSegments = job.getConfiguration.get(CarbonInputFormat.INPUT_SEGMENT_NUMBERS)
-    if(!validSegments.isEmpty) {
+    if (!validSegments.isEmpty) {
       var filterResolver: FilterResolverIntf = null
       if (filterExpression != null) {
         // set filter resolver tree
@@ -98,7 +94,7 @@ class CarbonSparkPartition(rddId: Int, val idx: Int,
           inputSplit.getLocations, inputSplit.getLength
         )
       )
-      if(!blockList.isEmpty) {
+      if (blockList.nonEmpty) {
         // group blocks to nodes, tasks
         val nodeBlockMapping =
           CarbonLoaderUtil.nodeBlockTaskMapping(blockList.asJava, -1, defaultParallelism)
@@ -117,16 +113,15 @@ class CarbonSparkPartition(rddId: Int, val idx: Int,
         val noOfNodes = nodeBlockMapping.size
         val noOfTasks = result.size()
         logInfo(s"Identified  no.of.Blocks: $noOfBlocks,"
-          + s"parallelism: $defaultParallelism , no.of.nodes: $noOfNodes, no.of.tasks: $noOfTasks"
+                + s"parallelism: $defaultParallelism , no.of.nodes: $noOfNodes, no.of.tasks: $noOfTasks"
         )
         logInfo("Time taken to identify Blocks to scan : " + (System
-          .currentTimeMillis() - startTime)
+                                                                .currentTimeMillis() - startTime)
         )
-        for (j <- 0 to result.size()-1)
-        {
+        for (j <- 0 until result.size()) {
           val cp = result.get(j).asInstanceOf[CarbonSparkPartition]
           logInfo(s"Node : " + cp.locations.toSeq.mkString(",")
-            + ", No.Of Blocks : " + cp.tableBlockInfos.size())
+                  + ", No.Of Blocks : " + cp.tableBlockInfos.size())
         }
       } else {
         logInfo("No blocks identified to scan")
@@ -143,15 +138,15 @@ class CarbonSparkPartition(rddId: Int, val idx: Int,
   }
 
 
-   override def compute(thepartition: Partition, context: TaskContext): Iterator[(K, V)] = {
-    val LOGGER = LogServiceFactory.getLogService(this.getClass().getName())
+  override def compute(thepartition: Partition, context: TaskContext): Iterator[(K, V)] = {
+    val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
     val iter = new Iterator[(K, V)] {
       var rowIterator: CarbonIterator[RowResult] = _
       var queryStartTime: Long = 0
       try {
         val carbonSparkPartition = thepartition.asInstanceOf[CarbonSparkPartition]
-        if(!carbonSparkPartition.tableBlockInfos.isEmpty) {
-          queryModel.setQueryId(queryModel.getQueryId() + "_" + carbonSparkPartition.idx)
+        if (!carbonSparkPartition.tableBlockInfos.isEmpty) {
+          queryModel.setQueryId(queryModel.getQueryId + "_" + carbonSparkPartition.idx)
           // fill table block info
           queryModel.setTableBlockInfos(carbonSparkPartition.tableBlockInfos)
           queryStartTime = System.currentTimeMillis
@@ -160,7 +155,7 @@ class CarbonSparkPartition(rddId: Int, val idx: Int,
           logInfo("*************************" + carbonPropertiesFilePath)
           if (null == carbonPropertiesFilePath) {
             System.setProperty("carbon.properties.filepath", System.getProperty("user.dir")
-              + '/' + "conf" + '/' + "carbon.properties"
+                                                             + '/' + "conf" + '/' + "carbon.properties"
             )
           }
           // execute query
@@ -184,7 +179,7 @@ class CarbonSparkPartition(rddId: Int, val idx: Int,
 
       override def hasNext: Boolean = {
         if (!finished && !havePair) {
-          finished = (null == rowIterator) || (!rowIterator.hasNext())
+          finished = (null == rowIterator) || (!rowIterator.hasNext)
           havePair = !finished
         }
         if (finished) {
@@ -199,22 +194,22 @@ class CarbonSparkPartition(rddId: Int, val idx: Int,
         }
         havePair = false
         val row = rowIterator.next()
-        val key = row.getKey()
-        val value = row.getValue()
+        val key = row.getKey
+        val value = row.getValue
         keyClass.getKey(key, value)
       }
 
       logInfo("*************************** Total Time Taken to execute the query in Carbon Side: " +
-        (System.currentTimeMillis - queryStartTime)
+              (System.currentTimeMillis - queryStartTime)
       )
     }
     iter
   }
 
 
-   /**
-    * Get the preferred locations where to launch this task.
-    */
+  /**
+   * Get the preferred locations where to launch this task.
+   */
   override def getPreferredLocations(partition: Partition): Seq[String] = {
     val theSplit = partition.asInstanceOf[CarbonSparkPartition]
     theSplit.locations.filter(_ != "localhost")

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
@@ -113,13 +113,12 @@ class CarbonQueryRDD[K, V](
         val noOfNodes = nodeBlockMapping.size
         val noOfTasks = result.size()
         logInfo(s"Identified  no.of.Blocks: $noOfBlocks,"
-                + s"parallelism: $defaultParallelism , no.of.nodes: $noOfNodes, no.of.tasks: $noOfTasks"
-        )
-        logInfo("Time taken to identify Blocks to scan : " + (System
-                                                                .currentTimeMillis() - startTime)
-        )
-        for (j <- 0 until result.size()) {
-          val cp = result.get(j).asInstanceOf[CarbonSparkPartition]
+                + s"parallelism: $defaultParallelism , " +
+                s"no.of.nodes: $noOfNodes, no.of.tasks: $noOfTasks")
+        logInfo("Time taken to identify Blocks to scan : " +
+                (System.currentTimeMillis() - startTime))
+        result.asScala.foreach { r =>
+          val cp = r.asInstanceOf[CarbonSparkPartition]
           logInfo(s"Node : " + cp.locations.toSeq.mkString(",")
                   + ", No.Of Blocks : " + cp.tableBlockInfos.size())
         }
@@ -154,8 +153,8 @@ class CarbonQueryRDD[K, V](
           val carbonPropertiesFilePath = System.getProperty("carbon.properties.filepath", null)
           logInfo("*************************" + carbonPropertiesFilePath)
           if (null == carbonPropertiesFilePath) {
-            System.setProperty("carbon.properties.filepath", System.getProperty("user.dir")
-                                                             + '/' + "conf" + '/' + "carbon.properties"
+            System.setProperty("carbon.properties.filepath",
+              System.getProperty("user.dir") + '/' + "conf" + '/' + "carbon.properties"
             )
           }
           // execute query

--- a/integration/spark/src/main/scala/org/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -40,7 +40,7 @@ object CarbonThriftServer {
     try {
       Thread.sleep(Integer.parseInt(warmUpTime))
     } catch {
-      case Exception =>
+      case e: Exception =>
         val LOG = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
         LOG.error("Wrong value for carbon.spark.warmUpTime " + warmUpTime +
                   "Using default Value and proceeding")

--- a/integration/spark/src/main/scala/org/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -27,7 +27,7 @@ import org.carbondata.core.util.CarbonProperties
 object CarbonThriftServer {
 
   def main(args: Array[String]): Unit = {
-    var conf = new SparkConf()
+    val conf = new SparkConf()
       .setAppName("Carbon Thrift Server")
     val sparkHome = System.getenv.get("SPARK_HOME")
     if (null != sparkHome) {
@@ -40,14 +40,14 @@ object CarbonThriftServer {
     try {
       Thread.sleep(Integer.parseInt(warmUpTime))
     } catch {
-      case _ =>
+      case Exception =>
         val LOG = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
         LOG.error("Wrong value for carbon.spark.warmUpTime " + warmUpTime +
-          "Using default Value and proceeding")
+                  "Using default Value and proceeding")
         Thread.sleep(30000)
     }
 
-    val carbonContext = new CarbonContext(sc, args(0))
+    val carbonContext = new CarbonContext(sc, args.head)
 
     HiveThriftServer2.startWithContext(carbonContext)
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
@@ -29,9 +29,9 @@ import org.carbondata.core.constants.CarbonCommonConstants
 import org.carbondata.query.expression.{DataType => CarbonDataType}
 
 object CarbonScalaUtil {
-  def convertSparkToCarbonDataType(dataType: org.apache.spark.sql.types.DataType): CarbonDataType =
+  def convertSparkToCarbonDataType(
+      dataType: org.apache.spark.sql.types.DataType): CarbonDataType = {
     dataType match {
-
       case StringType => CarbonDataType.StringType
       case IntegerType => CarbonDataType.IntegerType
       case LongType => CarbonDataType.LongType
@@ -45,9 +45,9 @@ object CarbonScalaUtil {
       case NullType => CarbonDataType.NullType
       case _ => CarbonDataType.DecimalType
     }
+  }
 
-  def convertSparkToCarbonSchemaDataType(dataType: String): String =
-
+  def convertSparkToCarbonSchemaDataType(dataType: String): String = {
     dataType match {
       case CarbonCommonConstants.STRING_TYPE => CarbonCommonConstants.STRING
       case CarbonCommonConstants.INTEGER_TYPE => CarbonCommonConstants.INTEGER
@@ -62,8 +62,9 @@ object CarbonScalaUtil {
       case CarbonCommonConstants.TIMESTAMP_TYPE => CarbonCommonConstants.TIMESTAMP
       case anyType => anyType
     }
+  }
 
-  def convertSparkColumnToCarbonLevel(field: (String, String)): Seq[Level] =
+  def convertSparkColumnToCarbonLevel(field: (String, String)): Seq[Level] = {
     field._2 match {
       case CarbonCommonConstants.STRING_TYPE => Seq(
         Level(field._1, field._1, Int.MaxValue, CarbonCommonConstants.STRING))
@@ -88,6 +89,7 @@ object CarbonScalaUtil {
       case CarbonCommonConstants.TIMESTAMP_TYPE => Seq(
         Level(field._1, field._1, Int.MaxValue, CarbonCommonConstants.TIMESTAMP))
     }
+  }
 
 
   case class TransformHolder(rdd: Any, mataData: CarbonMetaData)
@@ -97,7 +99,7 @@ object CarbonScalaUtil {
       val relation = CarbonEnv.getInstance(carbonContext).carbonCatalog
         .lookupRelation1(Option(carbonTable.getDatabaseName),
           carbonTable.getFactTableName, None)(carbonContext).asInstanceOf[CarbonRelation]
-      var rdd = new SchemaRDD(carbonContext, relation)
+      val rdd = new SchemaRDD(carbonContext, relation)
       rdd.registerTempTable(carbonTable.getFactTableName)
       TransformHolder(rdd, createSparkMeta(carbonTable))
     }

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -59,18 +59,19 @@ object GlobalDictionaryUtil extends Logging {
    * find columns which need to generate global dictionary.
    *
    * @param dimensions dimension list of schema
-   * @param columns column list of csv file
+   * @param columns    column list of csv file
    * @return java.lang.String[]
    */
-  def pruneDimensions(dimensions: Array[CarbonDimension], headers: Array[String],
-                      columns: Array[String]): ( Array[CarbonDimension], Array[String] ) = {
+  def pruneDimensions(dimensions: Array[CarbonDimension],
+      headers: Array[String],
+      columns: Array[String]): (Array[CarbonDimension], Array[String]) = {
     val dimensionBuffer = new ArrayBuffer[CarbonDimension]
     val columnNameBuffer = new ArrayBuffer[String]
     val dimensionsWithDict = dimensions.filter(hasEncoding(_, Encoding.DICTIONARY,
       Encoding.DIRECT_DICTIONARY))
     for (dim <- dimensionsWithDict) {
       breakable {
-        for (i <- 0 until headers.length) {
+        for (i <- headers.indices) {
           if (dim.getColName.equalsIgnoreCase(headers(i))) {
             dimensionBuffer += dim
             columnNameBuffer += columns(i)
@@ -83,13 +84,14 @@ object GlobalDictionaryUtil extends Logging {
   }
 
   /**
-   *  use this method to judge whether CarbonDimension use some encoding or not
+   * use this method to judge whether CarbonDimension use some encoding or not
    */
-  def hasEncoding(dimension: CarbonDimension, encoding: Encoding,
-    excludeEncoding: Encoding): Boolean = {
+  def hasEncoding(dimension: CarbonDimension,
+      encoding: Encoding,
+      excludeEncoding: Encoding): Boolean = {
     if (dimension.isComplex()) {
       var has = false
-      var children = dimension.getListOfChildDimensions
+      val children = dimension.getListOfChildDimensions
       breakable {
         for (i <- 0 until children.size) {
           has = has || hasEncoding(children.get(i), encoding, excludeEncoding)
@@ -101,23 +103,23 @@ object GlobalDictionaryUtil extends Logging {
       has
     } else {
       dimension.hasEncoding(encoding) &&
-        ( excludeEncoding == null || ! dimension.hasEncoding(excludeEncoding))
+      (excludeEncoding == null || !dimension.hasEncoding(excludeEncoding))
     }
   }
 
   def gatherDimensionByEncoding(dimension: CarbonDimension,
-                                encoding: Encoding,
-                                excludeEncoding: Encoding,
-                                dimensionsWithEncoding: ArrayBuffer[CarbonDimension]) {
+      encoding: Encoding,
+      excludeEncoding: Encoding,
+      dimensionsWithEncoding: ArrayBuffer[CarbonDimension]) {
     if (dimension.isComplex()) {
-      val children = dimension.getListOfChildDimensions()
+      val children = dimension.getListOfChildDimensions
       for (i <- 0 until children.size) {
         gatherDimensionByEncoding(children.get(i), encoding, excludeEncoding,
           dimensionsWithEncoding)
       }
     } else {
       if (dimension.hasEncoding(encoding) &&
-        ( excludeEncoding == null || ! dimension.hasEncoding(excludeEncoding))) {
+          (excludeEncoding == null || !dimension.hasEncoding(excludeEncoding))) {
         dimensionsWithEncoding += dimension
       }
     }
@@ -133,13 +135,13 @@ object GlobalDictionaryUtil extends Logging {
   /**
    * invoke CarbonDictionaryWriter to write dictionary to file.
    *
-   * @param model instance of DictionaryLoadModel
+   * @param model       instance of DictionaryLoadModel
    * @param columnIndex the index of current column in column list
-   * @param iter distinct value list of dictionary
+   * @param iter        distinct value list of dictionary
    */
   def writeGlobalDictionaryToFile(model: DictionaryLoadModel,
-                                  columnIndex: Int,
-                                  iter: Iterator[String]): Unit = {
+      columnIndex: Int,
+      iter: Iterator[String]): Unit = {
     val writer: CarbonDictionaryWriter = new CarbonDictionaryWriterImpl(
       model.hdfsLocation, model.table,
       model.primDimensions(columnIndex).getColumnId)
@@ -148,19 +150,18 @@ object GlobalDictionaryUtil extends Logging {
         writer.write(iter.next)
       }
     } finally {
-      writer.close
+      writer.close()
     }
   }
 
   /**
    * invokes the CarbonDictionarySortIndexWriter to write column sort info
    * sortIndex and sortIndexInverted data to sortinsex file.
-    *
-    * @param model
-   * @param index
+   *
    */
-  def writeGlobalDictionaryColumnSortInfo(model: DictionaryLoadModel, index: Int,
-    dictionary: Dictionary): Unit = {
+  def writeGlobalDictionaryColumnSortInfo(model: DictionaryLoadModel,
+      index: Int,
+      dictionary: Dictionary): Unit = {
     val preparator: CarbonDictionarySortInfoPreparator =
       new CarbonDictionarySortInfoPreparator(model.hdfsLocation, model.table)
     val dictionarySortInfo: CarbonDictionarySortInfo =
@@ -180,10 +181,9 @@ object GlobalDictionaryUtil extends Logging {
   /**
    * read global dictionary from cache
    */
-  def readGlobalDictionaryFromCache(model: DictionaryLoadModel
-  ): HashMap[String, Dictionary] = {
+  def readGlobalDictionaryFromCache(model: DictionaryLoadModel): HashMap[String, Dictionary] = {
     val dictMap = new HashMap[String, Dictionary]
-    for (i <- 0 until model.primDimensions.length) {
+    for (i <- model.primDimensions.indices) {
       if (model.dictFileExists(i)) {
         val dict = CarbonLoaderUtil.getDictionary(model.table,
           model.primDimensions(i).getColumnId, model.hdfsLocation,
@@ -197,22 +197,19 @@ object GlobalDictionaryUtil extends Logging {
 
   /**
    * invoke CarbonDictionaryReader to read dictionary from files.
-   *
-   * @param model
-   * @return: scala.Tuple2<scala.collection.mutable.HashSet<java.lang.String>[],boolean[]>
    */
-  def readGlobalDictionaryFromFile(model: DictionaryLoadModel
-  ): HashMap[String, HashSet[String]] = {
+  def readGlobalDictionaryFromFile(model: DictionaryLoadModel): HashMap[String, HashSet[String]] = {
     val dictMap = new HashMap[String, HashSet[String]]
-    for (i <- 0 until model.primDimensions.length) {
+    for (i <- model.primDimensions.indices) {
       val set = new HashSet[String]
       if (model.dictFileExists(i)) {
         val reader: CarbonDictionaryReader = new CarbonDictionaryReaderImpl(
           model.hdfsLocation, model.table, model.primDimensions(i).getColumnId)
         val values = reader.read
         if (values != null) {
-          for (j <- 0 until values.size)
+          for (j <- 0 until values.size) {
             set.add(new String(values.get(j)))
+          }
         }
       }
       dictMap.put(model.primDimensions(i).getColumnId, set)
@@ -221,25 +218,24 @@ object GlobalDictionaryUtil extends Logging {
   }
 
   def generateParserForChildrenDimension(dim: CarbonDimension,
-                                         format: DataFormat,
-                                         mapColumnValuesWithId:
-                                           HashMap[String, HashSet[String]],
-                                         generic: GenericParser): Unit = {
+      format: DataFormat,
+      mapColumnValuesWithId:
+      HashMap[String, HashSet[String]],
+      generic: GenericParser): Unit = {
     val children = dim.getListOfChildDimensions.asScala
-    for (i <- 0 until children.length) {
+    for (i <- children.indices) {
       generateParserForDimension(Some(children(i)), format.cloneAndIncreaseIndex,
         mapColumnValuesWithId) match {
-          case Some(childDim) =>
-            generic.addChild(childDim)
-          case None =>
-        }
+        case Some(childDim) =>
+          generic.addChild(childDim)
+        case None =>
+      }
     }
   }
 
   def generateParserForDimension(dimension: Option[CarbonDimension],
-                                 format: DataFormat,
-                                 mapColumnValuesWithId: HashMap[String, HashSet[String]]
-  ): Option[GenericParser] = {
+      format: DataFormat,
+      mapColumnValuesWithId: HashMap[String, HashSet[String]]): Option[GenericParser] = {
     dimension match {
       case None =>
         None
@@ -262,8 +258,12 @@ object GlobalDictionaryUtil extends Logging {
   def createDataFormat(delimiters: Array[String]): DataFormat = {
     if (ArrayUtils.isNotEmpty(delimiters)) {
       val patterns = new Array[Pattern](delimiters.length)
-      for (i <- 0 until patterns.length) {
-        patterns(i) = Pattern.compile(if (delimiters(i)== null) "" else delimiters(i))
+      for (i <- patterns.indices) {
+        patterns(i) = Pattern.compile(if (delimiters(i) == null) {
+          ""
+        } else {
+          delimiters(i)
+        })
       }
       DataFormat(delimiters, 0, patterns)
     } else {
@@ -274,30 +274,30 @@ object GlobalDictionaryUtil extends Logging {
   /**
    * create a instance of DictionaryLoadModel
    *
-   * @param table CarbonTableIdentifier
-   * @param columnNames column list
-   * @param hdfsLocation store location in HDFS
+   * @param table          CarbonTableIdentifier
+   * @param dimensions    column list
+   * @param hdfsLocation   store location in HDFS
    * @param dictfolderPath path of dictionary folder
    * @return: org.carbondata.spark.rdd.DictionaryLoadModel
    */
   def createDictionaryLoadModel(carbonLoadModel: CarbonLoadModel,
-                                table: CarbonTableIdentifier,
-                                dimensions: Array[CarbonDimension],
-                                hdfsLocation: String,
-                                dictfolderPath: String): DictionaryLoadModel = {
+      table: CarbonTableIdentifier,
+      dimensions: Array[CarbonDimension],
+      hdfsLocation: String,
+      dictfolderPath: String): DictionaryLoadModel = {
     val primDimensionsBuffer = new ArrayBuffer[CarbonDimension]
-    for (i <- 0 until dimensions.length) {
+    for (i <- dimensions.indices) {
       val dims = getPrimDimensionWithDict(dimensions(i))
-      for (j <- 0 until dims.length) {
+      for (j <- dims.indices) {
         primDimensionsBuffer += dims(j)
       }
     }
-    val primDimensions = primDimensionsBuffer.toSeq.map { x => x }.toArray
+    val primDimensions = primDimensionsBuffer.map { x => x }.toArray
     // list dictionary file path
     val dictFilePaths = new Array[String](primDimensions.length)
     val dictFileExists = new Array[Boolean](primDimensions.length)
     val carbonTablePath = CarbonStorePath.getCarbonTablePath(hdfsLocation, table)
-    for (i <- 0 until primDimensions.length) {
+    for (i <- primDimensions.indices) {
       dictFilePaths(i) = carbonTablePath.getDictionaryFilePath(primDimensions(i).getColumnId)
       dictFileExists(i) = CarbonUtil.isFileExists(dictFilePaths(i))
     }
@@ -307,7 +307,7 @@ object GlobalDictionaryUtil extends Logging {
       dictfolderPath,
       dictFilePaths,
       dictFileExists,
-      dimensions.map(_.isComplex() == true),
+      dimensions.map(_.isComplex == true),
       primDimensions,
       carbonLoadModel.getDelimiters)
   }
@@ -316,23 +316,27 @@ object GlobalDictionaryUtil extends Logging {
    * append all file path to a String, file path separated by comma
    */
   def getCsvRecursivePathsFromCarbonFile(carbonFile: CarbonFile): String = {
-    if (carbonFile.isDirectory()) {
+    if (carbonFile.isDirectory) {
       val files = carbonFile.listFiles()
       val stringbuild = new StringBuilder()
       for (j <- 0 until files.size) {
         val filePath = getCsvRecursivePathsFromCarbonFile(files(j))
-        if (!filePath.isEmpty()) {
+        if (!filePath.isEmpty) {
           stringbuild.append(filePath).append(",")
         }
       }
-      if (!stringbuild.isEmpty) {
+      if (stringbuild.nonEmpty) {
         stringbuild.substring(0, stringbuild.size - 1)
       } else {
         stringbuild.toString()
       }
     } else {
       val path = carbonFile.getPath
-      if (path.toLowerCase().endsWith(".csv")) path else ""
+      if (path.toLowerCase().endsWith(".csv")) {
+        path
+      } else {
+        ""
+      }
     }
   }
 
@@ -349,11 +353,11 @@ object GlobalDictionaryUtil extends Logging {
         val fileType = FileFactory.getFileType(filePaths(i))
         val carbonFile = FileFactory.getCarbonFile(filePaths(i), fileType)
         val filePath = getCsvRecursivePathsFromCarbonFile(carbonFile)
-        if (!filePath.isEmpty()) {
+        if (!filePath.isEmpty) {
           stringbuild.append(filePath).append(",")
         }
       }
-      if (!stringbuild.isEmpty) {
+      if (stringbuild.nonEmpty) {
         stringbuild.substring(0, stringbuild.size - 1)
       } else {
         stringbuild.toString()
@@ -365,19 +369,29 @@ object GlobalDictionaryUtil extends Logging {
    * load CSV files to DataFrame by using datasource "com.databricks.spark.csv"
    *
    * @param sqlContext SQLContext
-   * @param filePath file or directory path
+   * @param carbonLoadModel   CarbonLoadModel
    * @return: org.apache.spark.sql.DataFrame
    */
   private def loadDataFrame(sqlContext: SQLContext,
-                            carbonLoadModel: CarbonLoadModel): DataFrame = {
+      carbonLoadModel: CarbonLoadModel): DataFrame = {
     val df = sqlContext.read
       .format("com.databricks.spark.csv")
-      .option("header",
-        {if (StringUtils.isEmpty(carbonLoadModel.getCsvHeader)) "true"
-          else "false" })
-      .option("delimiter",
-        {if (StringUtils.isEmpty(carbonLoadModel.getCsvDelimiter))"" + CSVWriter.DEFAULT_SEPARATOR
-          else carbonLoadModel.getCsvDelimiter})
+      .option("header", {
+        if (StringUtils.isEmpty(carbonLoadModel.getCsvHeader)) {
+          "true"
+        }
+        else {
+          "false"
+        }
+      })
+      .option("delimiter", {
+        if (StringUtils.isEmpty(carbonLoadModel.getCsvDelimiter)) {
+          "" + CSVWriter.DEFAULT_SEPARATOR
+        }
+        else {
+          carbonLoadModel.getCsvDelimiter
+        }
+      })
       .option("parserLib", "univocity")
       .load(getCsvRecursivePaths(carbonLoadModel.getFactFilePath))
     df
@@ -401,12 +415,10 @@ object GlobalDictionaryUtil extends Logging {
   /**
    * generate global dictionary with SQLContext and CarbonLoadModel
    *
-   * @param sqlContext
-   * @param carbonLoadModel
    */
   def generateGlobalDictionary(sqlContext: SQLContext,
-                               carbonLoadModel: CarbonLoadModel,
-                               hdfsLocation: String): Unit = {
+      carbonLoadModel: CarbonLoadModel,
+      hdfsLocation: String): Unit = {
     try {
       val table = new CarbonTableIdentifier(carbonLoadModel.getDatabaseName,
         carbonLoadModel.getTableName)
@@ -425,10 +437,14 @@ object GlobalDictionaryUtil extends Logging {
       val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
       val dimensions = carbonTable.getDimensionByTableName(
         carbonTable.getFactTableName).asScala.toArray
-      val headers = if (StringUtils.isEmpty(carbonLoadModel.getCsvHeader)) df.columns
-      else carbonLoadModel.getCsvHeader.split("" + CSVWriter.DEFAULT_SEPARATOR)
+      val headers = if (StringUtils.isEmpty(carbonLoadModel.getCsvHeader)) {
+        df.columns
+      }
+      else {
+        carbonLoadModel.getCsvHeader.split("" + CSVWriter.DEFAULT_SEPARATOR)
+      }
       val (requireDimension, requireColumnNames) = pruneDimensions(dimensions, headers, df.columns)
-      if (requireDimension.size >= 1) {
+      if (requireDimension.length >= 1) {
         // select column to push down pruning
         df = df.select(requireColumnNames.head, requireColumnNames.tail: _*)
         val model = createDictionaryLoadModel(carbonLoadModel, table, requireDimension,
@@ -448,11 +464,10 @@ object GlobalDictionaryUtil extends Logging {
         val fileMapArray = carbonLoadModel.getDimFolderPath.split(",")
         for (fileMap <- fileMapArray) {
           val dimTableName = fileMap.split(":")(0)
-          val dimFilePath = fileMap.substring(dimTableName.length + 1)
           var dimDataframe = loadDataFrame(sqlContext, carbonLoadModel)
           val (requireDimensionForDim, requireColumnNamesForDim) =
             pruneDimensions(dimensions, dimDataframe.columns, dimDataframe.columns)
-          if (requireDimensionForDim.size >= 1) {
+          if (requireDimensionForDim.length >= 1) {
             dimDataframe = dimDataframe.select(requireColumnNamesForDim.head,
               requireColumnNamesForDim.tail: _*)
             val modelforDim = createDictionaryLoadModel(carbonLoadModel, table,
@@ -476,8 +491,8 @@ object GlobalDictionaryUtil extends Logging {
   }
 
   def generateAndWriteNewDistinctValueList(valuesBuffer: mutable.HashSet[String],
-    dictionary: Dictionary,
-    model: DictionaryLoadModel, columnIndex: Int): Int = {
+      dictionary: Dictionary,
+      model: DictionaryLoadModel, columnIndex: Int): Int = {
     val values = valuesBuffer.toArray
     java.util.Arrays.sort(values, Ordering[String])
     var distinctValueCount: Int = 0
@@ -501,7 +516,7 @@ object GlobalDictionaryUtil extends Logging {
           for (i <- 1 until values.length) {
             if (preValue != values(i)) {
               if (dictionary.getSurrogateKey(values(i)) ==
-                CarbonCommonConstants.INVALID_SURROGATE_KEY) {
+                  CarbonCommonConstants.INVALID_SURROGATE_KEY) {
                 writer.write(values(i))
                 preValue = values(i)
                 distinctValueCount += 1
@@ -522,7 +537,7 @@ object GlobalDictionaryUtil extends Logging {
         }
       }
     } finally {
-      writer.close
+      writer.close()
     }
     distinctValueCount
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -257,12 +257,11 @@ object GlobalDictionaryUtil extends Logging {
 
   def createDataFormat(delimiters: Array[String]): DataFormat = {
     if (ArrayUtils.isNotEmpty(delimiters)) {
-      val patterns = new Array[Pattern](delimiters.length)
-      for (i <- patterns.indices) {
-        patterns(i) = Pattern.compile(if (delimiters(i) == null) {
+      val patterns = delimiters.map { d =>
+        Pattern.compile(if (d == null) {
           ""
         } else {
-          delimiters(i)
+          d
         })
       }
       DataFormat(delimiters, 0, patterns)

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -309,7 +309,7 @@ object GlobalDictionaryUtil extends Logging {
       val stringbuild = new StringBuilder()
       for (j <- 0 until files.size) {
         val filePath = getCsvRecursivePathsFromCarbonFile(files(j))
-        if (!filePath.isEmpty) {
+        if (filePath.nonEmpty) {
           stringbuild.append(filePath).append(",")
         }
       }
@@ -341,7 +341,7 @@ object GlobalDictionaryUtil extends Logging {
         val fileType = FileFactory.getFileType(filePaths(i))
         val carbonFile = FileFactory.getCarbonFile(filePaths(i), fileType)
         val filePath = getCsvRecursivePathsFromCarbonFile(carbonFile)
-        if (!filePath.isEmpty) {
+        if (filePath.nonEmpty) {
           stringbuild.append(filePath).append(",")
         }
       }

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/QueryPlanUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/QueryPlanUtil.scala
@@ -38,8 +38,8 @@ object QueryPlanUtil {
   /**
    * createCarbonInputFormat from query model
    */
-  def createCarbonInputFormat(absoluteTableIdentifier: AbsoluteTableIdentifier) :
-  (CarbonInputFormat[RowResult], Job) = {
+  def createCarbonInputFormat(
+      absoluteTableIdentifier: AbsoluteTableIdentifier): (CarbonInputFormat[RowResult], Job) = {
     val carbonInputFormat = new CarbonInputFormat[RowResult]()
     val jobConf: JobConf = new JobConf(new Configuration)
     val job: Job = new Job(jobConf)


### PR DESCRIPTION
Add Scala code style template to the same dev/java-code-format-template.xml.
Formatted scala code along with following operations.

- Removed unnecessary semicolon
- Handled Java accessor method called as empty-paren
- Named boolean parameters
- Removed Never used variables
- Removed redundant collection conversion
- Updated Unnecassary var converted to val
- Used match case wherever it is required instead of if else
- for loop style is corrected by using indices instead of for(i <- 0 until result.length) to for(i <- result.indices)
- redundant Return keyword is removed
- Used Seq.head instead of using Seq(0) in all places
- Simplified boolean expression like if(exp == true) to if(exp)
- Used isEmpty or nonEmpty instead of using size>0 or size==0 or collections