### PR TITLE
[Bug 610]carbondatasourcerelation size issue fix

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
@@ -140,7 +140,12 @@ private[sql] case class CarbonDatasourceRelation(
                     carbonRelation.cubeMeta.carbonTableIdentifier.getDatabaseName +
                     CarbonCommonConstants.FILE_SEPARATOR +
                     carbonRelation.cubeMeta.carbonTableIdentifier.getTableName
-    FileFactory.getDirectorySize(tablePath)
+    val fileType = FileFactory.getFileType
+    if(FileFactory.isFileExist(tablePath, fileType)) {
+      FileFactory.getDirectorySize(tablePath)
+    } else {
+      0L
+    }
   }
 }
 


### PR DESCRIPTION
When table is dropped and user runs below command
"drop table if exists <tablename>"
carbon is giving issue while evaluating size as directory doesn't exist.

Fixe is made to check if directory exists than only evaluate size.