### PR TITLE
[Issue- 479] Direct dictionary dataload failure when used with No dictionary columns

### DIFF
--- a/core/src/main/java/org/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonMetadataUtil.java
@@ -16,19 +16,7 @@ import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.compression.ValueCompressionModel;
 import org.carbondata.core.metadata.BlockletInfoColumnar;
 import org.carbondata.core.metadata.ValueEncoderMeta;
-import org.carbondata.format.BlockletBTreeIndex;
-import org.carbondata.format.BlockletIndex;
-import org.carbondata.format.BlockletInfo;
-import org.carbondata.format.BlockletMinMaxIndex;
-import org.carbondata.format.ChunkCompressionMeta;
-import org.carbondata.format.ColumnSchema;
-import org.carbondata.format.CompressionCodec;
-import org.carbondata.format.DataChunk;
-import org.carbondata.format.Encoding;
-import org.carbondata.format.FileFooter;
-import org.carbondata.format.PresenceMeta;
-import org.carbondata.format.SegmentInfo;
-import org.carbondata.format.SortState;
+import org.carbondata.format.*;
 
 /**
  * Util class to convert to thrift metdata classes

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/directdictionary/TimestampDataTypeDirectDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/directdictionary/TimestampDataTypeDirectDictionaryTestCase.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.carbondata.spark.testsuite.directdictionary
+
+import java.io.File
+import java.sql.Timestamp
+
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{CarbonContext, Row}
+import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.hive.HiveContext
+
+import org.carbondata.core.constants.CarbonCommonConstants
+import org.carbondata.core.util.CarbonProperties
+import org.carbondata.core.keygenerator.directdictionary.timestamp.TimeStampGranularityConstants
+import org.scalatest.BeforeAndAfterAll
+
+
+/**
+  * Test Class for detailed query on timestamp datatypes
+  *
+  *
+  */
+class TimestampDataTypeDirectDictionaryTest extends QueryTest with BeforeAndAfterAll {
+  var oc: HiveContext = _
+
+  override def beforeAll {
+    try {
+      CarbonProperties.getInstance()
+        .addProperty(TimeStampGranularityConstants.CARBON_CUTOFF_TIMESTAMP, "2000-12-13 02:10.00.0")
+      CarbonProperties.getInstance()
+        .addProperty(TimeStampGranularityConstants.CARBON_TIME_GRANULARITY,
+          TimeStampGranularityConstants.TIME_GRAN_SEC.toString
+        )
+      CarbonProperties.getInstance().addProperty("carbon.direct.dictionary", "true")
+      sql(
+        "CREATE CUBE directDictionaryCube DIMENSIONS (empno Integer,doj Timestamp) MEASURES " +
+          "(salary Integer) " +
+          "OPTIONS (PARTITIONER [PARTITION_COUNT=1])"
+      )
+
+      CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss")
+      val currentDirectory = new File(this.getClass.getResource("/").getPath + "/../../")
+        .getCanonicalPath
+      var csvFilePath = currentDirectory + "/src/test/resources/datasample.csv"
+      sql("LOAD DATA fact from '" + csvFilePath + "' INTO CUBE directDictionaryCube PARTITIONDATA" +
+        "(DELIMITER ',', QUOTECHAR '\"')");
+
+    } catch {
+      case x: Throwable => CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+    }
+  }
+
+  test("select doj from directDictionaryCube") {
+    checkAnswer(
+      sql("select doj from directDictionaryCube"),
+      Seq(Row(Timestamp.valueOf("2016-03-14 15:00:09.0")),
+        Row(Timestamp.valueOf("2016-04-14 15:00:09.0"))
+      )
+    )
+  }
+
+
+  test("select doj from directDictionaryCube with equals filter") {
+    checkAnswer(
+      sql("select doj from directDictionaryCube where doj='2016-03-14 15:00:09'"),
+      Seq(Row(Timestamp.valueOf("2016-03-14 15:00:09")))
+    )
+
+  }
+  
+    test("select doj from directDictionaryCube with greater than filter") {
+    checkAnswer(
+      sql("select doj from directDictionaryCube where doj>'2016-03-14 15:00:09'"),
+      Seq(Row(Timestamp.valueOf("2016-04-14 15:00:09")))
+    )
+
+  }
+
+
+  override def afterAll {
+    sql("drop cube directDictionaryCube")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+    CarbonProperties.getInstance().addProperty("carbon.direct.dictionary", "false")
+  }
+}

