### PR TITLE
[Bug] Sort index not created properly for null members in case of String type

### DIFF
--- a/core/src/main/java/org/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
+++ b/core/src/main/java/org/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
@@ -224,7 +224,6 @@ public class ColumnDictionaryInfo extends AbstractColumnDictionaryInfo {
     try {
       switch (dataType) {
         case INT:
-
           return Integer.compare((Integer.parseInt(dictionaryVal)), (Integer.parseInt(memberVal)));
         case DOUBLE:
           return Double
@@ -243,7 +242,6 @@ public class ColumnDictionaryInfo extends AbstractColumnDictionaryInfo {
           dateToStr = parser.parse(memberVal);
           dictionaryDate = parser.parse(dictionaryVal);
           return dictionaryDate.compareTo(dateToStr);
-
         case DECIMAL:
           java.math.BigDecimal javaDecValForDictVal = new java.math.BigDecimal(dictionaryVal);
           java.math.BigDecimal javaDecValForMemberVal = new java.math.BigDecimal(memberVal);
@@ -252,6 +250,13 @@ public class ColumnDictionaryInfo extends AbstractColumnDictionaryInfo {
           return -1;
       }
     } catch (Exception e) {
+      //In all data types excluding String data type the null member will be the highest
+      //while doing search in dictioary when the member comparison happens with filter member
+      //which is also null member, since the parsing fails in other data type except string
+      //explicit comparison is required, is both are null member then system has to return 0.
+      if (memberVal.equals(dictionaryVal)) {
+        return 0;
+      }
       return -1;
     }
   }

--- a/core/src/main/java/org/carbondata/core/writer/sortindex/CarbonDictionarySortModel.java
+++ b/core/src/main/java/org/carbondata/core/writer/sortindex/CarbonDictionarySortModel.java
@@ -73,6 +73,9 @@ public class CarbonDictionarySortModel implements Comparable<CarbonDictionarySor
         try {
           d1 = new Double(memberValue);
         } catch (NumberFormatException e) {
+          if (CarbonCommonConstants.MEMBER_DEFAULT_VAL.equals(o.memberValue)) {
+            return -1;
+          }
           return 1;
         }
         try {
@@ -87,6 +90,9 @@ public class CarbonDictionarySortModel implements Comparable<CarbonDictionarySor
         try {
           val1 = new java.math.BigDecimal(memberValue);
         } catch (NumberFormatException e) {
+          if (CarbonCommonConstants.MEMBER_DEFAULT_VAL.equals(o.memberValue)) {
+            return -1;
+          }
           return 1;
         }
         try {
@@ -104,6 +110,9 @@ public class CarbonDictionarySortModel implements Comparable<CarbonDictionarySor
         try {
           date1 = parser.parse(memberValue);
         } catch (ParseException e) {
+          if (CarbonCommonConstants.MEMBER_DEFAULT_VAL.equals(o.memberValue)) {
+            return -1;
+          }
           return 1;
         }
         try {

--- a/core/src/main/java/org/carbondata/query/expression/LiteralExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/LiteralExpression.java
@@ -56,4 +56,13 @@ public class LiteralExpression extends LeafExpression {
     return "LiteralExpression(" + value + ')';
   }
 
+  /**
+   * getLiteralExpDataType.
+   *
+   * @return
+   */
+  public DataType getLiteralExpDataType() {
+    return dataType;
+  }
+
 }

--- a/core/src/main/java/org/carbondata/query/filter/resolver/ConditionalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/ConditionalFilterResolverImpl.java
@@ -80,7 +80,9 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
         // column expression.
         // we need to check if the other expression contains column
         // expression or not in depth.
-        if (FilterUtil.checkIfExpressionContainsColumn(rightExp)) {
+        if (FilterUtil.checkIfExpressionContainsColumn(rightExp)||
+            FilterUtil.isExpressionNeedsToResolved(rightExp,isIncludeFilter) &&
+            columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)){
           isExpressionResolve = true;
         } else {
           //Visitor pattern is been used in this scenario inorder to populate the

--- a/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
@@ -69,6 +69,7 @@ import org.carbondata.query.evaluators.DimColumnExecuterFilterInfo;
 import org.carbondata.query.expression.ColumnExpression;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.LiteralExpression;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 import org.carbondata.query.filter.executer.AndFilterExecuterImpl;
 import org.carbondata.query.filter.executer.ColGroupFilterExecuterImpl;
@@ -1207,6 +1208,27 @@ public final class FilterUtil {
 
     traverseResolverTreeAndPopulateStartAndEndKeys(filterResolverTree.getRight(), tableIdentifier,
         segmentProperties, startKeys, setOfStartKeyByteArray, endKeys, setOfEndKeyByteArray);
+  }
+
+  /**
+   * Method will find whether the expression needs to be resolved, this can happen
+   * if the expression is exclude and data type is null(mainly in IS NOT NULL filter scenario)
+   * @param rightExp
+   * @param isIncludeFilter
+   * @return
+   */
+  public static boolean isExpressionNeedsToResolved(Expression rightExp, boolean isIncludeFilter) {
+    if (!isIncludeFilter && rightExp instanceof LiteralExpression && (
+        org.carbondata.query.expression.DataType.NullType == ((LiteralExpression) rightExp)
+            .getLiteralExpDataType())) {
+      return true;
+    }
+    for (Expression child : rightExp.getChildren()) {
+      if (isExpressionNeedsToResolved(child, isIncludeFilter)) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/filterexpr/FilterProcessorTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/filterexpr/FilterProcessorTestCase.scala
@@ -36,6 +36,7 @@ class FilterProcessorTestCase extends QueryTest with BeforeAndAfterAll {
   override def beforeAll {
     sql("drop cube if exists filtertestTables")
     sql("drop cube if exists filtertestTablesWithDecimal")
+    sql("drop cube if exists filtertestTablesWithNull")
     sql("CREATE CUBE filtertestTables DIMENSIONS (ID Integer, date Timestamp, country String, " +
       "name String, phonetype String, serialname String) " +
       "MEASURES (salary Integer) " +
@@ -58,6 +59,26 @@ class FilterProcessorTestCase extends QueryTest with BeforeAndAfterAll {
         s"filtertestTablesWithDecimal " +
         s"OPTIONS(DELIMITER ',', " +
         s"FILEHEADER '')"
+    )
+    sql(
+      "CREATE CUBE filtertestTablesWithNull DIMENSIONS (ID Integer, date Timestamp, country " +
+        "String, " +
+        "name String, phonetype String, serialname String) " +
+        "MEASURES (salary Integer) " +
+        "OPTIONS (PARTITIONER [PARTITION_COUNT=1])"
+    )
+    sql(
+      s"LOAD DATA FACT FROM './src/test/resources/data2.csv' INTO CUBE " +
+        s"filtertestTablesWithNull " +
+        s"OPTIONS(DELIMITER ',', " +
+        s"FILEHEADER '')"
+    )
+  }
+
+  test("Is not null filter") {
+    checkAnswer(
+      sql("select id from filtertestTablesWithNull " + "where id is not null"),
+      Seq(Row(4), Row(6))
     )
   }
 


### PR DESCRIPTION
SortModel reference was not sorting the forward dictionary values when null member/nonparseable was present in the column data other than string.

In filter layer also when IS NOT NULL filter resolve happens the filter expression has to be evaluated with all the filter values when the column data has both null and unparseable data in different data type column other than String.