### PR TITLE
[Issue-578] Compaction Support : Delete segment by id query should support decimal value also as id

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -1325,8 +1325,13 @@ class CarbonSqlParser()
         ShowLoadsCommand(schemaName, cubeName.toLowerCase(), limit)
     }
 
+  protected lazy val segmentId: Parser[String] =
+    ( numericLit ^^ { u => u } |
+      elem("decimal", _.isInstanceOf[lexical.FloatLit]) ^^ (_.chars)
+      )
+
   protected lazy val deleteLoadsByID: Parser[LogicalPlan] =
-    DELETE ~> (LOAD|SEGMENT) ~> repsep(numericLit, ",") ~ (FROM ~> (CUBE | TABLE) ~>
+    DELETE ~> (LOAD|SEGMENT) ~> repsep(segmentId, ",") ~ (FROM ~> (CUBE | TABLE) ~>
       (ident <~ ".").? ~ ident) <~
       opt(";") ^^ {
       case loadids ~ cube => cube match {

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
@@ -30,6 +30,13 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
     segments
   }
 
+  val currentDirectory = new File(this.getClass.getResource("/").getPath + "/../../")
+    .getCanonicalPath
+
+  var csvFilePath1 = currentDirectory + "/src/test/resources/compaction/compaction1.csv"
+  var csvFilePath2 = currentDirectory + "/src/test/resources/compaction/compaction2.csv"
+  var csvFilePath3 = currentDirectory + "/src/test/resources/compaction/compaction3.csv"
+
   override def beforeAll {
 
     sql(
@@ -39,12 +46,7 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
         ".format' TBLPROPERTIES('DICTIONARY_EXCLUDE'='country')"
     )
 
-    val currentDirectory = new File(this.getClass.getResource("/").getPath + "/../../")
-      .getCanonicalPath
 
-    var csvFilePath1 = currentDirectory + "/src/test/resources/compaction/compaction1.csv"
-    var csvFilePath2 = currentDirectory + "/src/test/resources/compaction/compaction2.csv"
-    var csvFilePath3 = currentDirectory + "/src/test/resources/compaction/compaction3.csv"
 
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/mm/dd")
@@ -139,6 +141,14 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
         Row("iraq"),
         Row("ireland")
       )
+    )
+    sql("LOAD DATA LOCAL INPATH '" + csvFilePath1 + "' INTO TABLE nodictionaryCompaction " +
+        "OPTIONS('DELIMITER' = ',')"
+    )
+    sql("DELETE segment 0.1,3 FROM TABLE nodictionaryCompaction")
+    checkAnswer(
+      sql("select country from nodictionaryCompaction"),
+      Seq()
     )
   }
 


### PR DESCRIPTION
After compaction segment id will be decimal value, so delete segment by id query should support decimal value also as id