--- a/processing/src/main/java/org/carbondata/processing/dimension/load/command/impl/CSVDimensionLoadCommand.java
+++ b/processing/src/main/java/org/carbondata/processing/dimension/load/command/impl/CSVDimensionLoadCommand.java
@@ -38,6 +38,7 @@ import org.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGene
 import org.carbondata.core.util.CarbonUtil;
 import org.carbondata.processing.dimension.load.command.DimensionLoadCommand;
 import org.carbondata.processing.dimension.load.info.DimensionLoadInfo;
+import org.carbondata.processing.schema.metadata.ColumnSchemaDetails;
 import org.carbondata.processing.schema.metadata.HierarchiesInfo;
 import org.carbondata.processing.surrogatekeysgenerator.csvbased.CarbonCSVBasedDimSurrogateKeyGen;
 import org.carbondata.processing.surrogatekeysgenerator.csvbased.CarbonCSVBasedSeqGenMeta;
@@ -336,9 +337,12 @@ public class CSVDimensionLoadCommand implements DimensionLoadCommand {
             .generateSurrogateKeysForTimeDims(tuple, columnName, columnIndex[i], propertyvalue);
       } else {
         CarbonCSVBasedSeqGenMeta meta = dimensionLoadInfo.getMeta();
-        if (meta.isDirectDictionary(i)) {
+        String dimensionColumnIds = meta.getDimensionColumnIds()[i];
+        ColumnSchemaDetails columnSchemaDetails =
+            meta.getColumnSchemaDetailsWrapper().get(dimensionColumnIds);
+        if (columnSchemaDetails.isDirectDictionary()) {
           DirectDictionaryGenerator directDictionaryGenerator = DirectDictionaryKeyGeneratorFactory
-              .getDirectDictionaryGenerator(meta.getColumnDataType()[i]);
+              .getDirectDictionaryGenerator(columnSchemaDetails.getColumnType());
           output[i] = directDictionaryGenerator.generateDirectSurrogateKey(tuple);
         } else {
           output[i] = surrogateKeyGen.generateSurrogateKeys(tuple, columnName);

--- a/processing/src/main/java/org/carbondata/processing/graphgenerator/GraphGenerator.java
+++ b/processing/src/main/java/org/carbondata/processing/graphgenerator/GraphGenerator.java
@@ -563,7 +563,7 @@ public class GraphGenerator {
     seqMeta.setActualDimNames(graphConfiguration.getActualDimensionColumns());
     seqMeta.setNormHiers(graphConfiguration.getNormHiers());
     seqMeta.setHeirKeySize(graphConfiguration.getHeirAndKeySizeString());
-    seqMeta.setDirectDictionaryColumns(graphConfiguration.getDirectDictionaryColumnString());
+    seqMeta.setColumnSchemaDetails(graphConfiguration.getColumnSchemaDetails().toString());
     String[] aggType = graphConfiguration.getAggType();
     StringBuilder builder = new StringBuilder();
     for (int i = 0; i < aggType.length; i++) {
@@ -787,8 +787,8 @@ public class GraphGenerator {
         .setActualDims(CarbonSchemaParser.getCubeDimensions(dimensions, carbonDataLoadSchema));
     graphConfiguration.setComplexTypeString(CarbonSchemaParser.getComplexTypeString(dimensions));
     prepareNoDictionaryMapping(dimensions, graphConfiguration);
-    graphConfiguration.setDirectDictionaryColumnString(
-        CarbonSchemaParser.getDirectDictionaryColumnString(dimensions, carbonDataLoadSchema));
+    graphConfiguration.setColumnSchemaDetails(
+        CarbonSchemaParser.getColumnSchemaDetails(dimensions));
     String factTableName = carbonDataLoadSchema.getCarbonTable().getFactTableName();
     graphConfiguration.setTableName(factTableName);
     StringBuilder dimString = new StringBuilder();

--- a/processing/src/main/java/org/carbondata/processing/graphgenerator/configuration/GraphConfigurationInfo.java
+++ b/processing/src/main/java/org/carbondata/processing/graphgenerator/configuration/GraphConfigurationInfo.java
@@ -21,6 +21,8 @@ package org.carbondata.processing.graphgenerator.configuration;
 
 import java.util.Map;
 
+import org.carbondata.processing.schema.metadata.ColumnSchemaDetailsWrapper;
+
 public class GraphConfigurationInfo {
   private String connectionName;
 
@@ -189,9 +191,9 @@ public class GraphConfigurationInfo {
   private Boolean[] isNoDictionaryDimMapping;
 
   /**
-   * String of direct dictionary columns and index separated by COLON_SPC_CHARACTER
+   * wrapper object holding the columnschemadetails
    */
-  private String directDictionaryColumnString;
+  private ColumnSchemaDetailsWrapper columnSchemaDetailsWrapper;
 
   /**
    * It is column groups in below format
@@ -962,22 +964,20 @@ public class GraphConfigurationInfo {
   }
 
   /**
-   * Set String of direct dictionary columns index/ordinal and column DataType separated by
-   * COLON_SPC_CHARACTER
+   * Set Wrapper Object having the columnschemadetails
    *
-   * @param directDictionaryColumnString
+   * @param columnSchemaDetailsWrapper
    */
-  public void setDirectDictionaryColumnString(String directDictionaryColumnString) {
-    this.directDictionaryColumnString = directDictionaryColumnString;
+  public void setColumnSchemaDetails(ColumnSchemaDetailsWrapper columnSchemaDetailsWrapper) {
+    this.columnSchemaDetailsWrapper = columnSchemaDetailsWrapper;
   }
 
   /**
-   * String of direct dictionary columns index and DataType separated by COLON_SPC_CHARACTER
-   *
+   * return the Wrapper Object having the columnschemadetails
    * @return
    */
-  public String getDirectDictionaryColumnString() {
-    return directDictionaryColumnString;
+  public ColumnSchemaDetailsWrapper getColumnSchemaDetails() {
+    return columnSchemaDetailsWrapper;
   }
 
   public void setColumnGroupsString(String columnGroups) {

--- a/processing/src/main/java/org/carbondata/processing/schema/metadata/ColumnSchemaDetails.java
+++ b/processing/src/main/java/org/carbondata/processing/schema/metadata/ColumnSchemaDetails.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.carbondata.processing.schema.metadata;
+
+import org.carbondata.core.carbon.metadata.datatype.DataType;
+import org.carbondata.core.util.DataTypeUtil;
+
+/**
+ * Class holds the common column schema details needed for the data load
+ */
+public class ColumnSchemaDetails {
+
+  /**
+   * column Name
+   */
+  private String columnName;
+  /**
+   * column datatype
+   */
+  private DataType columnType;
+  /**
+   * boolean to identify direct dictionary column
+   */
+  private Boolean isDirectDictionary;
+
+  /**
+   * Constructor to initialize object from the input string separated by comma (,)
+   *
+   * @param input
+   */
+  ColumnSchemaDetails(String input) {
+    String[] splits = input.split(",");
+    columnName = splits[0];
+    columnType = DataTypeUtil.getDataType(splits[1]);
+    isDirectDictionary = Boolean.parseBoolean(splits[2]);
+  }
+
+  /**
+   * Constructor to initialize the ColumnSchemaDetails
+   *
+   * @param columnName
+   * @param columnType
+   * @param isDirectDictionary
+   */
+  public ColumnSchemaDetails(String columnName, DataType columnType, Boolean isDirectDictionary) {
+    this.columnName = columnName;
+    this.columnType = columnType;
+    this.isDirectDictionary = isDirectDictionary;
+
+  }
+
+  /**
+   * returns the ColumnName
+   *
+   * @return
+   */
+  public String getColumnName() {
+    return columnName;
+  }
+
+  /**
+   * returns the dataType of the column
+   *
+   * @return
+   */
+  public DataType getColumnType() {
+    return columnType;
+  }
+
+  /**
+   * returns boolean value to identify direct dictionary
+   *
+   * @return
+   */
+  public Boolean isDirectDictionary() {
+    return isDirectDictionary;
+  }
+
+  /**
+   * @return
+   */
+  public String toString() {
+    return columnName + "," + columnType + "," + isDirectDictionary;
+  }
+}

--- a/processing/src/main/java/org/carbondata/processing/schema/metadata/ColumnSchemaDetailsWrapper.java
+++ b/processing/src/main/java/org/carbondata/processing/schema/metadata/ColumnSchemaDetailsWrapper.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.carbondata.processing.schema.metadata;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.carbondata.core.constants.CarbonCommonConstants;
+
+/**
+ * Wrapper class to hold the columnschema details
+ */
+public class ColumnSchemaDetailsWrapper {
+
+  /**
+   * Map of the ColumnSchemaDetails
+   */
+  private Map<String, ColumnSchemaDetails> columnSchemaDetailsMap;
+
+  /**
+   * return the string object
+   *
+   * @return
+   */
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    int size = columnSchemaDetailsMap.size();
+    Set<Map.Entry<String, ColumnSchemaDetails>> entries = columnSchemaDetailsMap.entrySet();
+    Iterator<Map.Entry<String, ColumnSchemaDetails>> iterator = entries.iterator();
+
+    while (iterator.hasNext()) {
+      Map.Entry<String, ColumnSchemaDetails>  entry = iterator.next();
+      builder.append(entry.getKey());
+      builder.append(CarbonCommonConstants.HASH_SPC_CHARACTER);
+      builder.append(entry.getValue().toString());
+      if (iterator.hasNext()) {
+        builder.append(CarbonCommonConstants.HASH_SPC_CHARACTER);
+      }
+    }
+    return builder.toString();
+  }
+
+  /**
+   * default constructor
+   */
+  public ColumnSchemaDetailsWrapper() {
+
+  }
+
+  /**
+   * Constructor take serialized string as input and populates the List of columnschema details
+   *
+   * @param input
+   */
+  public ColumnSchemaDetailsWrapper(String input) {
+    columnSchemaDetailsMap = new HashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
+    String[] split = input.split(CarbonCommonConstants.HASH_SPC_CHARACTER);
+    for (int i=0 ; i< split.length ;i++) {
+      String key = split[i++];
+      ColumnSchemaDetails details = new ColumnSchemaDetails(split[i]);
+      columnSchemaDetailsMap.put(key, details);
+    }
+  }
+
+  /**
+   * returns ColumnSchemaDetails of all columns
+   *
+   * @return
+   */
+  public Map<String, ColumnSchemaDetails> getColumnSchemaDetailsMap() {
+    return columnSchemaDetailsMap;
+  }
+
+  /**
+   * sets the map of column schema
+   *
+   * @param columnSchemaDetailsMap
+   */
+  public void setColumnSchemaDetailsMap(Map<String, ColumnSchemaDetails> columnSchemaDetailsMap) {
+    this.columnSchemaDetailsMap = columnSchemaDetailsMap;
+  }
+
+  /**
+   * returns the columnSchemaDetails of requested column
+   *
+   * @param key
+   * @return
+   */
+  public ColumnSchemaDetails get(String key) {
+    return columnSchemaDetailsMap.get(key);
+  }
+}

--- a/processing/src/main/java/org/carbondata/processing/schema/metadata/ColumnsInfo.java
+++ b/processing/src/main/java/org/carbondata/processing/schema/metadata/ColumnsInfo.java
@@ -150,9 +150,9 @@ public class ColumnsInfo {
   private String[] dimensionColumnIds;
 
   /**
-   * array of boolean values to identify the direct dictionary column
+   * wrapper object having the columnSchemaDetails
    */
-  private boolean[] directDictionary;
+  private ColumnSchemaDetailsWrapper columnSchemaDetailsWrapper;
 
   public Map<String, GenericDataType> getComplexTypesMap() {
     return complexTypesMap;
@@ -494,18 +494,20 @@ public class ColumnsInfo {
   }
 
   /**
-   * The method returns the array boolean to identify the direct dictionary
+   * returns wrapper object having the columnSchemaDetails
+   *
    * @return
    */
-  public boolean[] getDirectDictionary() {
-    return directDictionary;
+  public ColumnSchemaDetailsWrapper getColumnSchemaDetailsWrapper() {
+    return columnSchemaDetailsWrapper;
   }
 
   /**
-   * the method sets the array boolean to identify the direct dictionary
-   * @param directDictionary
+   * set the wrapper object having the columnSchemaDetails
+   *
+   * @param columnSchemaDetailsWrapper
    */
-  public void setDirectDictionary(boolean[] directDictionary) {
-    this.directDictionary = directDictionary;
+  public void setColumnSchemaDetailsWrapper(ColumnSchemaDetailsWrapper columnSchemaDetailsWrapper) {
+    this.columnSchemaDetailsWrapper = columnSchemaDetailsWrapper;
   }
 }

--- a/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/FileStoreSurrogateKeyGenForCSV.java
+++ b/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/FileStoreSurrogateKeyGenForCSV.java
@@ -52,6 +52,8 @@ import org.carbondata.core.util.CarbonUtilException;
 import org.carbondata.core.writer.ByteArrayHolder;
 import org.carbondata.core.writer.HierarchyValueWriterForCSV;
 import org.carbondata.processing.datatypes.GenericDataType;
+import org.carbondata.processing.schema.metadata.ColumnSchemaDetails;
+import org.carbondata.processing.schema.metadata.ColumnSchemaDetailsWrapper;
 import org.carbondata.processing.schema.metadata.ColumnsInfo;
 
 import org.pentaho.di.core.exception.KettleException;
@@ -257,12 +259,15 @@ public class FileStoreSurrogateKeyGenForCSV extends CarbonCSVBasedDimSurrogateKe
     List<String> dictionaryKeys = new ArrayList<>(dimColumnNames.length);
     List<DictionaryColumnUniqueIdentifier> dictionaryColumnUniqueIdentifiers =
         new ArrayList<>(dimColumnNames.length);
+    ColumnSchemaDetailsWrapper columnSchemaDetailsWrapper =
+        columnsInfo.getColumnSchemaDetailsWrapper();
     // update the member cache for dimension
     for (int i = 0; i < dimColumnNames.length; i++) {
-      if(columnsInfo.getDirectDictionary()[i]){
+      String dimColName = dimColumnNames[i].substring(tableName.length() + 1);
+      ColumnSchemaDetails details = columnSchemaDetailsWrapper.get(dimColumnIds[i]);
+      if(details.isDirectDictionary()){
         continue;
       }
-      String dimColName = dimColumnNames[i].substring(tableName.length() + 1);
       GenericDataType complexType = columnsInfo.getComplexTypesMap().get(dimColName);
       if (complexType != null) {
         List<GenericDataType> primitiveChild = new ArrayList<GenericDataType>();

--- a/processing/src/main/java/org/carbondata/processing/util/CarbonSchemaParser.java
+++ b/processing/src/main/java/org/carbondata/processing/util/CarbonSchemaParser.java
@@ -19,13 +19,7 @@
 
 package org.carbondata.processing.util;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.carbondata.core.carbon.CarbonDataLoadSchema;
 import org.carbondata.core.carbon.CarbonDataLoadSchema.DimensionRelation;
@@ -37,6 +31,9 @@ import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.keygenerator.KeyGenerator;
 import org.carbondata.core.keygenerator.factory.KeyGeneratorFactory;
+import org.carbondata.core.util.CarbonUtil;
+import org.carbondata.processing.schema.metadata.ColumnSchemaDetails;
+import org.carbondata.processing.schema.metadata.ColumnSchemaDetailsWrapper;
 
 public final class CarbonSchemaParser {
   /**
@@ -575,7 +572,6 @@ public final class CarbonSchemaParser {
     return carbonDataLoadSchema.getCarbonTable().getFactTableName();
   }
 
-
   /**
    * It will return all column groups in below format
    * 0,1~2~3,4,5,6~7~8,9
@@ -607,7 +603,6 @@ public final class CarbonSchemaParser {
     }
     return columnGroups.toString();
   }
-
 
   /**
    * getHeirAndCardinalityString
@@ -1166,26 +1161,24 @@ public final class CarbonSchemaParser {
   }
 
   /**
-   * the method returns the String of direct dictionary column index and column DataType
-   * separated by COLON_SPC_CHARACTER
+   * the method returns the ColumnSchemaDetailsWrapper
    *
    * @param dimensions
    * @return
    */
-  public static String getDirectDictionaryColumnString(List<CarbonDimension> dimensions,
-      CarbonDataLoadSchema carbonDataLoadSchema) {
-    StringBuffer buff = new StringBuffer();
-    int counter = 0;
+  public static ColumnSchemaDetailsWrapper getColumnSchemaDetails(
+      List<CarbonDimension> dimensions) {
+    ColumnSchemaDetailsWrapper columnSchemaDetailsWrapper = new ColumnSchemaDetailsWrapper();
+    Map<String, ColumnSchemaDetails> columnSchemaDetailsMap =
+        new HashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     for (CarbonDimension cDimension : dimensions) {
-      if (cDimension.getEncoder().contains(Encoding.DIRECT_DICTIONARY)) {
-        buff.append(cDimension.getOrdinal());
-        buff.append(CarbonCommonConstants.COLON_SPC_CHARACTER);
-        buff.append(cDimension.getDataType());
-        buff.append(CarbonCommonConstants.COLON_SPC_CHARACTER);
-        counter++;
-      }
+      ColumnSchemaDetails details =
+          new ColumnSchemaDetails(cDimension.getColName(), cDimension.getDataType(),
+              CarbonUtil.hasEncoding(cDimension.getEncoder(), Encoding.DIRECT_DICTIONARY));
+      columnSchemaDetailsMap.put(cDimension.getColumnSchema().getColumnUniqueId(), details);
     }
-    return buff.toString();
+    columnSchemaDetailsWrapper.setColumnSchemaDetailsMap(columnSchemaDetailsMap);
+    return columnSchemaDetailsWrapper;
   }
 
   /**


### PR DESCRIPTION
1. Direct dictionary dataload failure when used with No dictionary columns
2. Clean up is not happening after the TestTimestampDataTypeDirectDictionary execution
3. Fixed Import issue of CarbonMetadataUtil
4. Rename TimestampDataTypeDirectDictionary_FT to TestTimestampDataTypeDirectDictionary