### PR TITLE
[Issue-578] Threaded compaction

### DIFF
--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -1047,15 +1047,6 @@ public final class CarbonCommonConstants {
   public static final String INVALID_SEGMENT_ID = "-1";
 
   /**
-   * This property will preserve the latest segments from merge.
-   */
-  public static final String PRESERVE_LATEST_SEGMENTS = "carbon.preserve.latest.segments";
-  /**
-   * By default this property of preserving the segments will be false
-   */
-  public static final String DEFAULT_PRESERVE_LATEST_SEGMENTS = "false";
-
-  /**
    * Size of Minor Compaction in MBs
    */
   public static final String MINOR_COMPACTION_SIZE = "carbon.minor.compaction.size";
@@ -1084,18 +1075,7 @@ public final class CarbonCommonConstants {
   /**
    * If preserve property is enabled then 2 segments will be preserved.
    */
-  public static final String DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER = "2";
-
-  /**
-   * To determine if the compaction need to consider the load start date.
-   */
-  public static final java.lang.String ENABLE_COMPACTION_BASED_ON_DATE =
-      "carbon.enable.date.based.compaction";
-
-  /**
-   * Default property of the date based compaction.default will be false.
-   */
-  public static final String DEFAULT_ENABLE_COMPACTION_BASED_ON_DATE = "false";
+  public static final String DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER = "0";
 
   /**
    * This property will determine the loads of how many days can be compacted.
@@ -1105,7 +1085,7 @@ public final class CarbonCommonConstants {
   /**
    * Default value of 1 day loads can be compacted
    */
-  public static final String DEFAULT_DAYS_ALLOWED_TO_COMPACT = "1";
+  public static final String DEFAULT_DAYS_ALLOWED_TO_COMPACT = "0";
 
   /**
    * space reserved for writing block meta data in carbon data file

--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -1095,7 +1095,7 @@ public final class CarbonCommonConstants {
   /**
    * Default property of the date based compaction.default will be false.
    */
-  public static final String DEFAULT_ENABLE_COMPACTION_BASED_ON_DATE = "true";
+  public static final String DEFAULT_ENABLE_COMPACTION_BASED_ON_DATE = "false";
 
   /**
    * This property will determine the loads of how many days can be compacted.

--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -978,13 +978,13 @@ public final class CarbonCommonConstants {
    */
   public static final String TO_LOAD_MERGE_MAX_SIZE_DEFAULT = "1";
   /**
-   * ENABLE_LOAD_MERGE
+   * ENABLE_AUTO_LOAD_MERGE
    */
-  public static final String ENABLE_LOAD_MERGE = "carbon.enable.load.merge";
+  public static final String ENABLE_AUTO_LOAD_MERGE = "carbon.enable.auto.load.merge";
   /**
-   * DEFAULT_ENABLE_LOAD_MERGE
+   * DEFAULT_ENABLE_AUTO_LOAD_MERGE
    */
-  public static final String DEFAULT_ENABLE_LOAD_MERGE = "false";
+  public static final String DEFAULT_ENABLE_AUTO_LOAD_MERGE = "false";
 
   /**
    * ZOOKEEPER_ENABLE_LOCK if this is set to true then zookeeper will be used to handle locking

--- a/core/src/main/java/org/carbondata/core/locks/HdfsFileLock.java
+++ b/core/src/main/java/org/carbondata/core/locks/HdfsFileLock.java
@@ -22,7 +22,6 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 
-import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.impl.FileFactory;
 
 /**
@@ -51,9 +50,7 @@ public class HdfsFileLock extends AbstractCarbonLock {
   public HdfsFileLock(String location, LockUsage lockUsage) {
     this.location = location;
     this.lockUsage = lockUsage;
-    if (this.lockUsage == LockUsage.METADATA_LOCK) {
-      this.location = location + File.separator + CarbonCommonConstants.METADATA_LOCK;
-    }
+    this.location = location + File.separator + this.lockUsage;
     initRetry();
   }
 

--- a/core/src/main/java/org/carbondata/core/locks/LocalFileLock.java
+++ b/core/src/main/java/org/carbondata/core/locks/LocalFileLock.java
@@ -27,7 +27,6 @@ import java.nio.channels.OverlappingFileLockException;
 
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
-import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.impl.FileFactory;
 
 /**
@@ -88,11 +87,9 @@ public class LocalFileLock extends AbstractCarbonLock {
     schemaName = tempStr.substring(tempStr.lastIndexOf('/') + 1, tempStr.length());
 
     cubeName = location.substring(location.lastIndexOf('/') + 1, location.length());
-    if (this.lockUsage == LockUsage.METADATA_LOCK) {
-      this.location =
-          tmpPath + File.separator + schemaName + File.separator + cubeName + File.separator
-              + CarbonCommonConstants.METADATA_LOCK;
-    }
+    this.location =
+        tmpPath + File.separator + schemaName + File.separator + cubeName + File.separator
+            + this.lockUsage;
     initRetry();
   }
 

--- a/core/src/main/java/org/carbondata/core/locks/LockUsage.java
+++ b/core/src/main/java/org/carbondata/core/locks/LockUsage.java
@@ -23,5 +23,7 @@ package org.carbondata.core.locks;
  * Each enum value is one specific lock case.
  */
 public enum LockUsage {
-  METADATA_LOCK;
+  METADATA_LOCK,
+  COMPACTION_LOCK;
+
 }

--- a/core/src/main/java/org/carbondata/core/locks/ZooKeeperLocking.java
+++ b/core/src/main/java/org/carbondata/core/locks/ZooKeeperLocking.java
@@ -87,18 +87,16 @@ public class ZooKeeperLocking extends AbstractCarbonLock {
     this.lockName = CarbonCommonConstants.METADATA_LOCK;
     this.lockTypeFolder = zooKeeperLocation;
 
-    if (lockUsage == LockUsage.METADATA_LOCK) {
-      this.lockTypeFolder =
-          zooKeeperLocation + CarbonCommonConstants.FILE_SEPARATOR + lockUsage.toString();
-      try {
-        createBaseNode();
-        // if exists returns null then path doesnt exist. so creating.
-        if (null == zk.exists(this.lockTypeFolder, true)) {
-          zk.create(this.lockTypeFolder, new byte[1], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        }
-      } catch (KeeperException | InterruptedException e) {
-        LOGGER.error(e, e.getMessage());
+    this.lockTypeFolder =
+        zooKeeperLocation + CarbonCommonConstants.FILE_SEPARATOR + lockUsage.toString();
+    try {
+      createBaseNode();
+      // if exists returns null then path doesnt exist. so creating.
+      if (null == zk.exists(this.lockTypeFolder, true)) {
+        zk.create(this.lockTypeFolder, new byte[1], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
       }
+    } catch (KeeperException | InterruptedException e) {
+      LOGGER.error(e, e.getMessage());
     }
   }
 

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -740,8 +740,11 @@ public final class CarbonProperties {
               CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER));
       // checking min and max . 0  , 100 is min & max.
       if (numberOfSegmentsToBePreserved < 0 || numberOfSegmentsToBePreserved > 100) {
-        numberOfSegmentsToBePreserved = Integer
-            .parseInt(CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER);
+        LOGGER.error("The specified value for property "
+            + CarbonCommonConstants.PRESERVE_LATEST_SEGMENTS_NUMBER + " is incorrect."
+            + " Correct value should be in range of 0 -100. Taking the default value.");
+        numberOfSegmentsToBePreserved =
+            Integer.parseInt(CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER);
       }
     } catch (NumberFormatException e) {
       numberOfSegmentsToBePreserved =

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -738,7 +738,7 @@ public final class CarbonProperties {
       numberOfSegmentsToBePreserved = Integer.parseInt(
           getProperty(CarbonCommonConstants.PRESERVE_LATEST_SEGMENTS_NUMBER,
               CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER));
-      // checking min and max . 0  , 20 is min max.
+      // checking min and max . 0  , 100 is min & max.
       if (numberOfSegmentsToBePreserved < 0 || numberOfSegmentsToBePreserved > 100) {
         numberOfSegmentsToBePreserved = Integer
             .parseInt(CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER);

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -739,7 +739,7 @@ public final class CarbonProperties {
           getProperty(CarbonCommonConstants.PRESERVE_LATEST_SEGMENTS_NUMBER,
               CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER));
       // checking min and max . 0  , 20 is min max.
-      if (numberOfSegmentsToBePreserved < 0 || numberOfSegmentsToBePreserved > 20) {
+      if (numberOfSegmentsToBePreserved < 0 || numberOfSegmentsToBePreserved > 100) {
         numberOfSegmentsToBePreserved = Integer
             .parseInt(CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER);
       }

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -738,6 +738,11 @@ public final class CarbonProperties {
       numberOfSegmentsToBePreserved = Integer.parseInt(
           getProperty(CarbonCommonConstants.PRESERVE_LATEST_SEGMENTS_NUMBER,
               CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER));
+      // checking min and max . 0  , 20 is min max.
+      if (numberOfSegmentsToBePreserved < 0 || numberOfSegmentsToBePreserved > 20) {
+        numberOfSegmentsToBePreserved = Integer
+            .parseInt(CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER);
+      }
     } catch (NumberFormatException e) {
       numberOfSegmentsToBePreserved =
           Integer.parseInt(CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER);

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -247,7 +247,7 @@ public final class CarbonDataMergerUtil {
       numberOfDaysAllowedToMerge = Long.parseLong(CarbonProperties.getInstance()
           .getProperty(CarbonCommonConstants.DAYS_ALLOWED_TO_COMPACT,
               CarbonCommonConstants.DEFAULT_DAYS_ALLOWED_TO_COMPACT));
-      if (numberOfDaysAllowedToMerge < 0 || numberOfDaysAllowedToMerge > 20) {
+      if (numberOfDaysAllowedToMerge < 0 || numberOfDaysAllowedToMerge > 100) {
         numberOfDaysAllowedToMerge =
             Long.parseLong(CarbonCommonConstants.DEFAULT_DAYS_ALLOWED_TO_COMPACT);
       }

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -248,6 +248,10 @@ public final class CarbonDataMergerUtil {
           .getProperty(CarbonCommonConstants.DAYS_ALLOWED_TO_COMPACT,
               CarbonCommonConstants.DEFAULT_DAYS_ALLOWED_TO_COMPACT));
       if (numberOfDaysAllowedToMerge < 0 || numberOfDaysAllowedToMerge > 100) {
+        LOGGER.error(
+            "The specified value for property " + CarbonCommonConstants.DAYS_ALLOWED_TO_COMPACT
+                + " is incorrect."
+                + " Correct value should be in range of 0 -100. Taking the default value.");
         numberOfDaysAllowedToMerge =
             Long.parseLong(CarbonCommonConstants.DEFAULT_DAYS_ALLOWED_TO_COMPACT);
       }

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -111,14 +111,14 @@ public final class CarbonDataMergerUtil {
    * @return
    */
 
-  public static boolean checkIfLoadMergingRequired() {
+  public static boolean checkIfAutoLoadMergingRequired() {
     // load merge is not supported as per new store format
     // moving the load merge check in early to avoid unnecessary load listing causing IOException
     // check whether carbons segment merging operation is enabled or not.
     // default will be false.
     String isLoadMergeEnabled = CarbonProperties.getInstance()
-        .getProperty(CarbonCommonConstants.ENABLE_LOAD_MERGE,
-            CarbonCommonConstants.DEFAULT_ENABLE_LOAD_MERGE);
+        .getProperty(CarbonCommonConstants.ENABLE_AUTO_LOAD_MERGE,
+            CarbonCommonConstants.DEFAULT_ENABLE_AUTO_LOAD_MERGE);
     if (isLoadMergeEnabled.equalsIgnoreCase("false")) {
       return false;
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -181,7 +181,7 @@ class CarbonSqlParser()
 
   override protected lazy val start: Parser[LogicalPlan] =
     createCube | showCreateCube | loadManagement | createAggregateTable | describeTable |
-      showCube | showLoads | alterCube | showAllCubes | createTable
+      showCube | showLoads | alterCube | showAllCubes | alterTable | createTable
 
   protected lazy val loadManagement: Parser[LogicalPlan] = loadData | dropCubeOrTable |
     deleteLoadsByID | deleteLoadsByLoadDate | deleteLoadsByDate | cleanFiles | loadDataNew
@@ -330,6 +330,21 @@ class CarbonSqlParser()
     dimensions ++ complexDimensions
   }
 
+  protected lazy val alterTable: Parser[LogicalPlan] =
+    ALTER ~> TABLE ~> restInput ^^ {
+      case statement =>
+        try {
+          // DDl will be parsed and we get the AST tree from the HiveQl
+          val node = HiveQlWrapper.getAst("alter table " + statement)
+          // processing the AST tree
+          nodeToPlanForAlterTable(node)
+        } catch {
+          // MalformedCarbonCommandException need to be throw directly, parser will catch it
+          case ce: MalformedCarbonCommandException =>
+            throw ce
+        }
+    }
+
   /**
    * For handling the create table DDl systax compatible to Hive syntax
    */
@@ -464,6 +479,40 @@ class CarbonSqlParser()
         // get logical plan.
         CreateCube(tableModel)
 
+    }
+  }
+
+  /**
+   * This function will traverse the tree and logical plan will be formed using that.
+   *
+   * @param node
+   * @return LogicalPlan
+   */
+  protected def nodeToPlanForAlterTable(node: Node): LogicalPlan = {
+    node match {
+      // if create table taken is found then only we will handle.
+      case Token("TOK_ALTERTABLE", children) =>
+
+        var dbName: Option[String] = None
+        var tableName: String = ""
+        var compactionType: String = ""
+
+        children.collect {
+
+          case t@Token("TOK_TABNAME", _) =>
+            val (db, tblName) = extractDbNameTableName(t)
+            dbName = db
+            tableName = tblName
+
+          case Token("TOK_ALTERTABLE_COMPACT", child :: Nil) =>
+            compactionType = BaseSemanticAnalyzer.unescapeSQLString(child.getText)
+
+          case _ => // Unsupport features
+        }
+
+        val altertablemodel = AlterTableModel(dbName, tableName, compactionType)
+
+        AlterTableCompaction(altertablemodel)
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -510,9 +510,14 @@ class CarbonSqlParser()
           case _ => // Unsupport features
         }
 
-        val altertablemodel = AlterTableModel(dbName, tableName, compactionType)
+        if (compactionType.equalsIgnoreCase("minor") || compactionType.equalsIgnoreCase("major")) {
+          val altertablemodel = AlterTableModel(dbName, tableName, compactionType)
+          AlterTableCompaction(altertablemodel)
+        }
+        else {
+          sys.error("Invalid compaction type, supported values are 'major' and 'minor'")
+        }
 
-        AlterTableCompaction(altertablemodel)
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -46,6 +46,7 @@ import org.carbondata.core.constants.CarbonCommonConstants
 import org.carbondata.core.datastorage.store.impl.FileFactory
 import org.carbondata.core.locks.{CarbonLockFactory, LockUsage}
 import org.carbondata.core.util.{CarbonProperties, CarbonUtil}
+import org.carbondata.integration.spark.merger.CompactionType
 import org.carbondata.lcm.status.SegmentStatusManager
 import org.carbondata.spark.exception.MalformedCarbonCommandException
 import org.carbondata.spark.load._
@@ -135,6 +136,10 @@ case class CarbonMergerMapping(storeLocation: String, hdfsStoreLocation: String,
   partitioner: Partitioner, metadataFilePath: String, mergedLoadName: String,
   kettleHomePath: String, cubeCreationTime: Long, schemaName: String,
   factTableName: String, validSegments: Array[String], tableId: String)
+
+case class AlterTableModel(dbName: Option[String], tableName: String, compactionType: String)
+
+case class CompactionModel(compactionSize: Long, compactionType: CompactionType)
 
 object TableNewProcessor {
   def apply(cm: tableModel, sqlContext: SQLContext): TableInfo = {
@@ -1140,6 +1145,71 @@ private[sql] case class AlterTable(
   }
 }
 
+/**
+ * Command for the compaction in alter table command
+ * @param alterTableModel
+ */
+private[sql] case class AlterTableCompaction(alterTableModel: AlterTableModel) extends
+  RunnableCommand {
+
+  def run(sqlContext: SQLContext): Seq[Row] = {
+    // TODO : Implement it.
+    var tableName = alterTableModel.tableName
+    val schemaName = getDB.getDatabaseName(alterTableModel.dbName, sqlContext)
+    if (null == org.carbondata.core.carbon.metadata.CarbonMetadata.getInstance
+      .getCarbonTable(schemaName + "_" + tableName)) {
+      logError("alter table failed. table not found: " + schemaName + "_" + tableName)
+      sys.error("alter table failed. table not found: " + schemaName + "_" + tableName)
+    }
+
+    val relation =
+      CarbonEnv.getInstance(sqlContext).carbonCatalog
+        .lookupRelation1(Option(schemaName), tableName, None)(sqlContext)
+        .asInstanceOf[CarbonRelation]
+    if (relation == null) {
+      sys.error(s"Table $schemaName.$tableName does not exist")
+    }
+    val carbonLoadModel = new CarbonLoadModel()
+
+
+    val table = relation.cubeMeta.carbonTable
+    carbonLoadModel.setAggTables(table.getAggregateTablesName.asScala.toArray)
+    carbonLoadModel.setTableName(table.getFactTableName)
+    val dataLoadSchema = new CarbonDataLoadSchema(table)
+    // Need to fill dimension relation
+    carbonLoadModel.setCarbonDataLoadSchema(dataLoadSchema)
+    carbonLoadModel.setTableName(relation.cubeMeta.carbonTableIdentifier.getTableName)
+    carbonLoadModel.setDatabaseName(relation.cubeMeta.carbonTableIdentifier.getDatabaseName)
+    carbonLoadModel.setStorePath(relation.cubeMeta.storePath)
+
+    val partitioner = relation.cubeMeta.partitioner
+
+    var kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
+    if (null == kettleHomePath) {
+      kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
+    }
+    if (kettleHomePath == null) {
+      sys.error(s"carbon.kettle.home is not set")
+    }
+    var storeLocation = CarbonProperties.getInstance
+      .getProperty(CarbonCommonConstants.STORE_LOCATION_TEMP_PATH,
+        System.getProperty("java.io.tmpdir")
+      )
+    storeLocation = storeLocation + "/carbonstore/" + System.nanoTime()
+
+    CarbonDataRDDFactory
+      .alterTableForCompaction(sqlContext,
+        alterTableModel,
+        carbonLoadModel,
+        partitioner,
+        relation.cubeMeta.storePath,
+        kettleHomePath,
+        storeLocation
+      )
+
+    Seq.empty
+  }
+}
 
 private[sql] case class CreateCube(cm: tableModel) extends RunnableCommand {
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1893,7 +1893,7 @@ private[sql] case class ShowLoads(
       val parser = new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP)
 
       var loadMetadataDetailsSortedArray = loadMetadataDetailsArray.sortWith(
-        (l1, l2) => Integer.parseInt(l1.getLoadName) > Integer.parseInt(l2.getLoadName))
+        (l1, l2) => java.lang.Double.parseDouble(l1.getLoadName) > java.lang.Double.parseDouble(l2.getLoadName))
 
 
       if (limit.isDefined) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1893,7 +1893,9 @@ private[sql] case class ShowLoads(
       val parser = new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP)
 
       var loadMetadataDetailsSortedArray = loadMetadataDetailsArray.sortWith(
-        (l1, l2) => java.lang.Double.parseDouble(l1.getLoadName) > java.lang.Double.parseDouble(l2.getLoadName))
+        (l1, l2) => java.lang.Double.parseDouble(l1.getLoadName) > java.lang.Double
+          .parseDouble(l2.getLoadName)
+      )
 
 
       if (limit.isDefined) {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -307,8 +307,6 @@ object CarbonDataRDDFactory extends Logging {
     val cubeCreationTime = CarbonEnv.getInstance(sqlContext).carbonCatalog
       .getCubeCreationTime(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)
 
-    if (CarbonDataMergerUtil.checkIfLoadMergingRequired()) {
-
       if (null == carbonLoadModel.getLoadMetadataDetails) {
         readLoadMetadataDetails(carbonLoadModel, hdfsStoreLocation)
       }
@@ -331,7 +329,6 @@ object CarbonDataRDDFactory extends Logging {
         executor,
         compactionModel
       )
-    }
   }
 
   def startCompactionThreads(sqlContext: SQLContext,
@@ -415,8 +412,9 @@ object CarbonDataRDDFactory extends Logging {
 
     // for handling of the segment Merging.
     def handleSegmentMerging(cubeCreationTime: Long): Unit = {
-      logger.info("compaction need status is " + CarbonDataMergerUtil.checkIfLoadMergingRequired())
-      if (CarbonDataMergerUtil.checkIfLoadMergingRequired()) {
+      logger
+        .info("compaction need status is " + CarbonDataMergerUtil.checkIfAutoLoadMergingRequired())
+      if (CarbonDataMergerUtil.checkIfAutoLoadMergingRequired()) {
         val compactionSize = CarbonDataMergerUtil.getCompactionSize(CompactionType.MINOR_COMPACTION)
 
         val executor: ExecutorService = Executors.newFixedThreadPool(1)

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -18,6 +18,9 @@
 
 package org.carbondata.spark.rdd
 
+import java.util
+import java.util.concurrent.{Executors, ExecutorService}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.util.control.Breaks._
@@ -27,12 +30,11 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.spark.{Logging, Partition, SparkContext}
 import org.apache.spark.sql.{CarbonEnv, CarbonRelation, SQLContext}
-import org.apache.spark.sql.execution.command.{CarbonMergerMapping, Partitioner}
+import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionModel, Partitioner}
 import org.apache.spark.util.{FileUtils, SplitUtils}
 
 import org.carbondata.common.logging.LogServiceFactory
-import org.carbondata.core.carbon.{AbsoluteTableIdentifier, CarbonDataLoadSchema,
-CarbonTableIdentifier}
+import org.carbondata.core.carbon.{AbsoluteTableIdentifier, CarbonDataLoadSchema, CarbonTableIdentifier}
 import org.carbondata.core.carbon.datastore.block.TableBlockInfo
 import org.carbondata.core.carbon.metadata.CarbonMetadata
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable
@@ -286,6 +288,119 @@ object CarbonDataRDDFactory extends Logging {
     }
   }
 
+  def alterTableForCompaction(sqlContext: SQLContext,
+    alterTableModel: AlterTableModel,
+    carbonLoadModel: CarbonLoadModel, partitioner: Partitioner, hdfsStoreLocation: String,
+    kettleHomePath: String, storeLocation: String): Unit = {
+    var compactionSize: Long = 0
+    var compactionType: CompactionType = CompactionType.MINOR_COMPACTION
+    if (alterTableModel.compactionType.equalsIgnoreCase("major")) {
+      compactionSize = CarbonDataMergerUtil.getCompactionSize(CompactionType.MAJOR_COMPACTION)
+      compactionType = CompactionType.MAJOR_COMPACTION
+    }
+    else {
+      compactionSize = CarbonDataMergerUtil.getCompactionSize(CompactionType.MINOR_COMPACTION)
+      compactionType = CompactionType.MINOR_COMPACTION
+    }
+
+    val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
+    val cubeCreationTime = CarbonEnv.getInstance(sqlContext).carbonCatalog
+      .getCubeCreationTime(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)
+
+    if (CarbonDataMergerUtil.checkIfLoadMergingRequired()) {
+
+      if (null == carbonLoadModel.getLoadMetadataDetails) {
+        readLoadMetadataDetails(carbonLoadModel, hdfsStoreLocation)
+      }
+      // reading the start time of data load.
+      val loadStartTime = CarbonLoaderUtil.readCurrentTime()
+      carbonLoadModel.setFactTimeStamp(loadStartTime)
+
+      val executor: ExecutorService = Executors.newFixedThreadPool(1)
+
+      val compactionModel = CompactionModel(compactionSize, compactionType)
+
+      startCompactionThreads(sqlContext,
+        carbonLoadModel,
+        partitioner,
+        hdfsStoreLocation,
+        kettleHomePath,
+        storeLocation,
+        carbonTable,
+        cubeCreationTime,
+        executor,
+        compactionModel
+      )
+    }
+  }
+
+  def startCompactionThreads(sqlContext: SQLContext,
+    carbonLoadModel: CarbonLoadModel,
+    partitioner: Partitioner,
+    hdfsStoreLocation: String,
+    kettleHomePath: String,
+    storeLocation: String,
+    carbonTable: CarbonTable,
+    cubeCreationTime: Long,
+    executor: ExecutorService,
+    compactionModel: CompactionModel): Unit = {
+
+    var segList: util.List[LoadMetadataDetails] = carbonLoadModel.getLoadMetadataDetails
+    breakable {
+      while (true) {
+
+        val loadsToMerge = CarbonDataMergerUtil.identifySegmentsToBeMerged(
+          hdfsStoreLocation,
+          carbonLoadModel,
+          partitioner.partitionCount,
+          compactionModel.compactionSize,
+          segList,
+          compactionModel.compactionType
+        )
+        logger.info("loads identified for merge is " + loadsToMerge)
+        if (loadsToMerge.size() > 1) {
+
+          executor.submit(new Runnable() {
+            def run() {
+
+              val lock = CarbonLockFactory
+                .getCarbonLockObj(carbonTable.getMetaDataFilepath, LockUsage.COMPACTION_LOCK)
+
+              if (lock.lockWithRetries()) {
+                // For Merging of the Carbon Segments.
+                try {
+                  Compactor.triggerCompaction(hdfsStoreLocation,
+                    carbonLoadModel,
+                    partitioner,
+                    storeLocation,
+                    carbonTable,
+                    kettleHomePath,
+                    cubeCreationTime,
+                    loadsToMerge,
+                    sqlContext
+                  )
+                }
+                finally {
+                  lock.unlock()
+                }
+              }
+              else {
+                logger.error("Not able to acquire the compaction lock.")
+              }
+            }
+          }
+          )
+          segList = CarbonDataMergerUtil
+            .filterOutAlreadyMergedSegments(segList, loadsToMerge)
+        }
+        else {
+          executor.shutdown()
+          break
+        }
+      }
+    }
+  }
+
   def loadCarbonData(sc: SQLContext,
       carbonLoadModel: CarbonLoadModel,
       storeLocation: String,
@@ -303,58 +418,22 @@ object CarbonDataRDDFactory extends Logging {
       logger.info("compaction need status is " + CarbonDataMergerUtil.checkIfLoadMergingRequired())
       if (CarbonDataMergerUtil.checkIfLoadMergingRequired()) {
         val compactionSize = CarbonDataMergerUtil.getCompactionSize(CompactionType.MINOR_COMPACTION)
-        val loadsToMerge = CarbonDataMergerUtil.identifySegmentsToBeMerged(
-          hdfsStoreLocation, carbonLoadModel, partitioner.partitionCount, compactionSize
+
+        val executor: ExecutorService = Executors.newFixedThreadPool(1)
+
+        val compactionModel = CompactionModel(compactionSize, CompactionType.MINOR_COMPACTION)
+
+        startCompactionThreads(sc,
+          carbonLoadModel,
+          partitioner,
+          hdfsStoreLocation,
+          kettleHomePath,
+          storeLocation,
+          carbonTable,
+          cubeCreationTime,
+          executor,
+          compactionModel
         )
-        logger.info("loads identified for merge is " + loadsToMerge)
-        if (loadsToMerge.size() > 1) {
-          logger.info("loads to merge which can be merged are " + loadsToMerge)
-          val mergedLoadName = CarbonDataMergerUtil.getMergedLoadName(loadsToMerge)
-          var finalMergeStatus = true
-          val schemaName: String = carbonLoadModel.getDatabaseName
-          val factTableName = carbonLoadModel.getTableName
-          val storePath = hdfsStoreLocation
-          val validSegments: Array[String] = CarbonDataMergerUtil
-            .getValidSegments(loadsToMerge).split(',')
-          val mergeLoadStartTime = CarbonLoaderUtil.readCurrentTime();
-          val carbonMergerMapping = CarbonMergerMapping(storeLocation,
-            hdfsStoreLocation,
-            partitioner,
-            carbonTable.getMetaDataFilepath(),
-            mergedLoadName,
-            kettleHomePath,
-            cubeCreationTime,
-            schemaName,
-            factTableName,
-            validSegments,
-            carbonTable.getCarbonTableIdentifier.getTableId
-          )
-          carbonLoadModel.setStorePath(carbonMergerMapping.hdfsStoreLocation)
-          val segmentStatusManager = new SegmentStatusManager(carbonTable
-            .getAbsoluteTableIdentifier)
-          carbonLoadModel.setLoadMetadataDetails(segmentStatusManager
-            .readLoadMetadata(carbonTable.getMetaDataFilepath()).toList.asJava
-          )
-
-          val mergeStatus = new CarbonMergerRDD(
-            sc.sparkContext,
-            new MergeResultImpl(),
-            carbonLoadModel,
-            carbonMergerMapping
-          ).collect
-
-          mergeStatus.foreach { eachMergeStatus =>
-            val state: Boolean = eachMergeStatus._2
-            if (!state) {
-              finalMergeStatus = false
-            }
-          }
-          if (finalMergeStatus) {
-            CarbonDataMergerUtil
-               .updateLoadMetadataWithMergeStatus(loadsToMerge, carbonTable.getMetaDataFilepath(),
-                 mergedLoadName, carbonLoadModel, mergeLoadStartTime)
-          }
-        }
       }
     }
 
@@ -416,8 +495,7 @@ object CarbonDataRDDFactory extends Logging {
       val schemaLastUpdatedTime = CarbonEnv.getInstance(sc).carbonCatalog
         .getSchemaLastUpdatedTime(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)
 
-
-      // For Merging of the Carbon Segments.
+      // compaction handling
       handleSegmentMerging(cubeCreationTime)
 
       // get partition way from configuration

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -18,7 +18,7 @@
 package org.carbondata.spark.rdd
 
 import java.util
-import java.util.List
+import java.util.{Collections, List}
 
 import scala.collection.JavaConverters._
 
@@ -73,8 +73,9 @@ class CarbonMergerRDD[K, V](
       CarbonProperties.getInstance().addProperty(tempLocationKey, storeLocation)
 
       // sorting the table block info List.
-      // Collections.sort(tableBlockInfoList1)
       var tableBlockInfoList = carbonSparkPartition.tableBlockInfos
+
+      Collections.sort(tableBlockInfoList)
 
       val segmentMapping: java.util.Map[String, TaskBlockInfo] =
         CarbonCompactionUtil.createMappingForSegments(tableBlockInfoList)

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -129,7 +129,7 @@ class CarbonMergerRDD[K, V](
       )
 
       carbonLoadModel.setSegmentId(mergeNumber)
-      carbonLoadModel.setPartitionId(theSplit.index.toString)
+      carbonLoadModel.setPartitionId("0")
       val merger =
         new RowResultMerger(result2,
         schemaName,

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/Compactor.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/Compactor.scala
@@ -69,12 +69,16 @@ object Compactor {
       cubeCreationTime,
       schemaName,
       factTableName,
-      validSegments
+      validSegments,
+      carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId
     )
     carbonLoadModel.setStorePath(carbonMergerMapping.hdfsStoreLocation)
     val segmentStatusManager = new SegmentStatusManager(new AbsoluteTableIdentifier
     (CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION),
-      new CarbonTableIdentifier(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)
+      new CarbonTableIdentifier(carbonLoadModel.getDatabaseName,
+        carbonLoadModel.getTableName,
+        carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId
+      )
     )
     )
     carbonLoadModel.setLoadMetadataDetails(segmentStatusManager

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/Compactor.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/Compactor.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.carbondata.spark.rdd
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.execution.command.{CarbonMergerMapping, Partitioner}
+
+import org.carbondata.common.logging.LogServiceFactory
+import org.carbondata.core.carbon.{AbsoluteTableIdentifier, CarbonTableIdentifier}
+import org.carbondata.core.carbon.metadata.schema.table.CarbonTable
+import org.carbondata.core.constants.CarbonCommonConstants
+import org.carbondata.core.load.LoadMetadataDetails
+import org.carbondata.core.util.CarbonProperties
+import org.carbondata.lcm.status.SegmentStatusManager
+import org.carbondata.spark.load.{CarbonLoaderUtil, CarbonLoadModel}
+import org.carbondata.spark.MergeResultImpl
+import org.carbondata.spark.merger.CarbonDataMergerUtil
+
+/**
+ * Compactor class which handled the compaction cases.
+ */
+object Compactor {
+
+  val logger = LogServiceFactory.getLogService(Compactor.getClass.getName)
+
+  def triggerCompaction(hdfsStoreLocation: String,
+    carbonLoadModel: CarbonLoadModel,
+    partitioner: Partitioner,
+    storeLocation: String,
+    carbonTable: CarbonTable,
+    kettleHomePath: String,
+    cubeCreationTime: Long,
+    loadsToMerge: java.util.List[LoadMetadataDetails],
+    sc: SQLContext): Unit = {
+
+    logger.info("loads about to merge are  " + loadsToMerge)
+    val startTime = System.nanoTime();
+    val mergedLoadName = CarbonDataMergerUtil.getMergedLoadName(loadsToMerge)
+    var finalMergeStatus = true
+    val schemaName: String = carbonLoadModel.getDatabaseName
+    val factTableName = carbonLoadModel.getTableName
+    val storePath = hdfsStoreLocation
+    val validSegments: Array[String] = CarbonDataMergerUtil
+      .getValidSegments(loadsToMerge).split(',')
+    val mergeLoadStartTime = CarbonLoaderUtil.readCurrentTime();
+    val carbonMergerMapping = CarbonMergerMapping(storeLocation,
+      hdfsStoreLocation,
+      partitioner,
+      carbonTable.getMetaDataFilepath(),
+      mergedLoadName,
+      kettleHomePath,
+      cubeCreationTime,
+      schemaName,
+      factTableName,
+      validSegments
+    )
+    carbonLoadModel.setStorePath(carbonMergerMapping.hdfsStoreLocation)
+    val segmentStatusManager = new SegmentStatusManager(new AbsoluteTableIdentifier
+    (CarbonProperties.getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION),
+      new CarbonTableIdentifier(carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)
+    )
+    )
+    carbonLoadModel.setLoadMetadataDetails(segmentStatusManager
+      .readLoadMetadata(carbonTable.getMetaDataFilepath()).toList.asJava
+    )
+
+    val mergeStatus = new CarbonMergerRDD(
+      sc.sparkContext,
+      new MergeResultImpl(),
+      carbonLoadModel,
+      carbonMergerMapping
+    ).collect
+
+    mergeStatus.foreach { eachMergeStatus =>
+      val state: Boolean = eachMergeStatus._2
+      if (!state) {
+        finalMergeStatus = false
+      }
+    }
+    if (finalMergeStatus) {
+      val endTime = System.nanoTime();
+      logger.info("time taken to merge " + mergedLoadName + " is " + (endTime - startTime))
+      CarbonDataMergerUtil
+        .updateLoadMetadataWithMergeStatus(loadsToMerge, carbonTable.getMetaDataFilepath(),
+          mergedLoadName, carbonLoadModel, mergeLoadStartTime
+        )
+    }
+  }
+}

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
@@ -19,7 +19,6 @@ import org.scalatest.BeforeAndAfterAll
 class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
-    CarbonProperties.getInstance().addProperty("carbon.enable.load.merge", "true")
     sql("drop table if exists  noDictionaryCompaction")
 
     sql(
@@ -50,6 +49,36 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
     // compaction will happen here.
     sql("alter table noDictionaryCompaction compact 'major'"
     )
+
+    // wait for compaction to finish.
+    Thread.sleep(1000)
+  }
+
+  // check for 15 seconds if the compacted segments has come or not .
+  // if not created after 15 seconds then testcase will fail.
+
+  test("check if compaction is completed or not.") {
+    var status = true
+    var noOfRetries = 0
+    while (status && noOfRetries < 10) {
+
+      val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
+          AbsoluteTableIdentifier(
+            CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
+            new CarbonTableIdentifier("default", "noDictionaryCompaction")
+          )
+      )
+      val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList
+
+      if (!segments.contains("0.1")) {
+        // wait for 2 seconds for compaction to complete.
+        Thread.sleep(2000)
+        noOfRetries += 1
+      }
+      else {
+        status = false
+      }
+    }
   }
 
 

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
@@ -65,7 +65,7 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
       val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
           AbsoluteTableIdentifier(
             CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
-            new CarbonTableIdentifier("default", "noDictionaryCompaction")
+            new CarbonTableIdentifier("default", "noDictionaryCompaction", "1")
           )
       )
       val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
@@ -44,11 +44,12 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
     sql("LOAD DATA fact from '" + csvFilePath2 + "' INTO CUBE noDictionaryCompaction  PARTITIONDATA" +
       "(DELIMITER ',', QUOTECHAR '\"')"
     )
-    // compaction will happen here.
     sql("LOAD DATA fact from '" + csvFilePath3 + "' INTO CUBE noDictionaryCompaction  PARTITIONDATA" +
       "(DELIMITER ',', QUOTECHAR '\"')"
     )
-
+    // compaction will happen here.
+    sql("alter table noDictionaryCompaction compact 'major'"
+    )
   }
 
 
@@ -87,7 +88,10 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
     )
     // merged segment should not be there
     val segments   = segmentStatusManager.getValidSegments.listOfValidSegments.asScala.toList
-      assert(!segments.contains("1"))
+    assert(!segments.contains("0"))
+    assert(!segments.contains("1"))
+    assert(!segments.contains("2"))
+    assert(segments.contains("0.1"))
 
     // now check the answers it should be same.
     checkAnswer(

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
@@ -69,7 +69,7 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
       val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
           AbsoluteTableIdentifier(
             CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
-            new CarbonTableIdentifier("default", "normalcompaction")
+            new CarbonTableIdentifier("default", "normalcompaction", "1")
           )
       )
       val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
@@ -61,6 +61,30 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
 
   }
 
+  test("check if compaction is completed or not.") {
+    var status = true
+    var noOfRetries = 0
+    while (status && noOfRetries < 10) {
+
+      val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(new
+          AbsoluteTableIdentifier(
+            CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
+            new CarbonTableIdentifier("default", "normalcompaction")
+          )
+      )
+      val segments = segmentStatusManager.getValidSegments().listOfValidSegments.asScala.toList
+
+      if (!segments.contains("0.1")) {
+        // wait for 2 seconds for compaction to complete.
+        Thread.sleep(2000)
+        noOfRetries += 1
+      }
+      else {
+        status = false
+      }
+    }
+  }
+
 
   test("select country from normalcompaction") {
     // check answers after compaction.

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
@@ -39,7 +39,6 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
 
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/mm/dd")
-    CarbonProperties.getInstance().addProperty("carbon.enable.load.merge", "true")
     sql("LOAD DATA fact from '" + csvFilePath1 + "' INTO CUBE normalcompaction PARTITIONDATA" +
       "(DELIMITER ',', QUOTECHAR '\"')"
     )
@@ -55,6 +54,9 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
     // compaction will happen here.
     sql("LOAD DATA fact from '" + csvFilePath3 + "' INTO CUBE normalcompaction  PARTITIONDATA" +
       "(DELIMITER ',', QUOTECHAR '\"')"
+    )
+    // compaction will happen here.
+    sql("alter table normalcompaction compact 'major'"
     )
 
   }
@@ -95,7 +97,10 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
     )
     // merged segment should not be there
     val segments   = segmentStatusManager.getValidSegments.listOfValidSegments.asScala.toList
+    assert(!segments.contains("0"))
     assert(!segments.contains("1"))
+    assert(!segments.contains("2"))
+    assert(segments.contains("0.1"))
 
     // now check the answers it should be same.
     checkAnswer(


### PR DESCRIPTION
1. changed the property carbon.enable.load.merge to  "carbon.enable.auto.load.merge". this will enable/disable the compaction done during the data load. i.e minor compaction.

2. running compaction in separate thread.

3. DEFAULT_ENABLE_COMPACTION_BASED_ON_DATE = "false"

4. changed the minor compaction behaviour. minor compaction will happen only when the configured size is reached. not before that.

