### PR TITLE
Complex type example should use carbon store format

### DIFF
--- a/examples/src/main/scala/org/carbondata/examples/ComplexTypeExample.scala
+++ b/examples/src/main/scala/org/carbondata/examples/ComplexTypeExample.scala
@@ -55,11 +55,11 @@ object ComplexTypeExample {
                                  activeDeactivedate: array<string>>,
                   gamePointId double,
                   contractNumber double)
-                row format delimited fields terminated by ','
-                collection items terminated by '$$' map keys terminated by ':' """)
+              STORED BY 'org.apache.carbondata.format' """)
 
-    cc.sql(s"LOAD DATA LOCAL INPATH '$dataPath' INTO TABLE $tableName")
-
+    cc.sql(s"load data local inpath '$dataPath' into table $tableName " +
+      "options ('COMPLEX_DELIMITER_LEVEL_1'='$', 'COMPLEX_DELIMITER_LEVEL_2'=':')")
+    
     // filter on complex ARRAY type with index filter
     cc.sql(s"SELECT mobile, proddate.activeDeactivedate, MAC[0] FROM $tableName " +
       "WHERE MAC[0] LIKE 'MAC1%'").show

--- a/examples/src/main/scala/org/carbondata/examples/ComplexTypeExample.scala
+++ b/examples/src/main/scala/org/carbondata/examples/ComplexTypeExample.scala
@@ -59,7 +59,7 @@ object ComplexTypeExample {
 
     cc.sql(s"load data local inpath '$dataPath' into table $tableName " +
       "options ('COMPLEX_DELIMITER_LEVEL_1'='$', 'COMPLEX_DELIMITER_LEVEL_2'=':')")
-    
+
     // filter on complex ARRAY type with index filter
     cc.sql(s"SELECT mobile, proddate.activeDeactivedate, MAC[0] FROM $tableName " +
       "WHERE MAC[0] LIKE 'MAC1%'").show


### PR DESCRIPTION
We must to add `STORED BY 'org.apache.carbondata.format' `into create statement, 
otherwise, ComplexTypeExample is an example for hive instead of for carbon

It must be merged after PR #440 ,and it also can verify whether PR #440 is proper.