### PR TITLE
[Issue 607]Validation for column group

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.execution.datasources.DescribeCommand
 import org.apache.spark.sql.hive.HiveQlWrapper
 
 import org.carbondata.spark.exception.MalformedCarbonCommandException
+import org.carbondata.spark.util.CommonUtil
 
 
 
@@ -470,13 +471,13 @@ class CarbonSqlParser()
                                   tableProperties: Map[String, String]): tableModel
   = {
 
-    // get column groups configuration from table properties.
-    val groupCols: Seq[String] = updateColumnGroupsInField(tableProperties)
-
     var (dims: Seq[Field], noDictionaryDims: Seq[String]) = extractDimColsAndNoDictionaryFields(
       fields, tableProperties)
     val msrs: Seq[Field] = extractMsrColsFromFields(fields, tableProperties)
 
+    // get column groups configuration from table properties.
+    val groupCols: Seq[String] = updateColumnGroupsInField(tableProperties,
+        noDictionaryDims, msrs, dims)
 
     val partitioner: Option[Partitioner] = getPartitionerObject(partitionCols, tableProperties)
 
@@ -494,7 +495,10 @@ class CarbonSqlParser()
    * @param tableProperties
    * @return
    */
-  protected def updateColumnGroupsInField(tableProperties: Map[String, String]): Seq[String] = {
+  protected def updateColumnGroupsInField(tableProperties: Map[String, String],
+      noDictionaryDims: Seq[String],
+      msrs: Seq[Field],
+      dims: Seq[Field]): Seq[String] = {
     if (None != tableProperties.get("COLUMN_GROUPS")) {
 
       var splittedColGrps: Seq[String] = Seq[String]()
@@ -506,8 +510,9 @@ class CarbonSqlParser()
       val m: Matcher = Pattern.compile("\\(([^)]+)\\)").matcher(nonSplitCols)
       while (m.find()) {
         val oneGroup: String = m.group(1)
-
-        splittedColGrps :+= oneGroup
+        CommonUtil.validateColumnGroup(oneGroup, noDictionaryDims, msrs, splittedColGrps, dims)
+        val arrangedColGrp = rearrangedColumnGroup(oneGroup, dims)
+        splittedColGrps :+= arrangedColGrp
       }
       // This will  be furthur handled.
       splittedColGrps
@@ -516,6 +521,42 @@ class CarbonSqlParser()
       null
     }
   }
+
+  def rearrangedColumnGroup(colGroup: String, dims: Seq[Field]): String = {
+    // if columns in column group is not in schema order than arrange it in schema order
+    var colGrpFieldIndx: Seq[Int] = Seq[Int]()
+    colGroup.split(',').map(_.trim).foreach { x =>
+      dims.zipWithIndex.foreach { dim =>
+        if (dim._1.column.equals(x)) {
+          colGrpFieldIndx :+= dim._2
+        }
+      }
+    }
+    // sort it
+    colGrpFieldIndx = colGrpFieldIndx.sorted
+    // check if columns in column group is in schema order
+    if (!checkIfInSequence(colGrpFieldIndx)) {
+      throw new MalformedCarbonCommandException("Invalid column group:" + colGroup)
+    }
+    def checkIfInSequence(colGrpFieldIndx: Seq[Int]): Boolean = {
+      for (i <- 0 until (colGrpFieldIndx.length - 1)) {
+        if ((colGrpFieldIndx(i + 1) - colGrpFieldIndx(i)) != 1) {
+          throw new MalformedCarbonCommandException(
+            "Invalid column group,column group column should be in sequence.")
+        }
+      }
+      true
+    }
+    val colGrpNames: StringBuilder = StringBuilder.newBuilder
+    for (i <- 0 until colGrpFieldIndx.length) {
+      colGrpNames.append(dims(colGrpFieldIndx(i)).column)
+      if (i < (colGrpFieldIndx.length - 1)) {
+        colGrpNames.append(",")
+      }
+    }
+    colGrpNames.toString()
+  }
+
 
   /**
    * For getting the partitioner Object

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -527,7 +527,7 @@ class CarbonSqlParser()
     var colGrpFieldIndx: Seq[Int] = Seq[Int]()
     colGroup.split(',').map(_.trim).foreach { x =>
       dims.zipWithIndex.foreach { dim =>
-        if (dim._1.column.equals(x)) {
+        if (dim._1.column.equalsIgnoreCase(x)) {
           colGrpFieldIndx :+= dim._2
         }
       }
@@ -542,7 +542,7 @@ class CarbonSqlParser()
       for (i <- 0 until (colGrpFieldIndx.length - 1)) {
         if ((colGrpFieldIndx(i + 1) - colGrpFieldIndx(i)) != 1) {
           throw new MalformedCarbonCommandException(
-            "Invalid column group,column group column should be in sequence.")
+            "Invalid column group,column in group should be contiguous as per schema.")
         }
       }
       true

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/CommonUtil.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.carbondata.spark.util
+
+import org.apache.spark.sql.execution.command.Field
+
+import org.carbondata.spark.exception.MalformedCarbonCommandException
+
+object CommonUtil {
+  def validateColumnGroup(colGroup: String, noDictionaryDims: Seq[String],
+      msrs: Seq[Field], retrievedColGrps: Seq[String], dims: Seq[Field]) {
+    val colGrpCols = colGroup.split(',').map(_.trim)
+    colGrpCols.foreach { x =>
+      // if column is no dictionary
+      if (noDictionaryDims.contains(x)) {
+        throw new MalformedCarbonCommandException(
+          "Column group is not supported for no dictionary columns:" + x)
+      } else if (msrs.filter { msr => msr.column.equals(x) }.size > 0) {
+        // if column is measure
+        throw new MalformedCarbonCommandException("Column group is not supported for measures:" + x)
+      } else if (foundIndExistingColGrp(x)) {
+        throw new MalformedCarbonCommandException("Column is available in other column group:" + x)
+      } else if (isComplex(x, dims)) {
+        throw new MalformedCarbonCommandException(
+          "Column group doesn't support Complex column:" + x)
+      } else if (isTimeStampColumn(x, dims)) {
+        throw new MalformedCarbonCommandException(
+          "Column group doesn't support Timestamp datatype:" + x)
+      }
+    }
+    // check if given column is present in other groups
+    def foundIndExistingColGrp(colName: String): Boolean = {
+      retrievedColGrps.foreach { colGrp =>
+        if (colGrp.split(",").contains(colName)) {
+          return true
+        }
+      }
+      false
+    }
+
+  }
+
+  def isTimeStampColumn(colName: String, dims: Seq[Field]): Boolean = {
+    dims.foreach { dim =>
+      if (dim.column.equalsIgnoreCase(colName)) {
+        if (None != dim.dataType && null != dim.dataType.get &&
+            "timestamp".equalsIgnoreCase(dim.dataType.get)) {
+          return true
+        }
+      }
+    }
+    false
+  }
+
+  def isComplex(colName: String, dims: Seq[Field]): Boolean = {
+    dims.foreach { x =>
+      if (None != x.children && null != x.children.get && x.children.get.size > 0) {
+        val children = x.children.get
+        if (x.column.equals(colName)) {
+          return true
+        } else {
+          children.foreach { child =>
+            val fieldName = x.column + "." + child.column
+            if (fieldName.equalsIgnoreCase(colName)) {
+              return true
+            }
+          }
+        }
+      }
+    }
+    false
+  }
+}


### PR DESCRIPTION
1.Measure should not be part of column group
2.No dictionary column should not be part of column group
3.same columname should not be specified two different column group
4.complex dimension should not be part of column group
6.timestamp should not be part of column group
7.Added test cases