### PR TITLE
[Bug] NOT NULL should not display any null values in the output

### DIFF
--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -976,6 +976,11 @@ public final class CarbonCommonConstants {
   public static final long CARBON_256MB = 256*1024*1024;
 
   /**
+   * Data type String.
+   */
+  public static final String DATATYPE_STRING = "STRING";
+
+  /**
    * SEGMENT_COMPACTED is property to indicate whether seg is compacted or not.
    */
   public static final String SEGMENT_COMPACTED = "Compacted";

--- a/integration/spark/src/test/resources/data2.csv
+++ b/integration/spark/src/test/resources/data2.csv
@@ -1,0 +1,4 @@
+ID,date,country,name,phonetype,serialname,salary
+4,2014-01-21 00:00:00,china,aaa4,phone2435,ASD66902,15003
+abc,,china,aaa5,phone2441,ASD90633,15004
+6,2014-03-07 00:00:00,china,aaa6,phone294,ASD59961,15005

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
@@ -72,6 +72,16 @@ class NO_DICTIONARY_COL_TestCase extends QueryTest with BeforeAndAfterAll {
       "LOAD DATA fact from './src/test/resources/data.csv' INTO CUBE NO_DICTIONARY_CARBON_7 " +
         "PARTITIONDATA(DELIMITER ',', QUOTECHAR '\"')"
     );
+    sql("CREATE CUBE filtertestTable DIMENSIONS (ID Integer,date Timestamp, country String, " +
+      "name String, phonetype String, serialname String) " +
+      "MEASURES (salary Integer) " +
+      "OPTIONS (NO_DICTIONARY(ID) PARTITIONER [PARTITION_COUNT=1])"
+    ).show()
+    sql(
+      s"LOAD DATA FACT FROM './src/test/resources/data2.csv' INTO CUBE filtertestTable OPTIONS" +
+        s"(DELIMITER ',', " +
+        s"FILEHEADER '')"
+    );
 
   }
 
@@ -129,6 +139,14 @@ class NO_DICTIONARY_COL_TestCase extends QueryTest with BeforeAndAfterAll {
       Seq(Row(17))
     )
   }
+  test("Detail Query with NO_DICTIONARY_COLUMN with IS NOT NULL filter") {
+
+
+    checkAnswer(
+      sql("select id  from filtertestTable where id is not null"),
+      Seq(Row(4), Row(6))
+    )
+  }
 
   test("Detail Query with NO_DICTIONARY_COLUMN with equals multiple filter Compare With HIVE " +
     "RESULT"
@@ -173,7 +191,7 @@ class NO_DICTIONARY_COL_TestCase extends QueryTest with BeforeAndAfterAll {
       sql("select sum(empno) from NO_DICTIONARY_CARBON_6")
     )
   }
