### PR TITLE
[Issue 560] Zookeeper test case fails randomly and generates big log files under core package

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -172,7 +172,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.8</version>
+      <version>3.4.7</version>
     </dependency>
   </dependencies>
   <build>

--- a/core/src/test/java/org/carbondata/core/locks/ZooKeeperLockingTest.java
+++ b/core/src/test/java/org/carbondata/core/locks/ZooKeeperLockingTest.java
@@ -32,7 +32,8 @@ public class ZooKeeperLockingTest {
    */
   @Before public void setUp() throws Exception {
     Properties startupProperties = new Properties();
-    startupProperties.setProperty("dataDir", (new File(".").getAbsolutePath()));
+    startupProperties.setProperty("dataDir", (new File("./target").getAbsolutePath()));
+    startupProperties.setProperty("dataLogDir", (new File("./target").getAbsolutePath()));
     freePort = findFreePort();
     startupProperties.setProperty("clientPort", "" + freePort);
     QuorumPeerConfig quorumConfiguration = new QuorumPeerConfig();

--- a/core/src/test/java/org/carbondata/core/locks/ZooKeeperLockingTest.java
+++ b/core/src/test/java/org/carbondata/core/locks/ZooKeeperLockingTest.java
@@ -11,7 +11,6 @@ import java.util.Properties;
 import org.carbondata.core.util.CarbonProperties;
 
 import mockit.NonStrictExpectations;
-
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -78,11 +77,6 @@ public class ZooKeeperLockingTest {
     };
 
     ZooKeeperLocking zkl = new ZooKeeperLocking(LockUsage.METADATA_LOCK);
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      Assert.assertTrue(false);
-    }
     Assert.assertTrue(zkl.lock());
 
     ZooKeeperLocking zk2 = new ZooKeeperLocking(LockUsage.METADATA_LOCK);


### PR DESCRIPTION
There are three issues with that ZooKeeper test case
1. Some times test case hangs while starting the zookeeper server, that is the bug in zookeeper 3.4.8, it could be solved by either downgrading to 3.4.7 or overriding the ZooKeeperServer start method. Please have a look at https://issues.apache.org/jira/browse/ZOOKEEPER-2383

2. It generates very big log files under core/version-2 folder. It could be solved by moving the folder to target.

3. Test case some times failing because it cannot get the node, It is because the baseNode existance and creation is added to Watcher. It calls every time for each call. Calls some times hangs there. So we can pre-create the base node solves the issue.