### PR TITLE
Fixed bug  select function like trim or length along with avg aggregator

### DIFF
--- a/integration-testcases/src/test/scala/org/apache/spark/sql/common/util/CarbonHiveContext.scala
+++ b/integration-testcases/src/test/scala/org/apache/spark/sql/common/util/CarbonHiveContext.scala
@@ -44,8 +44,7 @@ object CarbonHiveContext extends LocalSQLContext(
   val hdfsCarbonPath = new File("./target/test/").getCanonicalPath;
   hdfsCarbonPath
 }) {
-
-  {
+    sparkContext.setLogLevel("ERROR")
     val currentDirectory = new File(this.getClass.getResource("/").getPath + "/../../")
       .getCanonicalPath
     CarbonProperties.getInstance().addProperty("carbon.kettle.home", currentDirectory+"/../processing/carbonplugins")
@@ -62,7 +61,6 @@ object CarbonHiveContext extends LocalSQLContext(
 
     CarbonLoaderUtil.deleteStorePath(hdfsCarbonPath)
     //	    //		sql("drop cube timestamptypecube");
-  }
 }
 
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -373,18 +373,14 @@ object PartialAggregation {
 
   private def convertAggregatesForPushdown(convertUnknown: Boolean,
       rewrittenAggregateExpressions: Seq[Expression]) = {
-    if (canBeConvertedToCarbonAggregate(rewrittenAggregateExpressions)) {
-      var counter: Int = 0
-      var updatedExpressions = MutableList[Expression]()
-      rewrittenAggregateExpressions.foreach(v => {
-        val updated = convertAggregate(v, counter, convertUnknown)
-        updatedExpressions += updated
-        counter = counter + 1
-      })
-      updatedExpressions
-    } else {
-      rewrittenAggregateExpressions
-    }
+    var counter: Int = 0
+    var updatedExpressions = MutableList[Expression]()
+    rewrittenAggregateExpressions.foreach(v => {
+      val updated = convertAggregate(v, counter, convertUnknown)
+      updatedExpressions += updated
+      counter = counter + 1
+    })
+    updatedExpressions
   }
 
   def makePositionLiteral(expr: Expression, index: Int): PositionLiteral = {
@@ -446,7 +442,7 @@ object PartialAggregation {
    * There should be sync between carbonOperators validation and here. we should not convert to
    * carbon aggregates if the validation does not satisfy.
    */
-  def canBeConvertedToCarbonAggregate(expressions: Seq[Expression]): Boolean = {
+  private def canBeConvertedToCarbonAggregate(expressions: Seq[Expression]): Boolean = {
     val detailQuery = expressions.map {
       case attr@AttributeReference(_, _, _, _) => true
       case par: Alias if par.children.head.isInstanceOf[AggregateExpression1] => true
@@ -467,72 +463,99 @@ object PartialAggregation {
             aggregateExpressionsOrig
           }
           else {
-            convertAggregatesForPushdown(false, aggregateExpressionsOrig)
+            // First calculate partialComputation before converting and then check whether it could
+            // be converted or not. This type of checks are necessary for queries like
+            // select sum(col)+10 from table. Here the aggregates are different for
+            // partialComputation and aggregateExpressionsOrig. So first check on partialComputation
+            val preCheckEval = getPartialEvaluation(groupingExpressions, aggregateExpressionsOrig)
+            preCheckEval match {
+              case Some(allExprs) =>
+                if (canBeConvertedToCarbonAggregate(allExprs._1)) {
+                  convertAggregatesForPushdown(false, aggregateExpressionsOrig)
+                } else {
+                  aggregateExpressionsOrig
+                }
+              case _ => aggregateExpressionsOrig
+            }
           }
-        // Collect all aggregate expressions.
-        val allAggregates =
-          aggregateExpressions.flatMap(_ collect { case a: AggregateExpression1 => a })
-        // Collect all aggregate expressions that can be computed partially.
-        val partialAggregates =
-          aggregateExpressions.flatMap(_ collect { case p: PartialAggregate1 => p })
+        val evaluation = getPartialEvaluation(groupingExpressions, aggregateExpressions)
 
-        // Only do partial aggregation if supported by all aggregate expressions.
-        if (allAggregates.size == partialAggregates.size) {
-          // Create a map of expressions to their partial evaluations for all aggregate expressions.
-          val partialEvaluations: Map[TreeNodeRef, SplitEvaluation] =
-            partialAggregates.map(a => (new TreeNodeRef(a), a.asPartial)).toMap
-
-          // We need to pass all grouping expressions though so the grouping can happen a second
-          // time. However some of them might be unnamed so we alias them allowing them to be
-          // referenced in the second aggregation.
-          val namedGroupingExpressions: Map[Expression, NamedExpression] = groupingExpressions.map {
-            case n: NamedExpression => (n, n)
-            case other => (other, Alias(other, "PartialGroup")())
-          }.toMap
-
-          // Replace aggregations with a new expression that computes the result from the already
-          // computed partial evaluations and grouping values.
-          val rewrittenAggregateExpressions = aggregateExpressions.map(_.transformUp {
-            case e: Expression if partialEvaluations.contains(new TreeNodeRef(e)) =>
-              partialEvaluations(new TreeNodeRef(e)).finalEvaluation
-
-            case e: Expression =>
-              // Should trim aliases around `GetField`s. These aliases are introduced while
-              // resolving struct field accesses, because `GetField` is not a `NamedExpression`.
-              // (Should we just turn `GetField` into a `NamedExpression`?)
-              namedGroupingExpressions.collectFirst {
-                case (expr, ne) if expr semanticEquals e => ne.toAttribute
-              }.getOrElse(e)
-          }).asInstanceOf[Seq[NamedExpression]]
-
-          val partialComputation =
-            (namedGroupingExpressions.values ++
-             partialEvaluations.values.flatMap(_.partialEvaluations)).toSeq
-
-          // Convert the other aggregations for push down to Carbon layer. Here don't touch earlier
-          // converted native carbon aggregators.
-          val convertedPartialComputation =
-            if (combinedPlan._2) {
-              partialComputation
-            }
-            else {
-              convertAggregatesForPushdown(true, partialComputation)
-                .asInstanceOf[Seq[NamedExpression]]
-            }
-
-          val namedGroupingAttributes = namedGroupingExpressions.values.map(_.toAttribute).toSeq
-
-          Some(
-            (namedGroupingAttributes,
+        evaluation match {
+          case(Some((partialComputation,
               rewrittenAggregateExpressions,
-              groupingExpressions,
-              convertedPartialComputation,
-              child))
-        } else {
-          None
+              namedGroupingAttributes))) =>
+            // Convert the other aggregations for push down to Carbon layer.
+            // Here don't touch earlier converted native carbon aggregators.
+            val convertedPartialComputation =
+              if (combinedPlan._2) {
+                partialComputation
+              }
+              else {
+                convertAggregatesForPushdown(true, partialComputation)
+                  .asInstanceOf[Seq[NamedExpression]]
+              }
+
+            Some(
+              (namedGroupingAttributes,
+                rewrittenAggregateExpressions,
+                groupingExpressions,
+                convertedPartialComputation,
+                child))
+          case _ => None
         }
+
       case _ => None
     }
+  }
+
+  def getPartialEvaluation(groupingExpressions: Seq[Expression],
+      aggregateExpressions: Seq[Expression]):
+      Option[(Seq[NamedExpression], Seq[NamedExpression], Seq[Attribute])] = {
+    // Collect all aggregate expressions.
+    val allAggregates =
+      aggregateExpressions.flatMap(_ collect { case a: AggregateExpression1 => a })
+    // Collect all aggregate expressions that can be computed partially.
+    val partialAggregates =
+      aggregateExpressions.flatMap(_ collect { case p: PartialAggregate1 => p })
+
+    // Only do partial aggregation if supported by all aggregate expressions.
+    if (allAggregates.size == partialAggregates.size) {
+      // Create a map of expressions to their partial evaluations for all aggregate expressions.
+      val partialEvaluations: Map[TreeNodeRef, SplitEvaluation] =
+        partialAggregates.map(a => (new TreeNodeRef(a), a.asPartial)).toMap
+
+      // We need to pass all grouping expressions though so the grouping can happen a second
+      // time. However some of them might be unnamed so we alias them allowing them to be
+      // referenced in the second aggregation.
+      val namedGroupingExpressions: Map[Expression, NamedExpression] = groupingExpressions.map {
+        case n: NamedExpression => (n, n)
+        case other => (other, Alias(other, "PartialGroup")())
+      }.toMap
+
+      // Replace aggregations with a new expression that computes the result from the already
+      // computed partial evaluations and grouping values.
+      val rewrittenAggregateExpressions = aggregateExpressions.map(_.transformUp {
+        case e: Expression if partialEvaluations.contains(new TreeNodeRef(e)) =>
+          partialEvaluations(new TreeNodeRef(e)).finalEvaluation
+
+        case e: Expression =>
+          // Should trim aliases around `GetField`s. These aliases are introduced while
+          // resolving struct field accesses, because `GetField` is not a `NamedExpression`.
+          // (Should we just turn `GetField` into a `NamedExpression`?)
+          namedGroupingExpressions.collectFirst {
+            case (expr, ne) if expr semanticEquals e => ne.toAttribute
+          }.getOrElse(e)
+      }).asInstanceOf[Seq[NamedExpression]]
+
+      val partialComputation =
+        (namedGroupingExpressions.values ++
+         partialEvaluations.values.flatMap(_.partialEvaluations)).toSeq
+      val namedGroupingAttributes = namedGroupingExpressions.values.map(_.toAttribute).toSeq
+      Some(partialComputation, rewrittenAggregateExpressions, namedGroupingAttributes)
+    } else {
+      None
+    }
+
   }
 }
 

--- a/integration/spark/src/test/scala/org/apache/spark/sql/common/util/CarbonHiveContext.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/sql/common/util/CarbonHiveContext.scala
@@ -44,8 +44,7 @@ object CarbonHiveContext extends LocalSQLContext(
   val hdfsCarbonPath = new File("./target/test/").getCanonicalPath;
   hdfsCarbonPath
 }) {
-
-  {
+    sparkContext.setLogLevel("ERROR")
     CarbonProperties.getInstance().addProperty("carbon.kettle.home", "../../processing/carbonplugins")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.STORE_LOCATION_TEMP_PATH, System.getProperty("java.io.tmpdir"))
@@ -60,7 +59,6 @@ object CarbonHiveContext extends LocalSQLContext(
 
     CarbonLoaderUtil.deleteStorePath(hdfsCarbonPath)
     //	    //		sql("drop cube timestamptypecube");
-  }
 }
 
 

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/aggquery/AllDataTypesTestCaseAggregate.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/aggquery/AllDataTypesTestCaseAggregate.scala
@@ -48,7 +48,6 @@ class AllDataTypesTestCaseAggregate extends QueryTest with BeforeAndAfterAll {
   }
 
   test("select empname,length(designation),max(empno),min(empno), avg(empno) from alldatatypescubeAGG where empname in ('arvind','ayushi') group by empname,length(designation) order by empname") {
-    sql("select empname,length(designation),max(empno),min(empno), avg(empno) from alldatatypescubeAGG where empname in ('arvind','ayushi') group by empname,length(designation) order by empname").show()
     checkAnswer(
       sql("select empname,length(designation),max(empno),min(empno), avg(empno) from alldatatypescubeAGG where empname in ('arvind','ayushi') group by empname,length(designation) order by empname"),
       Seq(Row("arvind", 2, 11, 11, 11.0), Row("ayushi", 3, 15, 15, 15.0)))

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/aggquery/AllDataTypesTestCaseAggregate.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/aggquery/AllDataTypesTestCaseAggregate.scala
@@ -41,6 +41,19 @@ class AllDataTypesTestCaseAggregate extends QueryTest with BeforeAndAfterAll {
       Seq(Row(11, "arvind", 96.2, 1, 11), Row(15, "ayushi", 91.5, 1, 15)))
   }
 
+  test("select empname,trim(designation),avg(salary),avg(empno) from alldatatypescubeAGG where empname in ('arvind','ayushi') group by empname,trim(designation)") {
+    checkAnswer(
+      sql("select empname,trim(designation),avg(salary),avg(empno) from alldatatypescubeAGG where empname in ('arvind','ayushi') group by empname,trim(designation)"),
+      Seq(Row("arvind", "SE", 5040.56, 11.0), Row("ayushi", "SSA", 13245.48, 15.0)))
+  }
+
+  test("select empname,length(designation),max(empno),min(empno), avg(empno) from alldatatypescubeAGG where empname in ('arvind','ayushi') group by empname,length(designation) order by empname") {
+    sql("select empname,length(designation),max(empno),min(empno), avg(empno) from alldatatypescubeAGG where empname in ('arvind','ayushi') group by empname,length(designation) order by empname").show()
+    checkAnswer(
+      sql("select empname,length(designation),max(empno),min(empno), avg(empno) from alldatatypescubeAGG where empname in ('arvind','ayushi') group by empname,length(designation) order by empname"),
+      Seq(Row("arvind", 2, 11, 11, 11.0), Row("ayushi", 3, 15, 15, 15.0)))
+  }
+
   override def afterAll {
     sql("drop cube alldatatypescubeAGG")
   }


### PR DESCRIPTION
Following queries was not working 
select SID,length( MSISDN),max(LAYER1ID),min(LAYER1ID),avg(LAYER1ID) from smart_500 group by SID,length( MSISDN) order by SID limit 10;
select age,trim(imei),avg(gamepointid),avg(age) from table03 group by age,trim(imei);

It is because we are converting to carbon aggregates in `CarbonCatalystOperators` but going to detail query in `carbonOperators`, so it causes unexpected results. This PR add validation to made it sync between two classes