### PR TITLE
[Issue 513]Add tableId as part of CarbonTableIdentifier

### DIFF
--- a/core/src/main/java/org/carbondata/core/carbon/CarbonTableIdentifier.java
+++ b/core/src/main/java/org/carbondata/core/carbon/CarbonTableIdentifier.java
@@ -37,11 +37,17 @@ public class CarbonTableIdentifier implements Serializable {
   private String tableName;
 
   /**
+   * table id
+   */
+  private String tableId;
+
+  /**
    * constructor
    */
-  public CarbonTableIdentifier(String databaseName, String tableName) {
+  public CarbonTableIdentifier(String databaseName, String tableName, String tableId) {
     this.databaseName = databaseName;
     this.tableName = tableName;
+    this.tableId = tableId;
   }
 
   /**
@@ -59,41 +65,66 @@ public class CarbonTableIdentifier implements Serializable {
   }
 
   /**
+   * @return tableId
+   */
+  public String getTableId() {
+    return tableId;
+  }
+
+  /**
    * @return table unique name
    */
   public String getTableUniqueName() {
     return databaseName + '_' + tableName;
   }
 
-  /**
-   * overridden equals method
-   *
-   * @param other
-   * @return
-   */
-  @Override public boolean equals(Object other) {
-    if (this == other) return true;
-    if (other == null || getClass() != other.getClass()) return false;
-    CarbonTableIdentifier that = (CarbonTableIdentifier) other;
-    if (!databaseName.equals(that.databaseName)) return false;
-    return tableName.equals(that.tableName);
-
-  }
-
-  /**
-   * overridden hashcode method
-   *
-   * @return
-   */
   @Override public int hashCode() {
-    int result = databaseName.hashCode();
-    result = 31 * result + tableName.hashCode();
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((databaseName == null) ? 0 : databaseName.hashCode());
+    result = prime * result + ((tableId == null) ? 0 : tableId.hashCode());
+    result = prime * result + ((tableName == null) ? 0 : tableName.hashCode());
     return result;
   }
 
+  @Override public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    CarbonTableIdentifier other = (CarbonTableIdentifier) obj;
+    if (databaseName == null) {
+      if (other.databaseName != null) {
+        return false;
+      }
+    } else if (!databaseName.equals(other.databaseName)) {
+      return false;
+    }
+    if (tableId == null) {
+      if (other.tableId != null) {
+        return false;
+      }
+    } else if (!tableId.equals(other.tableId)) {
+      return false;
+    }
+    if (tableName == null) {
+      if (other.tableName != null) {
+        return false;
+      }
+    } else if (!tableName.equals(other.tableName)) {
+      return false;
+    }
+    return true;
+  }
+
   /*
-   * @return table unidque name
-   */
+ * @return table unidque name
+ */
   @Override public String toString() {
     return databaseName + '_' + tableName;
   }

--- a/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTable.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.carbondata.core.carbon.AbsoluteTableIdentifier;
+import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
@@ -41,9 +43,9 @@ public class CarbonTable implements Serializable {
   private static final long serialVersionUID = 8696507171227156445L;
 
   /**
-   * database name
+   * Absolute table identifier
    */
-  private String databaseName;
+  private AbsoluteTableIdentifier absoluteTableIdentifier;
 
   /**
    * TableName, Dimensions list
@@ -54,11 +56,6 @@ public class CarbonTable implements Serializable {
    * table measures list.
    */
   private Map<String, List<CarbonMeasure>> tableMeasuresMap;
-
-  /**
-   * TableName, Measures list.
-   */
-  private String factTableName;
 
   /**
    * tableUniqueName
@@ -76,11 +73,6 @@ public class CarbonTable implements Serializable {
   private String metaDataFilepath;
 
   /**
-   * Store path
-   */
-  private String storePath;
-
-  /**
    * last updated time
    */
   private long tableLastUpdatedTime;
@@ -96,11 +88,15 @@ public class CarbonTable implements Serializable {
    */
   public void loadCarbonTable(TableInfo tableInfo) {
     this.tableLastUpdatedTime = tableInfo.getLastUpdatedTime();
-    this.databaseName = tableInfo.getDatabaseName();
     this.tableUniqueName = tableInfo.getTableUniqueName();
-    this.factTableName = tableInfo.getFactTable().getTableName();
     this.metaDataFilepath = tableInfo.getMetaDataFilepath();
-    this.storePath = tableInfo.getStorePath();
+    //setting unique table identifier
+    CarbonTableIdentifier carbontableIdentifier =
+        new CarbonTableIdentifier(tableInfo.getDatabaseName(),
+            tableInfo.getFactTable().getTableName(), tableInfo.getFactTable().getTableId());
+    this.absoluteTableIdentifier =
+        new AbsoluteTableIdentifier(tableInfo.getStorePath(), carbontableIdentifier);
+
     fillDimensionsAndMeasuresForTables(tableInfo.getFactTable());
     List<TableSchema> aggregateTableList = tableInfo.getAggregateTableList();
     for (TableSchema aggTable : aggregateTableList) {
@@ -194,14 +190,14 @@ public class CarbonTable implements Serializable {
    * @return the databaseName
    */
   public String getDatabaseName() {
-    return databaseName;
+    return absoluteTableIdentifier.getCarbonTableIdentifier().getDatabaseName();
   }
 
   /**
    * @return the tabelName
    */
   public String getFactTableName() {
-    return factTableName;
+    return absoluteTableIdentifier.getCarbonTableIdentifier().getTableName();
   }
 
   /**
@@ -218,8 +214,11 @@ public class CarbonTable implements Serializable {
     return metaDataFilepath;
   }
 
+  /**
+   * @return storepath
+   */
   public String getStorePath() {
-    return storePath;
+    return absoluteTableIdentifier.getStorePath();
   }
 
   /**
@@ -350,17 +349,17 @@ public class CarbonTable implements Serializable {
   }
 
   /**
-   * @param databaseName
+   * @return absolute table identifier
    */
-  public void setDatabaseName(String databaseName) {
-    this.databaseName = databaseName;
+  public AbsoluteTableIdentifier getAbsoluteTableIdentifier() {
+    return absoluteTableIdentifier;
   }
 
   /**
-   * @param factTableName
+   * @return carbon table identifier
    */
-  public void setFactTableName(String factTableName) {
-    this.factTableName = factTableName;
+  public CarbonTableIdentifier getCarbonTableIdentifier() {
+    return absoluteTableIdentifier.getCarbonTableIdentifier();
   }
 
   /**

--- a/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/TableInfo.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/TableInfo.java
@@ -128,12 +128,12 @@ public class TableInfo implements Serializable {
     return null;
   }
 
-  public TableSchema getTableSchemaByTableId(int tableId) {
-    if (factTable.getTableId() == tableId) {
+  public TableSchema getTableSchemaByTableId(String tableId) {
+    if (factTable.getTableId().equals(tableId)) {
       return factTable;
     }
     for (TableSchema aggregatTableSchema : aggregateTableList) {
-      if (aggregatTableSchema.getTableId() == tableId) {
+      if (aggregatTableSchema.getTableId().equals(tableId)) {
         return aggregatTableSchema;
       }
     }

--- a/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/TableSchema.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/TableSchema.java
@@ -39,7 +39,7 @@ public class TableSchema implements Serializable {
   /**
    * table id
    */
-  private int tableId;
+  private String tableId;
 
   /**
    * table Name
@@ -63,14 +63,14 @@ public class TableSchema implements Serializable {
   /**
    * @return the tableId
    */
-  public int getTableId() {
+  public String getTableId() {
     return tableId;
   }
 
   /**
    * @param tableId the tableId to set
    */
-  public void setTableId(int tableId) {
+  public void setTableId(String tableId) {
     this.tableId = tableId;
   }
 
@@ -146,20 +146,14 @@ public class TableSchema implements Serializable {
     return null;
   }
 
-  /**
-   * to generate the hascode for this class instance
-   */
   @Override public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + tableId;
+    result = prime * result + ((tableId == null) ? 0 : tableId.hashCode());
     result = prime * result + ((tableName == null) ? 0 : tableName.hashCode());
     return result;
   }
 
-  /**
-   * equals method
-   */
   @Override public boolean equals(Object obj) {
     if (this == obj) {
       return true;
@@ -167,11 +161,15 @@ public class TableSchema implements Serializable {
     if (obj == null) {
       return false;
     }
-    if ((obj instanceof TableSchema)) {
+    if (getClass() != obj.getClass()) {
       return false;
     }
     TableSchema other = (TableSchema) obj;
-    if (tableId != other.tableId) {
+    if (tableId == null) {
+      if (other.tableId != null) {
+        return false;
+      }
+    } else if (!tableId.equals(other.tableId)) {
       return false;
     }
     if (tableName == null) {

--- a/core/src/main/java/org/carbondata/query/carbon/model/QueryModel.java
+++ b/core/src/main/java/org/carbondata/query/carbon/model/QueryModel.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import org.carbondata.core.cache.dictionary.Dictionary;
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.datastore.block.TableBlockInfo;
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonColumn;
@@ -185,9 +184,7 @@ public class QueryModel implements Serializable {
 
   private static void fillQueryModel(CarbonQueryPlan queryPlan, CarbonTable carbonTable,
       QueryModel queryModel, String factTableName) {
-    AbsoluteTableIdentifier currentTemp = queryModel.getAbsoluteTableIdentifier();
-    queryModel.setAbsoluteTableIdentifier(new AbsoluteTableIdentifier(currentTemp.getStorePath(),
-        new CarbonTableIdentifier(queryPlan.getSchemaName(), factTableName)));
+    queryModel.setAbsoluteTableIdentifier(carbonTable.getAbsoluteTableIdentifier());
     queryModel.setQueryDimension(queryPlan.getDimensions());
     fillSortInfoInModel(queryModel, queryPlan.getSortedDimemsions());
     queryModel.setQueryMeasures(

--- a/core/src/test/java/org/carbondata/core/cache/dictionary/ForwardDictionaryCacheTest.java
+++ b/core/src/test/java/org/carbondata/core/cache/dictionary/ForwardDictionaryCacheTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.carbondata.core.cache.Cache;
 import org.carbondata.core.cache.CacheProvider;
@@ -34,7 +35,6 @@ import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.util.CarbonProperties;
 import org.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriter;
 import org.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriterImpl;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +53,7 @@ public class ForwardDictionaryCacheTest extends AbstractDictionaryCacheTest {
     this.databaseName = props.getProperty("database", "testSchema");
     this.tableName = props.getProperty("tableName", "carbon");
     this.carbonStorePath = props.getProperty("storePath", "carbonStore");
-    carbonTableIdentifier = new CarbonTableIdentifier(databaseName, tableName);
+    carbonTableIdentifier = new CarbonTableIdentifier(databaseName, tableName, UUID.randomUUID().toString());
     columnIdentifiers = new String[] { "name", "place" };
     deleteStorePath();
     prepareDataSet();

--- a/core/src/test/java/org/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
+++ b/core/src/test/java/org/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -51,7 +52,7 @@ public class ReverseDictionaryCacheTest extends AbstractDictionaryCacheTest {
     this.databaseName = props.getProperty("database", "testSchema");
     this.tableName = props.getProperty("tableName", "carbon");
     this.carbonStorePath = props.getProperty("storePath", "carbonStore");
-    carbonTableIdentifier = new CarbonTableIdentifier(databaseName, tableName);
+    carbonTableIdentifier = new CarbonTableIdentifier(databaseName, tableName, UUID.randomUUID().toString());
     columnIdentifiers = new String[] { "name", "place" };
     deleteStorePath();
     prepareDataSet();

--- a/core/src/test/java/org/carbondata/core/carbon/metadata/CarbonMetadataTest.java
+++ b/core/src/test/java/org/carbondata/core/carbon/metadata/CarbonMetadataTest.java
@@ -131,7 +131,7 @@ public class CarbonMetadataTest extends TestCase {
     columnSchemaList.add(getColumnarDimensionColumn());
     columnSchemaList.add(getColumnarMeasureColumn());
     tableSchema.setListOfColumns(columnSchemaList);
-    tableSchema.setTableId(1);
+    tableSchema.setTableId(UUID.randomUUID().toString());
     tableSchema.setTableName("carbonTestTable");
     return tableSchema;
   }
@@ -142,6 +142,7 @@ public class CarbonMetadataTest extends TestCase {
     info.setLastUpdatedTime(timeStamp);
     info.setTableUniqueName("carbonTestDatabase_carbonTestTable");
     info.setFactTable(getTableSchema());
+    info.setStorePath("/test/store");
     return info;
   }
 }

--- a/core/src/test/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTableTest.java
+++ b/core/src/test/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTableTest.java
@@ -112,6 +112,7 @@ public class CarbonTableTest extends TestCase {
     info.setLastUpdatedTime(timeStamp);
     info.setTableUniqueName("carbonTestDatabase_carbonTestTable");
     info.setFactTable(getTableSchema());
+    info.setStorePath("testore");
     return info;
   }
 

--- a/core/src/test/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTableTest.java
+++ b/core/src/test/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTableTest.java
@@ -101,7 +101,7 @@ public class CarbonTableTest extends TestCase {
     columnSchemaList.add(getColumnarDimensionColumn());
     columnSchemaList.add(getColumnarMeasureColumn());
     tableSchema.setListOfColumns(columnSchemaList);
-    tableSchema.setTableId(1);
+    tableSchema.setTableId(UUID.randomUUID().toString());
     tableSchema.setTableName("carbonTestTable");
     return tableSchema;
   }

--- a/core/src/test/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTableWithComplexTypesTest.java
+++ b/core/src/test/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTableWithComplexTypesTest.java
@@ -141,7 +141,7 @@ public class CarbonTableWithComplexTypesTest extends TestCase {
     columnSchemaList.addAll(getColumnarDimensionColumn());
     columnSchemaList.add(getColumnarMeasureColumn());
     tableSchema.setListOfColumns(columnSchemaList);
-    tableSchema.setTableId(1);
+    tableSchema.setTableId(UUID.randomUUID().toString());
     tableSchema.setTableName("carbonTestTable");
     return tableSchema;
   }

--- a/core/src/test/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTableWithComplexTypesTest.java
+++ b/core/src/test/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTableWithComplexTypesTest.java
@@ -152,6 +152,7 @@ public class CarbonTableWithComplexTypesTest extends TestCase {
     info.setLastUpdatedTime(timeStamp);
     info.setTableUniqueName("carbonTestDatabase_carbonTestTable");
     info.setFactTable(getTableSchema());
+    info.setStorePath("testStore");
     return info;
   }
 

--- a/core/src/test/java/org/carbondata/core/path/CarbonFormatDirectoryStructureTest.java
+++ b/core/src/test/java/org/carbondata/core/path/CarbonFormatDirectoryStructureTest.java
@@ -20,11 +20,11 @@
 package org.carbondata.core.path;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.path.CarbonStorePath;
 import org.carbondata.core.carbon.path.CarbonTablePath;
-
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertTrue;
@@ -40,7 +40,7 @@ public class CarbonFormatDirectoryStructureTest {
    * test table path methods
    */
   @Test public void testTablePathStructure() throws IOException {
-    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("d1", "t1");
+    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("d1", "t1", UUID.randomUUID().toString());
     CarbonStorePath carbonStorePath = new CarbonStorePath(CARBON_STORE);
     CarbonTablePath carbonTablePath = carbonStorePath.getCarbonTablePath(tableIdentifier);
     assertTrue(carbonTablePath.getPath().equals(CARBON_STORE + "/d1/t1"));

--- a/core/src/test/java/org/carbondata/core/reader/sortindex/CarbonDictionarySortIndexReaderImplTest.java
+++ b/core/src/test/java/org/carbondata/core/reader/sortindex/CarbonDictionarySortIndexReaderImplTest.java
@@ -21,13 +21,13 @@ package org.carbondata.core.reader.sortindex;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.datastorage.store.filesystem.CarbonFile;
 import org.carbondata.core.datastorage.store.impl.FileFactory;
 import org.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriter;
 import org.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriterImpl;
-
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -56,7 +56,8 @@ public class CarbonDictionarySortIndexReaderImplTest {
    */
   @Test public void read() throws Exception {
     deleteStorePath();
-    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier("testSchema", "carbon");
+    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier("testSchema", "carbon",
+    		UUID.randomUUID().toString());
     CarbonDictionarySortIndexWriter dictionarySortIndexWriter =
         new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier, "Name", hdfsStorePath);
     List<int[]> expectedData = prepareExpectedData();

--- a/core/src/test/java/org/carbondata/core/writer/CarbonDictionaryWriterImplTest.java
+++ b/core/src/test/java/org/carbondata/core/writer/CarbonDictionaryWriterImplTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 
 import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.path.CarbonStorePath;
@@ -46,6 +47,7 @@ import org.carbondata.format.ColumnDictionaryChunkMeta;
 
 import mockit.Mock;
 import mockit.MockUp;
+
 import org.apache.thrift.TBase;
 import org.junit.After;
 import org.junit.Before;
@@ -95,7 +97,7 @@ public class CarbonDictionaryWriterImplTest {
     this.tableName = props.getProperty("tableName", "carbon");
     this.carbonStorePath = props.getProperty("storePath", "carbonStore");
     this.columnIdentifier = "Name";
-    carbonTableIdentifier = new CarbonTableIdentifier(databaseName, tableName);
+    carbonTableIdentifier = new CarbonTableIdentifier(databaseName, tableName, UUID.randomUUID().toString());
     deleteStorePath();
     prepareDataSet();
   }

--- a/core/src/test/java/org/carbondata/core/writer/sortindex/CarbonDictionarySortIndexWriterImplTest.java
+++ b/core/src/test/java/org/carbondata/core/writer/sortindex/CarbonDictionarySortIndexWriterImplTest.java
@@ -21,13 +21,13 @@ package org.carbondata.core.writer.sortindex;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.datastorage.store.filesystem.CarbonFile;
 import org.carbondata.core.datastorage.store.impl.FileFactory;
 import org.carbondata.core.reader.sortindex.CarbonDictionarySortIndexReader;
 import org.carbondata.core.reader.sortindex.CarbonDictionarySortIndexReaderImpl;
-
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -58,7 +58,7 @@ public class CarbonDictionarySortIndexWriterImplTest {
    */
   @Test public void write() throws Exception {
     String storePath = hdfsStorePath;
-    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier("testSchema", "carbon");
+    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier("testSchema", "carbon", UUID.randomUUID().toString());
     CarbonDictionarySortIndexWriter dictionarySortIndexWriter =
         new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier, "Name", storePath);
     List<int[]> indexList = prepareExpectedData();
@@ -83,7 +83,7 @@ public class CarbonDictionarySortIndexWriterImplTest {
    */
   @Test public void writingEmptyValue() throws Exception {
     String storePath = hdfsStorePath;
-    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier("testSchema", "carbon");
+    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier("testSchema", "carbon", UUID.randomUUID().toString());
     CarbonDictionarySortIndexWriter dictionarySortIndexWriter =
         new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier, "Name", storePath);
     List<Integer> sortIndex = new ArrayList<>();

--- a/examples/src/main/scala/org/carbondata/examples/GenerateDictionaryExample.scala
+++ b/examples/src/main/scala/org/carbondata/examples/GenerateDictionaryExample.scala
@@ -37,7 +37,7 @@ object GenerateDictionaryExample {
     val cc = InitForExamples.createCarbonContext("GenerateDictionaryExample")
     val factFilePath = InitForExamples.currentPath + "/src/main/resources/factSample.csv"
     val carbonTablePath = CarbonStorePath.getCarbonTablePath(InitForExamples.storeLocation,
-      new CarbonTableIdentifier("default", "dictSample"))
+      new CarbonTableIdentifier("default", "dictSample", "1"))
     val dictFolderPath = carbonTablePath.getMetadataDirectoryPath
 
     // execute sql statement
@@ -53,7 +53,7 @@ object GenerateDictionaryExample {
            """)
 
     // check generated dictionary
-    val tableIdentifier = new CarbonTableIdentifier("default", "dictSample")
+    val tableIdentifier = new CarbonTableIdentifier("default", "dictSample", "1")
     printDictionary(cc, tableIdentifier, dictFolderPath)
   }
 

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -111,7 +111,7 @@ struct SchemaEvolution{
 * The description of table schema
 */
 struct TableSchema{
-	1: required i32 table_id;  // ID used to
+	1: required string table_id;  // ID used to
 	2: required list<ColumnSchema> table_columns; // Columns in the table
 	3: required SchemaEvolution schema_evolution; // History of schema evolution of this table
 }

--- a/hadoop/src/main/java/org/carbondata/hadoop/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/carbondata/hadoop/CarbonInputFormat.java
@@ -96,10 +96,13 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String INPUT_SEGMENT_NUMBERS =
       "mapreduce.input.carboninputformat.segmentnumbers";
 
+  private static final String TABLE_ID = "mapreduce.input.carboninputformat.tableId";
+
   public static void setTableToAccess(Configuration configuration,
       CarbonTableIdentifier tableIdentifier) {
     configuration.set(CarbonInputFormat.DATABASE_NAME, tableIdentifier.getDatabaseName());
     configuration.set(CarbonInputFormat.TABLE_NAME, tableIdentifier.getTableName());
+    configuration.set(CarbonInputFormat.TABLE_ID, tableIdentifier.getTableId());
   }
 
   /**
@@ -125,8 +128,9 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
   public static CarbonTableIdentifier getTableToAccess(Configuration configuration) {
     String databaseName = configuration.get(CarbonInputFormat.DATABASE_NAME);
     String tableName = configuration.get(CarbonInputFormat.TABLE_NAME);
+    String tableId = configuration.get(CarbonInputFormat.TABLE_ID);
     if (databaseName != null && tableName != null) {
-      return new CarbonTableIdentifier(databaseName, tableName);
+      return new CarbonTableIdentifier(databaseName, tableName, tableId);
     }
     //TODO: better raise exception
     return null;

--- a/hadoop/src/test/java/org/carbondata/hadoop/ft/CarbonInputFormat_FT.java
+++ b/hadoop/src/test/java/org/carbondata/hadoop/ft/CarbonInputFormat_FT.java
@@ -21,6 +21,7 @@ package org.carbondata.hadoop.ft;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.hadoop.CarbonInputFormat;
@@ -31,6 +32,7 @@ import org.carbondata.query.expression.LiteralExpression;
 import org.carbondata.query.expression.conditional.EqualToExpression;
 
 import junit.framework.TestCase;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
@@ -51,7 +53,7 @@ public class CarbonInputFormat_FT extends TestCase {
     CarbonInputFormat carbonInputFormat = new CarbonInputFormat();
     JobConf jobConf = new JobConf(new Configuration());
     Job job = new Job(jobConf);
-    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("db", "table1");
+    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("db", "table1", UUID.randomUUID().toString());
     FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/"));
     carbonInputFormat.setTableToAccess(job.getConfiguration(), tableIdentifier);
     job.getConfiguration().set(CarbonInputFormat.INPUT_SEGMENT_NUMBERS, "1,2");
@@ -65,7 +67,7 @@ public class CarbonInputFormat_FT extends TestCase {
     CarbonInputFormat carbonInputFormat = new CarbonInputFormat();
     JobConf jobConf = new JobConf(new Configuration());
     Job job = new Job(jobConf);
-    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("db", "table1");
+    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("db", "table1", UUID.randomUUID().toString());
     FileInputFormat.addInputPath(job, new Path("/opt/carbonstore/"));
     carbonInputFormat.setTableToAccess(job.getConfiguration(), tableIdentifier);
     job.getConfiguration().set(CarbonInputFormat.INPUT_SEGMENT_NUMBERS, "1,2");

--- a/hadoop/src/test/java/org/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/carbondata/hadoop/test/util/StoreCreator.java
@@ -99,7 +99,7 @@ public class StoreCreator {
       String dbName = "testdb";
       String tableName = "testtable";
       absoluteTableIdentifier =
-          new AbsoluteTableIdentifier(storePath, new CarbonTableIdentifier(dbName, tableName));
+          new AbsoluteTableIdentifier(storePath, new CarbonTableIdentifier(dbName, tableName, UUID.randomUUID().toString()));
     } catch (IOException ex) {
 
     }
@@ -226,7 +226,7 @@ public class StoreCreator {
     SchemaEvolution schemaEvol = new SchemaEvolution();
     schemaEvol.setSchemaEvolutionEntryList(new ArrayList<SchemaEvolutionEntry>());
     tableSchema.setSchemaEvalution(schemaEvol);
-    tableSchema.setTableId(1);
+    tableSchema.setTableId(UUID.randomUUID().toString());
     tableInfo.setTableUniqueName(
         absoluteTableIdentifier.getCarbonTableIdentifier().getDatabaseName() + "_"
             + absoluteTableIdentifier.getCarbonTableIdentifier().getTableName());

--- a/hadoop/src/test/java/org/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/carbondata/hadoop/test/util/StoreCreator.java
@@ -146,6 +146,7 @@ public class StoreCreator {
 
   private static CarbonTable createTable() throws IOException {
     TableInfo tableInfo = new TableInfo();
+    tableInfo.setStorePath(absoluteTableIdentifier.getStorePath());
     tableInfo.setDatabaseName(absoluteTableIdentifier.getCarbonTableIdentifier().getDatabaseName());
     TableSchema tableSchema = new TableSchema();
     tableSchema.setTableName(absoluteTableIdentifier.getCarbonTableIdentifier().getTableName());
@@ -393,7 +394,7 @@ public class StoreCreator {
     }
     if (folder.isDirectory()) {
       File[] files = folder.listFiles();
-      for (int i = 0; i < file.length(); i++) {
+      for (int i = 0; i < files.length; i++) {
         if (!files[i].isDirectory() && files[i].getName().startsWith("part")) {
           factFile = files[i];
           break;

--- a/integration/spark/src/main/java/org/carbondata/integration/spark/merger/CarbonCompactionExecutor.java
+++ b/integration/spark/src/main/java/org/carbondata/integration/spark/merger/CarbonCompactionExecutor.java
@@ -27,8 +27,6 @@ import java.util.Set;
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.cache.dictionary.Dictionary;
-import org.carbondata.core.carbon.AbsoluteTableIdentifier;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.carbondata.core.carbon.datastore.block.TableBlockInfo;
 import org.carbondata.core.carbon.datastore.block.TaskBlockInfo;
@@ -190,8 +188,7 @@ public class CarbonCompactionExecutor {
 
     model.setQueryId(System.nanoTime() + "");
 
-    model.setAbsoluteTableIdentifier(new AbsoluteTableIdentifier(storePath,
-        new CarbonTableIdentifier(schemaName, factTableName)));
+    model.setAbsoluteTableIdentifier(carbonTable.getAbsoluteTableIdentifier());
 
     model.setAggTable(false);
     model.setLimit(-1);

--- a/integration/spark/src/main/java/org/carbondata/integration/spark/merger/CarbonCompactionUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/integration/spark/merger/CarbonCompactionUtil.java
@@ -28,7 +28,9 @@ import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.datastore.block.TableBlockInfo;
 import org.carbondata.core.carbon.datastore.block.TaskBlockInfo;
 import org.carbondata.core.carbon.datastore.exception.IndexBuilderException;
+import org.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.carbondata.core.carbon.metadata.blocklet.DataFileFooter;
+import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.path.CarbonStorePath;
 import org.carbondata.core.carbon.path.CarbonTablePath;
 import org.carbondata.core.constants.CarbonCommonConstants;
@@ -148,8 +150,8 @@ public class CarbonCompactionUtil {
     String tempLocationKey = schemaName + '_' + cubeName;
     String baseStorePath = CarbonProperties.getInstance()
         .getProperty(tempLocationKey, CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL);
-    CarbonTableIdentifier carbonTableIdentifier =
-        new CarbonTableIdentifier(schemaName, cubeName);
+    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(tempLocationKey);
+    CarbonTableIdentifier carbonTableIdentifier = carbonTable.getCarbonTableIdentifier();
     CarbonTablePath carbonTablePath =
         CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTableIdentifier);
     String partitionId = partitionID;

--- a/integration/spark/src/main/java/org/carbondata/integration/spark/merger/RowResultMerger.java
+++ b/integration/spark/src/main/java/org/carbondata/integration/spark/merger/RowResultMerger.java
@@ -32,6 +32,8 @@ import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.datastore.block.SegmentProperties;
+import org.carbondata.core.carbon.metadata.CarbonMetadata;
+import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
 import org.carbondata.core.carbon.path.CarbonStorePath;
 import org.carbondata.core.carbon.path.CarbonTablePath;
@@ -266,7 +268,9 @@ public class RowResultMerger {
   private String checkAndCreateCarbonStoreLocation(String factStoreLocation, String schemaName,
       String tableName, String partitionId, String segmentId) {
     String carbonStorePath = factStoreLocation;
-    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier(schemaName, tableName);
+    CarbonTable carbonTable = CarbonMetadata.getInstance()
+        .getCarbonTable(schemaName + CarbonCommonConstants.UNDERSCORE + tableName);
+    CarbonTableIdentifier carbonTableIdentifier = carbonTable.getCarbonTableIdentifier();
     CarbonTablePath carbonTablePath =
         CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier);
     String carbonDataDirectoryPath =

--- a/integration/spark/src/main/java/org/carbondata/spark/load/CarbonLoaderUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/load/CarbonLoaderUtil.java
@@ -32,6 +32,7 @@ import org.carbondata.core.cache.dictionary.DictionaryColumnUniqueIdentifier;
 import org.carbondata.core.carbon.CarbonDataLoadSchema;
 import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.datastore.block.TableBlockInfo;
+import org.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.carbondata.core.carbon.metadata.datatype.DataType;
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
@@ -405,7 +406,7 @@ public final class CarbonLoaderUtil {
     String databaseName = loadModel.getDatabaseName();
     String tableName = loadModel.getTableName();
     CarbonTableIdentifier carbonTableIdentifier =
-        new CarbonTableIdentifier(databaseName, tableName);
+        loadModel.getCarbonDataLoadSchema().getCarbonTable().getCarbonTableIdentifier();
     String segmentId = segmentName.substring(CarbonCommonConstants.LOAD_FOLDER.length());
     String tempLocationKey = databaseName + '_' + tableName;
     // form local store location
@@ -438,7 +439,7 @@ public final class CarbonLoaderUtil {
     String aggTableName = loadModel.getAggTableName();
     if (copyStore) {
       CarbonTableIdentifier carbonTableIdentifier =
-          new CarbonTableIdentifier(databaseName, tableName);
+          loadModel.getCarbonDataLoadSchema().getCarbonTable().getCarbonTableIdentifier();
       String segmentId = segmentName.substring(CarbonCommonConstants.LOAD_FOLDER.length());
       // form carbon store location
       String carbonStoreLocation = getStoreLocation(
@@ -733,7 +734,7 @@ public final class CarbonLoaderUtil {
       List<LoadMetadataDetails> listOfLoadFolderDetails) throws IOException {
     CarbonTablePath carbonTablePath = CarbonStorePath
         .getCarbonTablePath(schema.getCarbonTable().getStorePath(),
-            new CarbonTableIdentifier(schemaName, tableName));
+            schema.getCarbonTable().getCarbonTableIdentifier());
     String dataLoadLocation = carbonTablePath.getTableStatusFilePath();
 
     DataOutputStream dataOutputStream;
@@ -1218,7 +1219,9 @@ public final class CarbonLoaderUtil {
    */
   public static void checkAndCreateCarbonDataLocation(String carbonStorePath, String dbName,
       String tableName, int partitionCount, String segmentId) {
-    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier(dbName, tableName);
+    CarbonTable carbonTable = CarbonMetadata.getInstance()
+        .getCarbonTable(dbName + CarbonCommonConstants.UNDERSCORE + tableName);
+    CarbonTableIdentifier carbonTableIdentifier = carbonTable.getCarbonTableIdentifier();
     CarbonTablePath carbonTablePath =
         CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier);
     for (int i = 0; i < partitionCount; i++) {

--- a/integration/spark/src/main/java/org/carbondata/spark/load/DeleteLoadFolders.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/load/DeleteLoadFolders.java
@@ -37,7 +37,6 @@ import java.util.List;
 
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.path.CarbonStorePath;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.filesystem.CarbonFile;
@@ -133,7 +132,7 @@ public final class DeleteLoadFolders {
     String segmentId = oneLoad.getLoadName();
 
     path = new CarbonStorePath(storeLocation).getCarbonTablePath(
-        new CarbonTableIdentifier(loadModel.getDatabaseName(), loadModel.getTableName()))
+        loadModel.getCarbonDataLoadSchema().getCarbonTable().getCarbonTableIdentifier())
         .getCarbonDataDirectoryPath("" + partitionId, segmentId);
     return path;
   }

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -148,9 +148,7 @@ public final class CarbonDataMergerUtil {
       String mergeLoadStartTime) {
 
     AbsoluteTableIdentifier absoluteTableIdentifier =
-        new AbsoluteTableIdentifier(carbonLoadModel.getStorePath(),
-            new CarbonTableIdentifier(carbonLoadModel.getDatabaseName(),
-                carbonLoadModel.getTableName()));
+        carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable().getAbsoluteTableIdentifier();
 
     SegmentStatusManager segmentStatusManager = new SegmentStatusManager(absoluteTableIdentifier);
 
@@ -363,8 +361,7 @@ public final class CarbonDataMergerUtil {
         new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
 
     CarbonTableIdentifier tableIdentifier =
-        new CarbonTableIdentifier(carbonLoadModel.getDatabaseName(),
-            carbonLoadModel.getTableName());
+        carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable().getCarbonTableIdentifier();
 
     // variable to store one  segment size across partition.
     long sizeOfOneSegmentAcrossPartition = 0;

--- a/integration/spark/src/main/java/org/carbondata/spark/util/LoadMetadataUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/util/LoadMetadataUtil.java
@@ -30,8 +30,6 @@ package org.carbondata.spark.util;
 
 import java.io.File;
 
-import org.carbondata.core.carbon.AbsoluteTableIdentifier;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.filesystem.CarbonFile;
@@ -51,11 +49,8 @@ public final class LoadMetadataUtil {
         .getCarbonTable(loadModel.getDatabaseName() + '_' + loadModel.getTableName());
 
     String metaDataLocation = cube.getMetaDataFilepath();
-    SegmentStatusManager segmentStatusManager = new SegmentStatusManager(
-        new AbsoluteTableIdentifier(
-            loadModel.getStorePath(),
-            new CarbonTableIdentifier(loadModel.getDatabaseName(),
-                loadModel.getTableName())));
+    SegmentStatusManager segmentStatusManager =
+        new SegmentStatusManager(cube.getAbsoluteTableIdentifier());
     LoadMetadataDetails[] details = segmentStatusManager.readLoadMetadata(metaDataLocation);
     if (details != null && details.length != 0) {
       for (LoadMetadataDetails oneRow : details) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -53,7 +53,7 @@ private[sql] case class CarbonDatasourceHadoopRelation(sqlContext: SQLContext,
     val options = new CarbonOption(parameters)
     val job: Job = new Job(new JobConf())
     FileInputFormat.setInputPaths(job, paths.head)
-    val identifier = new CarbonTableIdentifier(options.dbName, options.tableName)
+    val identifier = new CarbonTableIdentifier(options.dbName, options.tableName, options.tableId)
     CarbonInputFormat.setTableToAccess(job.getConfiguration, identifier)
     val table = CarbonInputFormat.getCarbonTable(job.getConfiguration)
     if(table == null) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -130,8 +130,7 @@ case class CarbonDictionaryDecoder(
       val storePath = sqlContext.catalog.asInstanceOf[CarbonMetastoreCatalog].storePath
       val absoluteTableIdentifiers = relations.map { relation =>
         val carbonTable = relation.carbonRelation.carbonRelation.metaData.carbonTable
-        (carbonTable.getFactTableName, new AbsoluteTableIdentifier(storePath,
-          new CarbonTableIdentifier(carbonTable.getDatabaseName, carbonTable.getFactTableName)))
+        (carbonTable.getFactTableName, carbonTable.getAbsoluteTableIdentifier)
       }.toMap
 
       if (isRequiredToDecode) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonOperators.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.hive.CarbonMetastoreCatalog
 import org.apache.spark.unsafe.types.UTF8String
 
 import org.carbondata.common.logging.LogServiceFactory
-import org.carbondata.core.carbon.{AbsoluteTableIdentifier, CarbonTableIdentifier}
+import org.carbondata.core.carbon.{AbsoluteTableIdentifier}
 import org.carbondata.core.constants.CarbonCommonConstants
 import org.carbondata.core.util.CarbonProperties
 import org.carbondata.hadoop.CarbonInputFormat
@@ -486,8 +486,7 @@ case class CarbonTableScan(
     }
 
     val conf = new Configuration()
-    val absoluteTableIdentifier = new AbsoluteTableIdentifier(carbonCatalog.storePath,
-      new CarbonTableIdentifier(carbonTable.getDatabaseName, carbonTable.getFactTableName))
+    val absoluteTableIdentifier = carbonTable.getAbsoluteTableIdentifier
 
     val model = QueryModel.createModel(
       absoluteTableIdentifier, buildCarbonPlan, carbonTable)
@@ -522,9 +521,7 @@ case class CarbonTableScan(
     }
     // count(*) query executed in driver by querying from Btree
     if (isCountQuery) {
-      val absoluteTableIdentifier = new AbsoluteTableIdentifier(carbonCatalog.storePath,
-        new CarbonTableIdentifier(carbonTable.getDatabaseName, carbonTable.getFactTableName)
-      )
+      val absoluteTableIdentifier = carbonTable.getAbsoluteTableIdentifier
       val (carbonInputFormat: CarbonInputFormat[RowResult], job: Job) =
         QueryPlanUtil.createCarbonInputFormat(absoluteTableIdentifier)
       // get row count

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonRawOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonRawOperators.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.hive.CarbonMetastoreCatalog
 import org.apache.spark.sql.types.{DataType, Decimal}
 import org.apache.spark.unsafe.types.UTF8String
 
-import org.carbondata.core.carbon.{AbsoluteTableIdentifier, CarbonTableIdentifier}
+import org.carbondata.core.carbon.{AbsoluteTableIdentifier}
 import org.carbondata.core.constants.CarbonCommonConstants
 import org.carbondata.core.util.CarbonProperties
 import org.carbondata.query.carbon.model._
@@ -184,10 +184,7 @@ case class CarbonRawTableScan(
   def inputRdd: CarbonRawQueryRDD[BatchRawResult, Any] = {
 
     val conf = new Configuration()
-    val absoluteTableIdentifier =
-      new AbsoluteTableIdentifier(carbonCatalog.storePath,
-        new CarbonTableIdentifier(carbonTable.getDatabaseName,
-          carbonTable.getFactTableName))
+    val absoluteTableIdentifier = carbonTable.getAbsoluteTableIdentifier
     buildCarbonPlan.getDimAggregatorInfos.clear()
     val model = QueryModel.createModel(
       absoluteTableIdentifier, buildCarbonPlan, carbonTable)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -132,7 +132,7 @@ case class DataLoadTableFileMapping(table: String, loadPath: String)
 case class CarbonMergerMapping(storeLocation: String, hdfsStoreLocation: String,
   partitioner: Partitioner, metadataFilePath: String, mergedLoadName: String,
   kettleHomePath: String, cubeCreationTime: Long, schemaName: String,
-  factTableName: String, validSegments: Array[String])
+  factTableName: String, validSegments: Array[String], tableId: String)
 
 object TableNewProcessor {
   def apply(cm: tableModel, sqlContext: SQLContext): TableInfo = {
@@ -351,7 +351,7 @@ class TableNewProcessor(cm: tableModel, sqlContext: SQLContext) {
     val schemaEvol = new SchemaEvolution()
     schemaEvol
       .setSchemaEvolutionEntryList(new util.ArrayList[SchemaEvolutionEntry]())
-    tableSchema.setTableId(1)
+    tableSchema.setTableId(UUID.randomUUID().toString)
     tableSchema.setTableName(cm.cubeName)
     tableSchema.setListOfColumns(allColumns.asJava)
     tableSchema.setSchemaEvalution(schemaEvol)
@@ -1257,8 +1257,7 @@ private[sql] case class DeleteLoadsById(
     val path = carbonTable.getMetaDataFilepath
 
     var segmentStatusManager =
-      new SegmentStatusManager(new AbsoluteTableIdentifier(
-        carbonTable.getStorePath, new CarbonTableIdentifier(schemaName, tableName)))
+      new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
 
     val invalidLoadIds = segmentStatusManager.updateDeletionStatus(loadids.asJava, path).asScala
 
@@ -1322,8 +1321,7 @@ private[sql] case class DeleteLoadsByLoadDate(
 
     var carbonTable = org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance()
       .getCarbonTable(schemaName + '_' + tableName)
-    var segmentStatusManager = new SegmentStatusManager(new AbsoluteTableIdentifier(
-        carbonTable.getStorePath, new CarbonTableIdentifier(schemaName, tableName)))
+    var segmentStatusManager = new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
 
     if (null == carbonTable) {
       var relation = CarbonEnv.getInstance(sqlContext).carbonCatalog.lookupRelation1(
@@ -1817,16 +1815,15 @@ private[sql] case class ShowLoads(
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
     val schemaName = getDB.getDatabaseName(schemaNameOp, sqlContext)
-    val tableIdentifier = new CarbonTableIdentifier(schemaName, tableName)
+    val tableUniqueName = schemaName + "_" + tableName
     val carbonTable = org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance()
-      .getCarbonTable(tableIdentifier.getTableUniqueName)
+      .getCarbonTable(tableUniqueName)
     if (carbonTable == null) {
       sys.error(s"$schemaName.$tableName is not found")
     }
     val path = carbonTable.getMetaDataFilepath()
 
-    var segmentStatusManager = new SegmentStatusManager(new AbsoluteTableIdentifier(
-      carbonTable.getStorePath, new CarbonTableIdentifier(schemaName, tableName)))
+    var segmentStatusManager = new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
 
     val loadMetadataDetailsArray = segmentStatusManager.readLoadMetadata(path)
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/CarbonOption.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/CarbonOption.scala
@@ -27,6 +27,8 @@ class CarbonOption(options: Map[String, String]) {
 
   def tableName: String = options.getOrElse("tableName", "default_table")
 
+  def tableId: String = options.getOrElse("tableId", "default_table_id")
+
   def partitionCount: String = options.getOrElse("partitionCount", "1")
 
   def partitionClass: String = {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -127,10 +127,7 @@ object CarbonDataRDDFactory extends Logging {
     if (-1 == currentRestructNumber) {
       currentRestructNumber = 0
     }
-    var segmentStatusManager = new SegmentStatusManager(
-      new AbsoluteTableIdentifier(
-        cube.getStorePath,
-        new CarbonTableIdentifier(schemaName, tableName)))
+    var segmentStatusManager = new SegmentStatusManager(cube.getAbsoluteTableIdentifier)
     val loadMetadataDetailsArray = segmentStatusManager.readLoadMetadata(cube.getMetaDataFilepath())
       .toList
     val resultMap = new CarbonDeleteLoadByDateRDD(
@@ -329,14 +326,12 @@ object CarbonDataRDDFactory extends Logging {
             cubeCreationTime,
             schemaName,
             factTableName,
-            validSegments
+            validSegments,
+            carbonTable.getCarbonTableIdentifier.getTableId
           )
           carbonLoadModel.setStorePath(carbonMergerMapping.hdfsStoreLocation)
-          val segmentStatusManager = new SegmentStatusManager(new AbsoluteTableIdentifier
-          (CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION),
-            new CarbonTableIdentifier(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)
-          )
-          )
+          val segmentStatusManager = new SegmentStatusManager(carbonTable
+            .getAbsoluteTableIdentifier)
           carbonLoadModel.setLoadMetadataDetails(segmentStatusManager
             .readLoadMetadata(carbonTable.getMetaDataFilepath()).toList.asJava
           )
@@ -633,12 +628,11 @@ object CarbonDataRDDFactory extends Logging {
 
   }
 
-   def readLoadMetadataDetails(model: CarbonLoadModel, hdfsStoreLocation: String): Unit = {
+  def readLoadMetadataDetails(model: CarbonLoadModel, hdfsStoreLocation: String): Unit = {
     val metadataPath = model.getCarbonDataLoadSchema.getCarbonTable.getMetaDataFilepath
-    var segmentStatusManager = new SegmentStatusManager(
-      new AbsoluteTableIdentifier(
-        model.getStorePath,
-        new CarbonTableIdentifier(model.getDatabaseName, model.getTableName)))
+    var segmentStatusManager = new SegmentStatusManager(model.getCarbonDataLoadSchema.getCarbonTable
+      .
+        getAbsoluteTableIdentifier)
     val details = segmentStatusManager.readLoadMetadata(metadataPath)
     model.setLoadMetadataDetails(details.toList.asJava)
   }
@@ -652,12 +646,7 @@ object CarbonDataRDDFactory extends Logging {
     if (LoadMetadataUtil.isLoadDeletionRequired(carbonLoadModel)) {
       val loadMetadataFilePath = CarbonLoaderUtil
         .extractLoadMetadataFileLocation(carbonLoadModel)
-      val segmentStatusManager = new SegmentStatusManager(
-        new AbsoluteTableIdentifier(
-          cube.getStorePath,
-          new CarbonTableIdentifier(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)
-        )
-      )
+      val segmentStatusManager = new SegmentStatusManager(cube.getAbsoluteTableIdentifier)
       val details = segmentStatusManager
         .readLoadMetadata(loadMetadataFilePath)
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -60,6 +60,7 @@ class CarbonMergerRDD[K, V](
   val mergedLoadName = carbonMergerMapping.mergedLoadName
   val schemaName = carbonMergerMapping.schemaName
   val factTableName = carbonMergerMapping.factTableName
+  val tableId = carbonMergerMapping.tableId
   override def compute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
     val iter = new Iterator[(K, V)] {
@@ -173,7 +174,7 @@ class CarbonMergerRDD[K, V](
   override def getPartitions: Array[Partition] = {
     val startTime = System.currentTimeMillis()
     val absoluteTableIdentifier: AbsoluteTableIdentifier = new AbsoluteTableIdentifier(
-      hdfsStoreLocation, new CarbonTableIdentifier(schemaName, factTableName)
+      hdfsStoreLocation, new CarbonTableIdentifier(schemaName, factTableName, tableId)
     )
     val (carbonInputFormat: CarbonInputFormat[RowResult], job: Job) =
       QueryPlanUtil.createCarbonInputFormat(absoluteTableIdentifier)

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -370,7 +370,7 @@ object GlobalDictionaryUtil extends Logging {
                                   noDictDimension: Array[CarbonDimension]): Unit = {
 
     val carbonTablePath = CarbonStorePath.getCarbonTablePath(model.hdfsLocation,
-      new CarbonTableIdentifier(model.table.getDatabaseName, model.table.getTableName))
+      model.table)
     val schemaFilePath = carbonTablePath.getSchemaFilePath
 
     // read TableInfo
@@ -440,8 +440,8 @@ object GlobalDictionaryUtil extends Logging {
       carbonLoadModel: CarbonLoadModel,
       hdfsLocation: String): Unit = {
     try {
-      val table = new CarbonTableIdentifier(carbonLoadModel.getDatabaseName,
-        carbonLoadModel.getTableName)
+      val table = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.getAbsoluteTableIdentifier
+        .getCarbonTableIdentifier
 
       // create dictionary folder if not exists
       val carbonTablePath = CarbonStorePath.getCarbonTablePath(hdfsLocation, table)

--- a/integration/spark/src/test/scala/org/carbondata/integration/spark/testsuite/complexType/TestCreateTableWithDouble.scala
+++ b/integration/spark/src/test/scala/org/carbondata/integration/spark/testsuite/complexType/TestCreateTableWithDouble.scala
@@ -76,7 +76,7 @@ class TestCreateTableWithDouble extends QueryTest with BeforeAndAfterAll {
       case e : Throwable => fail(e)
     }
     // assert that field 'number' is a dimension
-    val tableIdentifier = new CarbonTableIdentifier("default", "doubleComplex2")
+    val tableIdentifier = new CarbonTableIdentifier("default", "doubleComplex2", "uniqueid")
     val carbonTable = org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance()
       .getCarbonTable(tableIdentifier.getTableUniqueName)
     val dimExist = carbonTable.getDimensionByTableName("doubleComplex2").toArray.

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
@@ -82,7 +82,7 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
     val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
         AbsoluteTableIdentifier(
           CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
-          new CarbonTableIdentifier("default", "noDictionaryCompaction")
+          new CarbonTableIdentifier("default", "noDictionaryCompaction", "1")
         )
     )
     // merged segment should not be there

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
@@ -90,7 +90,7 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
     val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
         AbsoluteTableIdentifier(
           CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
-          new CarbonTableIdentifier("default", "normalcompaction")
+          new CarbonTableIdentifier("default", "normalcompaction", "uniqueid")
         )
     )
     // merged segment should not be there

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
@@ -49,7 +49,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
 
   val storeLocation = new File(this.getClass.getResource("/").getPath + "/../test").getCanonicalPath
   val carbonTableIdentifier: CarbonTableIdentifier =
-    new CarbonTableIdentifier("default", "DataRetentionTable")
+    new CarbonTableIdentifier("default", "DataRetentionTable", "1")
   val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
       AbsoluteTableIdentifier(storeLocation, carbonTableIdentifier))
   val carbontablePath = CarbonStorePath.getCarbonTablePath(storeLocation, carbonTableIdentifier)

--- a/integration/spark/src/test/scala/org/carbondata/spark/util/AutoHighCardinalityIdentifyTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/util/AutoHighCardinalityIdentifyTestCase.scala
@@ -114,7 +114,7 @@ class AutoHighCardinalityIdentifyTestCase extends QueryTest with BeforeAndAfterA
   
   private def checkDictFile(table: CarbonTable) = {
     val tableIdentifier = new CarbonTableIdentifier(table.getDatabaseName,
-        table.getFactTableName)
+        table.getFactTableName, "1")
     val carbonTablePath = CarbonStorePath.getCarbonTablePath(CarbonHiveContext.hdfsCarbonBasePath,
         tableIdentifier)
     val newHc1 = table.getDimensionByName("highcard", "hc1")

--- a/integration/spark/src/test/scala/org/carbondata/spark/util/GlobalDictionaryUtilTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/util/GlobalDictionaryUtilTestCase.scala
@@ -161,7 +161,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
   def checkDictionary(relation: CarbonRelation, columnName: String, value: String) {
     val table = relation.cubeMeta.carbonTable
     val dimension = table.getDimensionByName(table.getFactTableName, columnName)
-    val tableIdentifier = new CarbonTableIdentifier(table.getDatabaseName, table.getFactTableName)
+    val tableIdentifier = new CarbonTableIdentifier(table.getDatabaseName, table.getFactTableName, "uniqueid")
 
     val columnIdentifier = new DictionaryColumnUniqueIdentifier(tableIdentifier,
       dimension.getColumnId, dimension.getDataType

--- a/processing/src/main/java/org/carbondata/processing/mdkeygen/MDKeyGenStep.java
+++ b/processing/src/main/java/org/carbondata/processing/mdkeygen/MDKeyGenStep.java
@@ -31,7 +31,6 @@ import java.util.Map.Entry;
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.common.logging.impl.StandardLogService;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
@@ -243,10 +242,10 @@ public class MDKeyGenStep extends BaseStep {
     String tempLocationKey = meta.getSchemaName() + '_' + meta.getCubeName();
     String baseStorePath = CarbonProperties.getInstance()
         .getProperty(tempLocationKey, CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL);
-    CarbonTableIdentifier carbonTableIdentifier =
-        new CarbonTableIdentifier(meta.getSchemaName(), meta.getCubeName());
+    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(
+        meta.getSchemaName() + CarbonCommonConstants.UNDERSCORE + meta.getTableName());
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTableIdentifier);
+        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTable.getCarbonTableIdentifier());
     String partitionId = meta.getPartitionID();
     String carbonDataDirectoryPath = carbonTablePath.getCarbonDataDirectoryPath(partitionId,
         meta.getSegmentId()+"");
@@ -480,12 +479,12 @@ public class MDKeyGenStep extends BaseStep {
   private String getCarbonDataFolderLocation() {
     String carbonStorePath =
         CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION_HDFS);
-    CarbonTableIdentifier carbonTableIdentifier =
-        new CarbonTableIdentifier(meta.getSchemaName(), meta.getTableName());
+    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(
+        meta.getSchemaName() + CarbonCommonConstants.UNDERSCORE + meta.getTableName());
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier);
+        CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTable.getCarbonTableIdentifier());
     String carbonDataDirectoryPath =
-        carbonTablePath.getCarbonDataDirectoryPath(meta.getPartitionID(), meta.getSegmentId()+"");
+        carbonTablePath.getCarbonDataDirectoryPath(meta.getPartitionID(), meta.getSegmentId() + "");
     return carbonDataDirectoryPath;
   }
 

--- a/processing/src/main/java/org/carbondata/processing/merger/step/CarbonSliceMergerStep.java
+++ b/processing/src/main/java/org/carbondata/processing/merger/step/CarbonSliceMergerStep.java
@@ -24,7 +24,8 @@ import java.io.File;
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.common.logging.impl.StandardLogService;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
+import org.carbondata.core.carbon.metadata.CarbonMetadata;
+import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.path.CarbonStorePath;
 import org.carbondata.core.carbon.path.CarbonTablePath;
 import org.carbondata.core.constants.CarbonCommonConstants;
@@ -161,10 +162,10 @@ public class CarbonSliceMergerStep extends BaseStep {
     String tempLocationKey = meta.getSchemaName() + '_' + meta.getCubeName();
     String baseStorePath = CarbonProperties.getInstance()
         .getProperty(tempLocationKey, CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL);
-    CarbonTableIdentifier carbonTableIdentifier =
-        new CarbonTableIdentifier(meta.getSchemaName(), meta.getCubeName());
+    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(
+        meta.getSchemaName() + CarbonCommonConstants.UNDERSCORE + meta.getCubeName());
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTableIdentifier);
+        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTable.getCarbonTableIdentifier());
     String partitionId = meta.getPartitionID();
     String carbonDataDirectoryPath = carbonTablePath.getCarbonDataDirectoryPath(partitionId,
         meta.getSegmentId()+"");

--- a/processing/src/main/java/org/carbondata/processing/sortandgroupby/sortdata/SortDataRows.java
+++ b/processing/src/main/java/org/carbondata/processing/sortandgroupby/sortdata/SortDataRows.java
@@ -36,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
@@ -530,9 +529,10 @@ public class SortDataRows {
     String tempLocationKey = schemaName + '_' + cubeName;
     String baseStorePath = CarbonProperties.getInstance()
         .getProperty(tempLocationKey, CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL);
-    CarbonTableIdentifier carbonTableIdentifier = new CarbonTableIdentifier(schemaName, cubeName);
+    CarbonTable carbonTable = CarbonMetadata.getInstance()
+        .getCarbonTable(schemaName + CarbonCommonConstants.UNDERSCORE + cubeName);
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTableIdentifier);
+        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTable.getCarbonTableIdentifier());
     String carbonDataDirectoryPath =
         carbonTablePath.getCarbonDataDirectoryPath(partitionID, segmentId);
     this.tempFileLocation = carbonDataDirectoryPath + File.separator + taskNo

--- a/processing/src/main/java/org/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -39,9 +39,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
+import org.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.carbondata.core.carbon.metadata.converter.SchemaConverter;
 import org.carbondata.core.carbon.metadata.converter.ThriftWrapperSchemaConverterImpl;
+import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.metadata.schema.table.column.ColumnSchema;
 import org.carbondata.core.carbon.path.CarbonStorePath;
 import org.carbondata.core.carbon.path.CarbonTablePath;
@@ -61,6 +62,7 @@ import org.carbondata.processing.store.CarbonDataFileAttributes;
 import org.carbondata.processing.store.writer.exception.CarbonDataWriterException;
 
 import org.apache.commons.lang3.ArrayUtils;
+
 import org.apache.hadoop.io.IOUtils;
 
 public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<T>
@@ -196,8 +198,10 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     // in case of compaction we will pass the cardinality.
     this.localCardinality = colCardinality;
     this.carbonDataFileAttributes = carbonDataFileAttributes;
-    CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier(databaseName, tableName);
-    carbonTablePath = CarbonStorePath.getCarbonTablePath(storeLocation, tableIdentifier);
+    CarbonTable carbonTable = CarbonMetadata.getInstance()
+        .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
+    carbonTablePath =
+        CarbonStorePath.getCarbonTablePath(storeLocation, carbonTable.getCarbonTableIdentifier());
     //TODO: We should delete the levelmetadata file after reading here.
     // so only data loading flow will need to read from cardinality file.
     if (null == this.localCardinality) {

--- a/processing/src/main/java/org/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -165,7 +165,7 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
   private FileOutputStream fileOutputStream;
 
   public AbstractFactDataWriter(String storeLocation, int measureCount, int mdKeyLength,
-      String tableName, IFileManagerComposite fileManager, int[] keyBlockSize,
+      String databaseName, String tableName, IFileManagerComposite fileManager, int[] keyBlockSize,
       CarbonDataFileAttributes carbonDataFileAttributes, List<ColumnSchema> columnSchema,
       String carbonDataDirectoryPath, int[] colCardinality) {
 
@@ -173,6 +173,7 @@ public abstract class AbstractFactDataWriter<T> implements CarbonFactDataWriter<
     this.measureCount = measureCount;
     // table name
     this.tableName = tableName;
+    this.databaseName = databaseName;
 
     this.storeLocation = storeLocation;
     this.blockletInfoList =

--- a/processing/src/main/java/org/carbondata/processing/store/writer/CarbonFactDataWriterImplForIntIndexAndAggBlock.java
+++ b/processing/src/main/java/org/carbondata/processing/store/writer/CarbonFactDataWriterImplForIntIndexAndAggBlock.java
@@ -51,8 +51,9 @@ public class CarbonFactDataWriterImplForIntIndexAndAggBlock extends AbstractFact
       CarbonDataFileAttributes carbonDataFileAttributes, String databaseName,
       List<ColumnSchema> wrapperColumnSchemaList, int numberOfNoDictionaryColumn,
       boolean[] isDictionaryColumn, String carbonDataDirectoryPath, int[] colCardinality) {
-    super(storeLocation, measureCount, mdKeyLength, tableName, fileManager, keyBlockSize,
-        carbonDataFileAttributes, wrapperColumnSchemaList, carbonDataDirectoryPath, colCardinality);
+    super(storeLocation, measureCount, mdKeyLength, databaseName, tableName, fileManager,
+        keyBlockSize, carbonDataFileAttributes, wrapperColumnSchemaList, carbonDataDirectoryPath,
+        colCardinality);
     this.isComplexType = isComplexType;
     this.databaseName = databaseName;
     this.numberOfNoDictionaryColumn = numberOfNoDictionaryColumn;

--- a/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
+++ b/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenStep.java
@@ -45,7 +45,6 @@ import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.common.logging.impl.StandardLogService;
 import org.carbondata.core.cache.dictionary.Dictionary;
-import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.metadata.CarbonMetadata;
 import org.carbondata.core.carbon.metadata.datatype.DataType;
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
@@ -657,10 +656,10 @@ public class CarbonCSVBasedSeqGenStep extends BaseStep {
     String tempLocationKey = meta.getSchemaName() + '_' + meta.getCubeName();
     String baseStorePath = CarbonProperties.getInstance()
         .getProperty(tempLocationKey, CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL);
-    CarbonTableIdentifier carbonTableIdentifier =
-        new CarbonTableIdentifier(meta.getSchemaName(), meta.getCubeName());
+    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(
+        meta.getSchemaName() + CarbonCommonConstants.UNDERSCORE + meta.getTableName());
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTableIdentifier);
+        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTable.getCarbonTableIdentifier());
     String partitionId = meta.getPartitionID();
     String carbonDataDirectoryPath = carbonTablePath.getCarbonDataDirectoryPath(partitionId,
         meta.getSegmentId()+"");

--- a/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/FileStoreSurrogateKeyGenForCSV.java
+++ b/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/FileStoreSurrogateKeyGenForCSV.java
@@ -35,6 +35,8 @@ import org.carbondata.core.cache.CacheType;
 import org.carbondata.core.cache.dictionary.Dictionary;
 import org.carbondata.core.cache.dictionary.DictionaryColumnUniqueIdentifier;
 import org.carbondata.core.carbon.CarbonTableIdentifier;
+import org.carbondata.core.carbon.metadata.CarbonMetadata;
+import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.path.CarbonStorePath;
 import org.carbondata.core.carbon.path.CarbonTablePath;
 import org.carbondata.core.constants.CarbonCommonConstants;
@@ -189,12 +191,12 @@ public class FileStoreSurrogateKeyGenForCSV extends CarbonCSVBasedDimSurrogateKe
 
   private String checkAndCreateLoadFolderNumber(String baseStorePath, String databaseName,
       String tableName) throws KettleException {
-    CarbonTableIdentifier carbonTableIdentifier =
-        new CarbonTableIdentifier(databaseName, tableName);
+    CarbonTable carbonTable = CarbonMetadata.getInstance()
+        .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTableIdentifier);
+        CarbonStorePath.getCarbonTablePath(baseStorePath, carbonTable.getCarbonTableIdentifier());
     String carbonDataDirectoryPath =
-        carbonTablePath.getCarbonDataDirectoryPath(this.partitionID, this.segmentId+"");
+        carbonTablePath.getCarbonDataDirectoryPath(this.partitionID, this.segmentId + "");
     carbonDataDirectoryPath = carbonDataDirectoryPath + File.separator + taskNo;
     carbonDataDirectoryPath =
         carbonDataDirectoryPath + CarbonCommonConstants.FILE_INPROGRESS_STATUS;
@@ -224,8 +226,9 @@ public class FileStoreSurrogateKeyGenForCSV extends CarbonCSVBasedDimSurrogateKe
     String[] dimColumnIds = columnsInfo.getDimensionColumnIds();
     String databaseName = columnsInfo.getSchemaName();
     String tableName = columnsInfo.getTableName();
-    CarbonTableIdentifier carbonTableIdentifier =
-        new CarbonTableIdentifier(databaseName, tableName);
+    CarbonTable carbonTable = CarbonMetadata.getInstance()
+        .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
+    CarbonTableIdentifier carbonTableIdentifier = carbonTable.getCarbonTableIdentifier();
     CacheProvider cacheProvider = CacheProvider.getInstance();
     Cache reverseDictionaryCache =
         cacheProvider.createCache(CacheType.REVERSE_DICTIONARY, carbonStorePath);


### PR DESCRIPTION
1.Changed tableId to string from int in schema.thrift
2.Added tableId in CarbonTableIdentifier
3.Made CarbonTable as hub to get carbonTableIdentifier or absoluteTableIdentifier

Impact: Since thrift file is changed for schema. Hence old cube will not work. We need to provide utility to change old schema as per this change.