-  
+
   test("average Query with NO_DICTIONARY_COLUMN  Compare With HIVE RESULT") {
 
     checkAnswer(

--- a/processing/src/main/java/org/carbondata/processing/graphgenerator/GraphGenerator.java
+++ b/processing/src/main/java/org/carbondata/processing/graphgenerator/GraphGenerator.java
@@ -530,6 +530,7 @@ public class GraphGenerator {
     seqMeta.setComplexTypeString(graphConfiguration.getComplexTypeString());
     seqMeta.setBatchSize(Integer.parseInt(graphConfiguration.getBatchSize()));
     seqMeta.setNoDictionaryDims(graphConfiguration.getNoDictionaryDims());
+    seqMeta.setDimensionColumnsDataType(graphConfiguration.getDimensionColumnsDataType());
     seqMeta.setCubeName(schemaInfo.getCubeName());
     seqMeta.setSchemaName(schemaInfo.getSchemaName());
     seqMeta.setComplexDelimiterLevel1(schemaInfo.getComplexDelimiterLevel1());
@@ -842,10 +843,10 @@ public class GraphGenerator {
     graphConfiguration.setMeasureNamesString(CarbonSchemaParser.getMeasuresNamesString(measures));
     graphConfiguration
         .setActualDimensionColumns(CarbonSchemaParser.getActualDimensions(dimensions));
-    //TODO: It will always be empty
+    graphConfiguration
+    .setDimensionColumnsDataType(CarbonSchemaParser.getDimensionsDataTypes(dimensions));
     //graphConfiguration.setNormHiers(CarbonSchemaParser.getNormHiers(cube, schema));
     graphConfiguration.setMeasureDataTypeInfo(CarbonSchemaParser.getMeasuresDataType(measures));
-
     graphConfiguration.setStoreLocation(
         this.schemaName + '/' + carbonDataLoadSchema.getCarbonTable().getFactTableName());
     graphConfiguration.setBlockletSize(

--- a/processing/src/main/java/org/carbondata/processing/graphgenerator/configuration/GraphConfigurationInfo.java
+++ b/processing/src/main/java/org/carbondata/processing/graphgenerator/configuration/GraphConfigurationInfo.java
@@ -203,7 +203,7 @@ public class GraphConfigurationInfo {
    * ~-> all ordinal with same group id
    */
   private String columnGroupsString;
-
+  private String columnsDataTypeString;
   /**
    * @return the connectionName
    */
@@ -997,5 +997,16 @@ public class GraphConfigurationInfo {
 
   public void setIsNoDictionaryDimMapping(Boolean[] isNoDictionaryDimMapping) {
     this.isNoDictionaryDimMapping = isNoDictionaryDimMapping;
+  }
+
+  /**
+   * @return columngroups
+   */
+  public String getDimensionColumnsDataType() {
+    return columnsDataTypeString;
+  }
+
+  public void setDimensionColumnsDataType(String columnsDataTypeString) {
+    this.columnsDataTypeString = columnsDataTypeString;
   }
 }

--- a/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
+++ b/processing/src/main/java/org/carbondata/processing/surrogatekeysgenerator/csvbased/CarbonCSVBasedSeqGenMeta.java
@@ -134,9 +134,17 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
    */
   protected String[] noDictionaryCols;
   /**
+   *
+   */
+  protected Map<String, String> dimColDataTypes;
+  /**
    * measureColumn
    */
   protected String[] measureColumn;
+  /**
+   * column data types
+   */
+  protected String[] dimColsDataType;
   /**
    * array of carbon measures
    */
@@ -363,6 +371,10 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
    * task id, each spark task has a unique id
    */
   private String taskNo;
+  /**
+   * column data type string.
+   */
+  private String columnsDataTypeString;
 
   public CarbonCSVBasedSeqGenMeta() {
     super();
@@ -622,6 +634,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
     segmentId = "";
     taskNo = "";
     columnSchemaDetails = "";
+    columnsDataTypeString="";
   }
 
   // helper method to allocate the arrays
@@ -662,6 +675,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
     retval.append("    ").append(XMLHandler.addTagValue("dimHierReleation", dimesionTableNames));
     retval.append("    ").append(XMLHandler.addTagValue("dimensionColumnIds", dimensionColumnIds));
     retval.append("    ").append(XMLHandler.addTagValue("dimNoDictionary", noDictionaryDims));
+    retval.append("    ").append(XMLHandler.addTagValue("dimColDataTypes", columnsDataTypeString));
     retval.append("    ").append(XMLHandler.addTagValue("factOrAggTable", tableName));
     retval.append("    ").append(XMLHandler.addTagValue("carbonhierColumn", carbonhierColumn));
     retval.append("    ").append(XMLHandler.addTagValue("normHiers", normHiers));
@@ -721,6 +735,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
       dimesionTableNames = XMLHandler.getTagValue(stepnode, "dimHierReleation");
       dimensionColumnIds = XMLHandler.getTagValue(stepnode, "dimensionColumnIds");
       noDictionaryDims = XMLHandler.getTagValue(stepnode, "dimNoDictionary");
+      columnsDataTypeString = XMLHandler.getTagValue(stepnode, "dimColDataTypes");
       tableName = XMLHandler.getTagValue(stepnode, "factOrAggTable");
       cubeName = XMLHandler.getTagValue(stepnode, "cubeName");
       schemaName = XMLHandler.getTagValue(stepnode, "schemaName");
@@ -760,7 +775,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
     columnSchemaDetailsWrapper = new ColumnSchemaDetailsWrapper(columnSchemaDetails);
 
     updateDimensions(carbondim, carbonmsr, noDictionaryDims);
-
+    dimColDataTypes=RemoveDictionaryUtil.extractDimColsDataTypeValues(columnsDataTypeString);
     if (null != complexTypeString) {
       complexTypes = getComplexTypesMap(complexTypeString);
     } else {
@@ -1258,6 +1273,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
       dimesionTableNames = rep.getStepAttributeString(idStep, "dimHierReleation");
       dimensionColumnIds = rep.getStepAttributeString(idStep, "dimensionColumnIds");
       noDictionaryDims = rep.getStepAttributeString(idStep, "dimNoDictionary");
+      columnsDataTypeString = rep.getStepAttributeString(idStep, "dimColDataTypes");
       normHiers = rep.getStepAttributeString(idStep, "normHiers");
       tableName = rep.getStepAttributeString(idStep, "factOrAggTable");
       batchSize = Integer.parseInt(rep.getStepAttributeString(idStep, "batchSize"));
@@ -1306,6 +1322,7 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
       rep.saveStepAttribute(idTransformation, idStep, "dimHierReleation", dimesionTableNames);
       rep.saveStepAttribute(idTransformation, idStep, "dimensionColumnIds", dimensionColumnIds);
       rep.saveStepAttribute(idTransformation, idStep, "dimNoDictionary", noDictionaryDims);
+      rep.saveStepAttribute(idTransformation, idStep, "dimColDataTypes", columnsDataTypeString);
       rep.saveStepAttribute(idTransformation, idStep, "foreignKeyHierarchyString",
           foreignKeyHierarchyString);
       rep.saveStepAttribute(idTransformation, idStep, "primaryKeysString", primaryKeysString);
@@ -1545,6 +1562,21 @@ public class CarbonCSVBasedSeqGenMeta extends BaseStepMeta implements StepMetaIn
 
   public void setNoDictionaryDims(String noDictionaryDims) {
     this.noDictionaryDims = noDictionaryDims;
+  }
+
+  /**
+   * @return columngroups
+   */
+  public String getDimensionColumnsDataType() {
+    return columnsDataTypeString;
+  }
+
+  /**
+   * @param columnsDataTypeString
+   */
+  public void setDimensionColumnsDataType(String columnsDataTypeString) {
+    this.columnsDataTypeString = columnsDataTypeString;
+
   }
 
   /**

--- a/processing/src/main/java/org/carbondata/processing/util/CarbonSchemaParser.java
+++ b/processing/src/main/java/org/carbondata/processing/util/CarbonSchemaParser.java
@@ -1053,6 +1053,24 @@ public final class CarbonSchemaParser {
     return actualDimString;
   }
 
+  /**Method will prepare column name and its data type string inorder
+   * to pass to the ETL steps.
+   * @param schemaInfo
+   * @param cube
+   * @return
+   */
+  public static String getDimensionsDataTypes(List<CarbonDimension> dimensions) {
+    StringBuilder dimDataTypeBuilder = new StringBuilder();
+    for (CarbonDimension cDimension : dimensions) {
+      dimDataTypeBuilder.append(cDimension.getColName());
+      dimDataTypeBuilder.append(CarbonCommonConstants.COMA_SPC_CHARACTER);
+      dimDataTypeBuilder.append(cDimension.getDataType().toString());
+      dimDataTypeBuilder.append(CarbonCommonConstants.AMPERSAND_SPC_CHARACTER);
+    }
+    String dimDataType = dimDataTypeBuilder.toString();
+    return dimDataType;
+  }
+
   /**
    * @param cube
    * @return

--- a/processing/src/main/java/org/carbondata/processing/util/RemoveDictionaryUtil.java
+++ b/processing/src/main/java/org/carbondata/processing/util/RemoveDictionaryUtil.java
@@ -24,7 +24,9 @@ package org.carbondata.processing.util;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.constants.IgnoreDictionary;
@@ -304,6 +306,24 @@ public class RemoveDictionaryUtil {
     }
 
     return list1.toArray(new String[list1.size()]);
+  }
+  /**
+   * This will extract the high cardinality count from the string.
+   */
+  public static Map<String, String> extractDimColsDataTypeValues(String colDataTypes) {
+    Map<String, String> mapOfColNameDataType =
+        new HashMap<String, String>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
+    if (null == colDataTypes || colDataTypes.isEmpty()) {
+      return mapOfColNameDataType;
+    }
+    String[] colArray = colDataTypes.split(CarbonCommonConstants.AMPERSAND_SPC_CHARACTER);
+    String[] colValueArray = null;
+    for (String colArrayVal : colArray) {
+      colValueArray = colArrayVal.split(CarbonCommonConstants.COMA_SPC_CHARACTER);
+      mapOfColNameDataType.put(colValueArray[0].toLowerCase(), colValueArray[1]);
+
+    }
+    return mapOfColNameDataType;
   }
 
   public static byte[] convertListByteArrToSingleArr(List<byte[]> noDictionaryValKeyList) {


### PR DESCRIPTION
Problem:
NOT NULL should not display any null values in the output

 No_Dictionary columns wont support double/decimal type, but in case of integer type data this scenario has to be handled.
issue is happening since no dictionary integer type column block contain String value, so when filter comparison happens the actual data which is a non null value  present in block
will be compared with default null member and the null will not get filtered out.

Solution:
To solve this issue while performing data load the no dictionary integer/other type of column excluding String type contains any un parseable data
the system has to convert it to default null member value.


