### PR TITLE
[Part of PR 396]Fixed error " Comparison method violates its general contract" .

### DIFF
--- a/core/src/main/java/org/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/carbondata/core/util/ByteUtil.java
@@ -308,60 +308,11 @@ public final class ByteUtil {
       }
       int len1 = byteBuffer1.remaining();
       int len2 = byteBuffer2.remaining();
-      int minLength = (len1 <= len2) ? len1 : len2;
-      int minWords = 0;
-
-      /*
-       * Compare 8 bytes at a time. Benchmarking shows comparing 8 bytes
-       * at a time is no slower than comparing 4 bytes at a time even on
-       * 32-bit. On the other hand, it is substantially faster on 64-bit.
-       */
-      if (minLength > 7) {
-        minWords = minLength / SIZEOF_LONG;
-        for (int i = 0; i < minWords * SIZEOF_LONG; i += SIZEOF_LONG) {
-
-          long lw = byteBuffer1.getLong();
-          long rw = byteBuffer2.getLong();
-
-          long diff = lw ^ rw;
-
-          if (diff != 0) {
-            if (!LITTLEENDIAN) {
-              return lessThanUnsigned(lw, rw) ? -1 : 1;
-            }
-
-            // Use binary search
-            int k = 0;
-            int y;
-            int x = (int) diff;
-            if (x == 0) {
-              x = (int) (diff >>> 32);
-              k = 32;
-            }
-            y = x << 16;
-            if (y == 0) {
-              k += 16;
-            } else {
-              x = y;
-            }
-
-            y = x << 8;
-            if (y == 0) {
-              k += 8;
-            }
-            return (int) (((lw >>> k) & 0xFFL) - ((rw >>> k) & 0xFFL));
-          }
-        }
-      }
-      // The epilogue to cover the last (minLength % 8) elements.
-      for (int i = minWords * SIZEOF_LONG; i < minLength; i++) {
-        int a = (byteBuffer1.get() & 0xff);
-        int b = (byteBuffer2.get() & 0xff);
-        if (a != b) {
-          return a - b;
-        }
-      }
-      return len1 - len2;
+      byte[] buffer1 = new byte[len1];
+      byte[] buffer2 = new byte[len2];
+      byteBuffer1.get(buffer1);
+      byteBuffer2.get(buffer2);
+      return compareTo(buffer1, buffer2);
     }
 
   }


### PR DESCRIPTION
The PR https://github.com/HuaweiBigData/carbondata/pull/396 test case finds the below error 
`java.lang.IllegalArgumentException: Comparison method violates its general contract!
at java.util.TimSort.mergeHi(TimSort.java:899)
at java.util.TimSort.mergeAt(TimSort.java:516)
at java.util.TimSort.mergeForceCollapse(TimSort.java:457)
at java.util.TimSort.sort(TimSort.java:254)
at java.util.Arrays.sort(Arrays.java:1438)
at org.carbondata.processing.sortandgroupby.sortdata.SortDataRows$1.call(SortDataRows.java:367)`

Here the comparison is going wrong, because it supposed to be unsafe comparison but here mixed both.
This scenario is covered by the testcases of PR https://github.com/HuaweiBigData/carbondata/pull/396