### PR TITLE
[Issue-566] copy out to newArray should use memberMapping[index]

### DIFF
--- a/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -1142,7 +1142,7 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
 
     insertHierIfRequired(out);
     RemoveDictionaryUtil
-        .prepareOut(newArray, byteBufferArr, out, dimLen - meta.complexTypes.size());
+        .prepareOut(newArray, byteBufferArr, out, dimLen - meta.complexTypes.size(), memberMapping);
 
     return newArray;
   }

--- a/processing/src/main/java/org/carbondata/processing/util/RemoveDictionaryUtil.java
+++ b/processing/src/main/java/org/carbondata/processing/util/RemoveDictionaryUtil.java
@@ -41,19 +41,19 @@ public class RemoveDictionaryUtil {
    * @param byteBufferArr
    */
   public static void prepareOut(Object[] newOutArr, ByteBuffer[] byteBufferArr, Object[] out,
-      int dimCount) {
+      int dimCount, int[] memberMapping) {
 
     byte[] nonDictionaryCols =
         RemoveDictionaryUtil.packByteBufferIntoSingleByteArray(byteBufferArr);
     Integer[] dimArray = new Integer[dimCount];
     for (int i = 0; i < dimCount; i++) {
-      dimArray[i] = (Integer) out[i];
+      dimArray[i] = (Integer) out[memberMapping[i]];
     }
 
     Object[] measureArray = new Object[out.length - dimCount];
     int index = 0;
     for (int j = dimCount; j < out.length; j++) {
-      measureArray[index++] = out[j];
+      measureArray[index++] = out[memberMapping[j]];
     }
 
     newOutArr[IgnoreDictionary.DIMENSION_INDEX_IN_ROW.getIndex()] = dimArray;

--- a/processing/src/main/java/org/carbondata/processing/util/RemoveDictionaryUtil.java
+++ b/processing/src/main/java/org/carbondata/processing/util/RemoveDictionaryUtil.java
@@ -53,7 +53,7 @@ public class RemoveDictionaryUtil {
     Object[] measureArray = new Object[out.length - dimCount];
     int index = 0;
     for (int j = dimCount; j < out.length; j++) {
-      measureArray[index++] = out[memberMapping[j]];
+      measureArray[index++] = out[j];
     }
 
     newOutArr[IgnoreDictionary.DIMENSION_INDEX_IN_ROW.getIndex()] = dimArray;


### PR DESCRIPTION
in this pr, i have fixed the exception in #566 
When do populateOutputRow, we copy the "out" value to "newArray" finnally.
In this function(prepareOut) , we shuld using the same index as out array, so memberMapping[index] is proper