### PR TITLE
[Bug] Fix bug when hadoop configueration item dfs.blocksize config human readable format

### DIFF
--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -270,7 +270,7 @@ object CarbonDataRDDFactory extends Logging {
     val defaultParallelism = if (context.defaultParallelism < 1) 1 else context.defaultParallelism
     val spaceConsumed = FileUtils.getSpaceOccupied(filePaths)
     val blockSize =
-      hadoopConfiguration.getLong("dfs.blocksize", CarbonCommonConstants.CARBON_256MB)
+      hadoopConfiguration.getLongBytes("dfs.blocksize", CarbonCommonConstants.CARBON_256MB)
     logInfo("[Block Distribution]")
     // calculate new block size to allow use all the parallelism
     if (spaceConsumed < defaultParallelism * blockSize) {


### PR DESCRIPTION
when dfs.blocksize of hadoop configuration set human readable format as 64k/128M/256G. etc, will throw exception when load data, since hadoop.Configuration#getLong() couldn't revert it to long rather than hadoop.Configuration#getLongBytes().