### PR TITLE
[Issue - 506] CarbonSqlParser is not validating the duplicate column …

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -362,7 +362,18 @@ class CarbonSqlParser()
         case list@Token("TOK_TABCOLLIST", _) =>
           val cols = BaseSemanticAnalyzer.getColumns(list, true)
           if (cols != null) {
-
+            val dupColsGrp = cols.asScala
+              .groupBy(x => x.getName) filter { case (_, colList) => colList
+              .size > 1
+            }
+            if (dupColsGrp.size > 0) {
+              var columnName: String = ""
+              dupColsGrp.toSeq.foreach(columnName += _._1 + ", ")
+              columnName = columnName.substring(0, columnName.lastIndexOf(", "))
+              val errorMessage = "Duplicate column name: " + columnName + " found in table " +
+                ".Please check create table statement."
+              throw new MalformedCarbonCommandException(errorMessage)
+            }
             cols.asScala.map { col =>
               val columnName = col.getName()
               val dataType = Option(col.getType)

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestLoadDataWithHiveSyntax.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataload/TestLoadDataWithHiveSyntax.scala
@@ -103,7 +103,17 @@ class TestLoadDataWithHiveSyntax extends QueryTest with BeforeAndAfterAll {
         "'COMPLEX_DELIMITER_LEVEL_1'='$', 'COMPLEX_DELIMITER_LEVEL_2'=':')");
     sql("drop table if exists complexcarbontable")
   }
-  
+
+  test("test duplicate column validation"){
+    try{
+        sql("create table duplicateColTest(col1 string, Col1 string)")
+    }
+    catch {
+      case e : Exception => {
+        assert(e.getMessage.contains("Duplicate column name"))
+      }
+    }
+  }
   test("complex types data loading with hive column having more than required column values") {
     sql("create table complexcarbontable(deviceInformationId int, channelsId string,"+ 
         "ROMSize string, purchasedate string, mobile struct<imei:string, imsi:string>,"+


### PR DESCRIPTION
…name if they are in different case in create table command

Modification:
Now in case duplicate columns  system will throw error while creating table.
