### PR TITLE
[Bug] Row level scanning filters while filtering invalid member giving exception

### DIFF
--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -1034,6 +1034,12 @@ public final class CarbonCommonConstants {
    */
   public static final String ZOOKEEPER_LOCK = "zookeeperLock";
 
+  /**
+   * Invalid filter member log string
+   */
+  public static final String FILTER_INVALID_MEMBER = " Invalid Record(s) are present "
+                                                     + "while filter evaluation. ";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/carbondata/query/expression/Expression.java
+++ b/core/src/main/java/org/carbondata/query/expression/Expression.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.query.carbonfilterinterface.ExpressionType;
 import org.carbondata.query.carbonfilterinterface.RowIntf;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public abstract class Expression implements Serializable {
@@ -37,7 +38,8 @@ public abstract class Expression implements Serializable {
   protected List<Expression> children =
       new ArrayList<Expression>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
 
-  public abstract ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException;
+  public abstract ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException;
 
   public abstract ExpressionType getFilterExpressionType();
 

--- a/core/src/main/java/org/carbondata/query/expression/ExpressionResult.java
+++ b/core/src/main/java/org/carbondata/query/expression/ExpressionResult.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.util.CarbonProperties;
-import org.carbondata.query.expression.exception.FilterUnsupportedException;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 
 public class ExpressionResult implements Comparable<ExpressionResult> {
 
@@ -60,7 +60,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
   }
 
   //CHECKSTYLE:OFF Approval No:Approval-V1R2C10_009
-  public Integer getInt() throws FilterUnsupportedException {
+  public Integer getInt() throws FilterIllegalMemberException {
     if (value == null) {
       return null;
     }
@@ -70,7 +70,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
           try {
             return Integer.parseInt(value.toString());
           } catch (NumberFormatException e) {
-            throw new FilterUnsupportedException(e);
+            throw new FilterIllegalMemberException(e);
           }
 
         case IntegerType:
@@ -90,37 +90,42 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
           }
 
         default:
-          throw new FilterUnsupportedException(
+          throw new FilterIllegalMemberException(
               "Cannot convert" + this.getDataType().name() + " to integer type value");
       }
 
     } catch (ClassCastException e) {
-      throw new FilterUnsupportedException(
+      throw new FilterIllegalMemberException(
           "Cannot convert" + this.getDataType().name() + " to Integer type value");
     }
   }
 
-  public String getString() {
+  public String getString() throws FilterIllegalMemberException {
     if (value == null) {
       return null;
     }
-    switch (this.getDataType()) {
-      case TimestampType:
-        SimpleDateFormat parser = new SimpleDateFormat(CarbonProperties.getInstance()
-            .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
-                CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
-        if (value instanceof Timestamp) {
-          return parser.format((Timestamp) value);
-        } else {
-          return parser.format(new Timestamp((long) value / 1000));
-        }
+    try {
+      switch (this.getDataType()) {
+        case TimestampType:
+          SimpleDateFormat parser = new SimpleDateFormat(CarbonProperties.getInstance()
+              .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+                  CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
+          if (value instanceof Timestamp) {
+            return parser.format((Timestamp) value);
+          } else {
+            return parser.format(new Timestamp((long) value / 1000));
+          }
 
-      default:
-        return value.toString();
+        default:
+          return value.toString();
+      }
+    } catch (Exception e) {
+      throw new FilterIllegalMemberException(
+          "Cannot convert" + this.getDataType().name() + " to String type value");
     }
   }
 
-  public Double getDouble() throws FilterUnsupportedException {
+  public Double getDouble() throws FilterIllegalMemberException {
     if (value == null) {
       return null;
     }
@@ -130,7 +135,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
           try {
             return Double.parseDouble(value.toString());
           } catch (NumberFormatException e) {
-            throw new FilterUnsupportedException(e);
+            throw new FilterIllegalMemberException(e);
           }
 
         case IntegerType:
@@ -146,17 +151,17 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
             return (Double) (value);
           }
         default:
-          throw new FilterUnsupportedException(
+          throw new FilterIllegalMemberException(
               "Cannot convert" + this.getDataType().name() + " to double type value");
       }
     } catch (ClassCastException e) {
-      throw new FilterUnsupportedException(
+      throw new FilterIllegalMemberException(
           "Cannot convert" + this.getDataType().name() + " to Double type value");
     }
   }
   //CHECKSTYLE:ON
 
-  public Long getLong() throws FilterUnsupportedException {
+  public Long getLong() throws FilterIllegalMemberException {
     if (value == null) {
       return null;
     }
@@ -166,7 +171,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
           try {
             return Long.parseLong(value.toString());
           } catch (NumberFormatException e) {
-            throw new FilterUnsupportedException(e);
+            throw new FilterIllegalMemberException(e);
           }
 
         case IntegerType:
@@ -182,18 +187,18 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
             return (Long) value;
           }
         default:
-          throw new FilterUnsupportedException(
+          throw new FilterIllegalMemberException(
               "Cannot convert" + this.getDataType().name() + " to Long type value");
       }
     } catch (ClassCastException e) {
-      throw new FilterUnsupportedException(
+      throw new FilterIllegalMemberException(
           "Cannot convert" + this.getDataType().name() + " to Long type value");
     }
 
   }
 
   //Add to judge for BigDecimal
-  public BigDecimal getDecimal() throws FilterUnsupportedException {
+  public BigDecimal getDecimal() throws FilterIllegalMemberException {
     if (value == null) {
       return null;
     }
@@ -203,7 +208,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
           try {
             return new BigDecimal(value.toString());
           } catch (NumberFormatException e) {
-            throw new FilterUnsupportedException(e);
+            throw new FilterIllegalMemberException(e);
           }
 
         case IntegerType:
@@ -221,17 +226,17 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
             return new BigDecimal((long) value);
           }
         default:
-          throw new FilterUnsupportedException(
+          throw new FilterIllegalMemberException(
               "Cannot convert" + this.getDataType().name() + " to Long type value");
       }
     } catch (ClassCastException e) {
-      throw new FilterUnsupportedException(
+      throw new FilterIllegalMemberException(
           "Cannot convert" + this.getDataType().name() + " to Long type value");
     }
 
   }
 
-  public Long getTime() throws FilterUnsupportedException {
+  public Long getTime() throws FilterIllegalMemberException {
     if (value == null) {
       return null;
     }
@@ -246,7 +251,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
             dateToStr = parser.parse(value.toString());
             return dateToStr.getTime() * 1000;
           } catch (ParseException e) {
-            throw new FilterUnsupportedException(
+            throw new FilterIllegalMemberException(
                 "Cannot convert" + this.getDataType().name() + " to Time/Long type value");
           }
         case IntegerType:
@@ -261,17 +266,17 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
             return (Long) value;
           }
         default:
-          throw new FilterUnsupportedException(
+          throw new FilterIllegalMemberException(
               "Cannot convert" + this.getDataType().name() + " to Time/Long type value");
       }
     } catch (ClassCastException e) {
-      throw new FilterUnsupportedException(
+      throw new FilterIllegalMemberException(
           "Cannot convert" + this.getDataType().name() + " to Time/Long type value");
     }
 
   }
 
-  public Boolean getBoolean() throws FilterUnsupportedException {
+  public Boolean getBoolean() throws FilterIllegalMemberException {
     if (value == null) {
       return null;
     }
@@ -281,18 +286,18 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
           try {
             return Boolean.parseBoolean(value.toString());
           } catch (NumberFormatException e) {
-            throw new FilterUnsupportedException(e);
+            throw new FilterIllegalMemberException(e);
           }
 
         case BooleanType:
           return Boolean.parseBoolean(value.toString());
 
         default:
-          throw new FilterUnsupportedException(
+          throw new FilterIllegalMemberException(
               "Cannot convert" + this.getDataType().name() + " to boolean type value");
       }
     } catch (ClassCastException e) {
-      throw new FilterUnsupportedException(
+      throw new FilterIllegalMemberException(
           "Cannot convert" + this.getDataType().name() + " to Boolean type value");
     }
   }
@@ -307,7 +312,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
     }
   }
 
-  public List<String> getListAsString() {
+  public List<String> getListAsString() throws FilterIllegalMemberException {
     List<String> evaluateResultListFinal = new ArrayList<String>(20);
     List<ExpressionResult> evaluateResultList = getList();
     for (ExpressionResult result : evaluateResultList) {
@@ -367,7 +372,7 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
         default:
           break;
       }
-    } catch (FilterUnsupportedException ex) {
+    } catch (FilterIllegalMemberException ex) {
       return false;
     }
 

--- a/core/src/main/java/org/carbondata/query/expression/arithmetic/AddExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/arithmetic/AddExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class AddExpression extends BinaryArithmeticExpression {
@@ -33,7 +34,8 @@ public class AddExpression extends BinaryArithmeticExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult addExprLeftRes = left.evaluate(value);
     ExpressionResult addExprRightRes = right.evaluate(value);
     ExpressionResult val1 = addExprLeftRes;

--- a/core/src/main/java/org/carbondata/query/expression/arithmetic/DivideExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/arithmetic/DivideExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class DivideExpression extends BinaryArithmeticExpression {
@@ -33,7 +34,8 @@ public class DivideExpression extends BinaryArithmeticExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult divideExprLeftRes = left.evaluate(value);
     ExpressionResult divideExprRightRes = right.evaluate(value);
     ExpressionResult val1 = divideExprLeftRes;

--- a/core/src/main/java/org/carbondata/query/expression/arithmetic/MultiplyExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/arithmetic/MultiplyExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class MultiplyExpression extends BinaryArithmeticExpression {
@@ -33,7 +34,8 @@ public class MultiplyExpression extends BinaryArithmeticExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult multiplyExprLeftRes = left.evaluate(value);
     ExpressionResult multiplyExprRightRes = right.evaluate(value);
     ExpressionResult val1 = multiplyExprLeftRes;

--- a/core/src/main/java/org/carbondata/query/expression/arithmetic/SubstractExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/arithmetic/SubstractExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class SubstractExpression extends BinaryArithmeticExpression {
@@ -34,7 +35,8 @@ public class SubstractExpression extends BinaryArithmeticExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult subtractExprLeftRes = left.evaluate(value);
     ExpressionResult subtractExprRightRes = right.evaluate(value);
     ExpressionResult val1 = subtractExprLeftRes;

--- a/core/src/main/java/org/carbondata/query/expression/conditional/EqualToExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/EqualToExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class EqualToExpression extends BinaryConditionalExpression {
@@ -34,7 +35,8 @@ public class EqualToExpression extends BinaryConditionalExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult elRes = left.evaluate(value);
     ExpressionResult erRes = right.evaluate(value);
 
@@ -56,7 +58,6 @@ public class EqualToExpression extends BinaryConditionalExpression {
       }
     }
 
-    // todo: move to util
     switch (val1.getDataType()) {
       case StringType:
         result = val1.getString().equals(val2.getString());

--- a/core/src/main/java/org/carbondata/query/expression/conditional/GreaterThanEqualToExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/GreaterThanEqualToExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class GreaterThanEqualToExpression extends BinaryConditionalExpression {
@@ -33,7 +34,8 @@ public class GreaterThanEqualToExpression extends BinaryConditionalExpression {
     super(left, right);
   }
 
-  public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult elRes = left.evaluate(value);
     ExpressionResult erRes = right.evaluate(value);
     ExpressionResult exprResVal1 = elRes;

--- a/core/src/main/java/org/carbondata/query/expression/conditional/GreaterThanExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/GreaterThanExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class GreaterThanExpression extends BinaryConditionalExpression {
@@ -31,10 +32,10 @@ public class GreaterThanExpression extends BinaryConditionalExpression {
 
   public GreaterThanExpression(Expression left, Expression right) {
     super(left, right);
-    // TODO Auto-generated constructor stub
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult exprLeftRes = left.evaluate(value);
     ExpressionResult exprRightRes = right.evaluate(value);
     ExpressionResult val1 = exprLeftRes;

--- a/core/src/main/java/org/carbondata/query/expression/conditional/InExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/InExpression.java
@@ -27,6 +27,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class InExpression extends BinaryConditionalExpression {
@@ -38,7 +39,8 @@ public class InExpression extends BinaryConditionalExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult leftRsult = left.evaluate(value);
 
     if (setOfExprResult == null) {
@@ -54,7 +56,6 @@ public class InExpression extends BinaryConditionalExpression {
           } else {
             val = expressionResVal;
           }
-
           switch (val.getDataType()) {
             case StringType:
               val = new ExpressionResult(val.getDataType(), expressionResVal.getString());
@@ -78,7 +79,6 @@ public class InExpression extends BinaryConditionalExpression {
               throw new FilterUnsupportedException(
                   "DataType: " + val.getDataType() + " not supported for the filter expression");
           }
-
         }
         setOfExprResult.add(val);
 

--- a/core/src/main/java/org/carbondata/query/expression/conditional/LessThanEqualToExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/LessThanEqualToExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class LessThanEqualToExpression extends BinaryConditionalExpression {
@@ -31,10 +32,10 @@ public class LessThanEqualToExpression extends BinaryConditionalExpression {
 
   public LessThanEqualToExpression(Expression left, Expression right) {
     super(left, right);
-    // TODO Auto-generated constructor stub
   }
 
-  public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult elRes = left.evaluate(value);
     ExpressionResult erRes = right.evaluate(value);
     ExpressionResult exprResValue1 = elRes;

--- a/core/src/main/java/org/carbondata/query/expression/conditional/LessThanExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/LessThanExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class LessThanExpression extends BinaryConditionalExpression {
@@ -34,7 +35,8 @@ public class LessThanExpression extends BinaryConditionalExpression {
     super(left, right);
   }
 
-  public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult erRes = right.evaluate(value);
     ExpressionResult elRes = left.evaluate(value);
 

--- a/core/src/main/java/org/carbondata/query/expression/conditional/ListExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/ListExpression.java
@@ -26,6 +26,7 @@ import org.carbondata.query.carbonfilterinterface.ExpressionType;
 import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class ListExpression extends Expression {
@@ -39,7 +40,11 @@ public class ListExpression extends Expression {
     List<ExpressionResult> listOfExprRes = new ArrayList<ExpressionResult>(10);
 
     for (Expression expr : children) {
-      listOfExprRes.add(expr.evaluate(value));
+      try {
+        listOfExprRes.add(expr.evaluate(value));
+      } catch (FilterIllegalMemberException e) {
+        continue;
+      }
     }
     return new ExpressionResult(listOfExprRes);
   }

--- a/core/src/main/java/org/carbondata/query/expression/conditional/NotEqualsExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/NotEqualsExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class NotEqualsExpression extends BinaryConditionalExpression {
@@ -34,7 +35,8 @@ public class NotEqualsExpression extends BinaryConditionalExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult elRes = left.evaluate(value);
     ExpressionResult erRes = right.evaluate(value);
 

--- a/core/src/main/java/org/carbondata/query/expression/conditional/NotInExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/NotInExpression.java
@@ -27,6 +27,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class NotInExpression extends BinaryConditionalExpression {
@@ -37,7 +38,8 @@ public class NotInExpression extends BinaryConditionalExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult leftRsult = left.evaluate(value);
 
     if (setOfExprResult == null) {
@@ -54,7 +56,6 @@ public class NotInExpression extends BinaryConditionalExpression {
           } else {
             val = exprResVal;
           }
-
           switch (val.getDataType()) {
             case StringType:
               val = new ExpressionResult(val.getDataType(), exprResVal.getString());
@@ -78,7 +79,6 @@ public class NotInExpression extends BinaryConditionalExpression {
               throw new FilterUnsupportedException(
                   "DataType: " + val.getDataType() + " not supported for the filter expression");
           }
-
         }
         setOfExprResult.add(val);
 

--- a/core/src/main/java/org/carbondata/query/expression/exception/FilterIllegalMemberException.java
+++ b/core/src/main/java/org/carbondata/query/expression/exception/FilterIllegalMemberException.java
@@ -16,11 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.carbondata.query.expression.exception;
 
 import java.util.Locale;
 
-public class FilterUnsupportedException extends Exception {
+/**
+ * FilterIllegalMemberException class representing exception which can cause while evaluating
+ * filter members needs to be gracefully handled without propagating to outer layer so that
+ * the execution should not get interrupted.
+ */
+public class FilterIllegalMemberException extends Exception {
 
   /**
    * default serial version ID.
@@ -38,7 +44,7 @@ public class FilterUnsupportedException extends Exception {
    * @param errorCode The error code for this exception.
    * @param msg       The error message for this exception.
    */
-  public FilterUnsupportedException(String msg) {
+  public FilterIllegalMemberException(String msg) {
     super(msg);
     this.msg = msg;
   }
@@ -49,7 +55,7 @@ public class FilterUnsupportedException extends Exception {
    * @param errorCode The error code for this exception.
    * @param msg       The error message for this exception.
    */
-  public FilterUnsupportedException(String msg, Throwable t) {
+  public FilterIllegalMemberException(String msg, Throwable t) {
     super(msg, t);
     this.msg = msg;
   }
@@ -60,7 +66,7 @@ public class FilterUnsupportedException extends Exception {
    * @param errorCode The error code for this exception.
    * @param msg       The error message for this exception.
    */
-  public FilterUnsupportedException(Throwable t) {
+  public FilterIllegalMemberException(Throwable t) {
     super(t);
   }
 
@@ -88,4 +94,5 @@ public class FilterUnsupportedException extends Exception {
   public String getMessage() {
     return this.msg;
   }
+
 }

--- a/core/src/main/java/org/carbondata/query/expression/logical/AndExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/logical/AndExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class AndExpression extends BinaryLogicalExpression {
@@ -32,10 +33,10 @@ public class AndExpression extends BinaryLogicalExpression {
 
   public AndExpression(Expression left, Expression right) {
     super(left, right);
-    // TODO Auto-generated constructor stub
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult resultLeft = left.evaluate(value);
     ExpressionResult resultRight = right.evaluate(value);
     switch (resultLeft.getDataType()) {
@@ -46,7 +47,6 @@ public class AndExpression extends BinaryLogicalExpression {
         throw new FilterUnsupportedException(
             "Incompatible datatype for applying AND Expression Filter");
     }
-
     return resultLeft;
   }
 

--- a/core/src/main/java/org/carbondata/query/expression/logical/NotExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/logical/NotExpression.java
@@ -25,6 +25,7 @@ import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
 import org.carbondata.query.expression.UnaryExpression;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class NotExpression extends UnaryExpression {
@@ -34,7 +35,8 @@ public class NotExpression extends UnaryExpression {
     super(child);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterIllegalMemberException, FilterUnsupportedException {
     ExpressionResult expResult = child.evaluate(value);
     expResult.set(DataType.BooleanType, !(expResult.getBoolean()));
     switch (expResult.getDataType()) {

--- a/core/src/main/java/org/carbondata/query/expression/logical/OrExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/logical/OrExpression.java
@@ -24,6 +24,7 @@ import org.carbondata.query.carbonfilterinterface.RowIntf;
 import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 
 public class OrExpression extends BinaryLogicalExpression {
@@ -34,7 +35,8 @@ public class OrExpression extends BinaryLogicalExpression {
     super(left, right);
   }
 
-  @Override public ExpressionResult evaluate(RowIntf value) throws FilterUnsupportedException {
+  @Override public ExpressionResult evaluate(RowIntf value)
+      throws FilterIllegalMemberException, FilterUnsupportedException {
     ExpressionResult resultLeft = left.evaluate(value);
     ExpressionResult resultRight = right.evaluate(value);
     switch (resultLeft.getDataType()) {

--- a/core/src/main/java/org/carbondata/query/filter/resolver/RestructureFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/RestructureFilterResolverImpl.java
@@ -29,6 +29,7 @@ import org.carbondata.query.expression.DataType;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.conditional.BinaryConditionalExpression;
 import org.carbondata.query.expression.conditional.ConditionalExpression;
+import org.carbondata.query.expression.exception.FilterUnsupportedException;
 import org.carbondata.query.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 import org.carbondata.query.filters.measurefilter.util.FilterUtil;
 
@@ -65,8 +66,10 @@ public class RestructureFilterResolverImpl implements FilterResolverIntf {
    * value
    *
    * @param absoluteTableIdentifier
+   * @throws FilterUnsupportedException
    */
-  @Override public void resolve(AbsoluteTableIdentifier absoluteTableIdentifier) {
+  @Override public void resolve(AbsoluteTableIdentifier absoluteTableIdentifier)
+      throws FilterUnsupportedException {
 
     DimColumnResolvedFilterInfo dimColumnResolvedFilterInfo = new DimColumnResolvedFilterInfo();
     if (!this.isExpressionResolve && exp instanceof BinaryConditionalExpression) {

--- a/core/src/main/java/org/carbondata/query/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -24,6 +24,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.SortedMap;
 
+import org.carbondata.common.logging.LogService;
+import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
 import org.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
@@ -35,6 +37,7 @@ import org.carbondata.query.expression.ColumnExpression;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
 import org.carbondata.query.expression.conditional.BinaryConditionalExpression;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.logical.BinaryLogicalExpression;
 import org.carbondata.query.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 import org.carbondata.query.filter.resolver.resolverinfo.MeasureColumnResolvedFilterInfo;
@@ -47,7 +50,8 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
    *
    */
   private static final long serialVersionUID = 6629319265336666789L;
-
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(RowLevelRangeFilterResolverImpl.class.getName());
   private List<DimColumnResolvedFilterInfo> dimColEvaluatorInfoList;
   private List<MeasureColumnResolvedFilterInfo> msrColEvalutorInfoList;
   private AbsoluteTableIdentifier tableIdentifier;
@@ -122,12 +126,20 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
           ((BinaryConditionalExpression) this.getFilterExpression()).getLiterals();
     }
     List<byte[]> filterValuesList = new ArrayList<byte[]>(20);
+    boolean invalidRowsPresent = false;
     for (ExpressionResult result : listOfExpressionResults) {
-      if (result.getString() == null) {
-        filterValuesList.add(CarbonCommonConstants.MEMBER_DEFAULT_VAL.getBytes());
-        continue;
+      try {
+        if (result.getString() == null) {
+          filterValuesList.add(CarbonCommonConstants.MEMBER_DEFAULT_VAL.getBytes());
+          continue;
+        }
+        filterValuesList.add(result.getString().getBytes());
+      } catch (FilterIllegalMemberException e) {
+        // Any invalid member while evaluation shall be ignored, system will log the
+        // error only once since all rows the evaluation happens so inorder to avoid
+        // too much log inforation only once the log will be printed.
+        FilterUtil.logError(e, invalidRowsPresent);
       }
-      filterValuesList.add(result.getString().getBytes());
     }
     Comparator<byte[]> filterNoDictValueComaparator = new Comparator<byte[]>() {
       @Override public int compare(byte[] filterMember1, byte[] filterMember2) {

--- a/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/CustomTypeDictionaryVisitor.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/CustomTypeDictionaryVisitor.java
@@ -28,6 +28,7 @@ import org.carbondata.core.carbon.AbsoluteTableIdentifier;
 import org.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
 import org.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
 import org.carbondata.query.expression.ColumnExpression;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 import org.carbondata.query.filter.resolver.metadata.FilterResolverMetadata;
 import org.carbondata.query.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
@@ -44,14 +45,19 @@ public class CustomTypeDictionaryVisitor implements ResolvedFilterInfoVisitorInt
    *
    * @param visitableObj
    * @param metadata
-   * @throws FilterUnsupportedException
+   * @throws FilterUnsupportedException,thrown out if exception occurs while evaluating
+   * filter models.
    */
   public void populateFilterResolvedInfo(DimColumnResolvedFilterInfo visitableObj,
       FilterResolverMetadata metadata) throws FilterUnsupportedException {
     DimColumnFilterInfo resolvedFilterObject = null;
 
-    List<String> evaluateResultListFinal =
-        metadata.getExpression().evaluate(null).getListAsString();
+    List<String> evaluateResultListFinal;
+    try {
+      evaluateResultListFinal = metadata.getExpression().evaluate(null).getListAsString();
+    } catch (FilterIllegalMemberException e) {
+      throw new FilterUnsupportedException(e);
+    }
     resolvedFilterObject = getDirectDictionaryValKeyMemberForFilter(metadata.getTableIdentifier(),
         metadata.getColumnExpression(), evaluateResultListFinal, metadata.isIncludeFilter());
     visitableObj.setFilterValues(resolvedFilterObject);

--- a/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/DictionaryColumnVisitor.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/DictionaryColumnVisitor.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.query.carbon.executor.exception.QueryExecutionException;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 import org.carbondata.query.filter.resolver.metadata.FilterResolverMetadata;
 import org.carbondata.query.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
@@ -39,13 +40,19 @@ public class DictionaryColumnVisitor implements ResolvedFilterInfoVisitorIntf {
    *
    * @param visitableObj
    * @param metadata
+   * @throws FilterUnsupportedException,thrown out if exception occurs while evaluating
+   * filter models.
    * @throws QueryExecutionException
    */
   public void populateFilterResolvedInfo(DimColumnResolvedFilterInfo visitableObj,
       FilterResolverMetadata metadata) throws FilterUnsupportedException {
     DimColumnFilterInfo resolvedFilterObject = null;
-    List<String> evaluateResultListFinal =
-        metadata.getExpression().evaluate(null).getListAsString();
+    List<String> evaluateResultListFinal;
+    try {
+      evaluateResultListFinal = metadata.getExpression().evaluate(null).getListAsString();
+    } catch (FilterIllegalMemberException e) {
+      throw new FilterUnsupportedException(e);
+    }
     try {
       resolvedFilterObject = FilterUtil
           .getFilterValues(metadata.getTableIdentifier(), metadata.getColumnExpression(),

--- a/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/NoDictionaryTypeVisitor.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/NoDictionaryTypeVisitor.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
+import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 import org.carbondata.query.filter.resolver.metadata.FilterResolverMetadata;
 import org.carbondata.query.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
@@ -41,13 +42,18 @@ public class NoDictionaryTypeVisitor implements ResolvedFilterInfoVisitorIntf {
    *
    * @param visitableObj
    * @param metadata
-   * @throws FilterUnsupportedException
+   * @throws FilterUnsupportedException,thrown out if exception occurs while evaluating
+   * filter models.
    */
   public void populateFilterResolvedInfo(DimColumnResolvedFilterInfo visitableObj,
       FilterResolverMetadata metadata) throws FilterUnsupportedException {
     DimColumnFilterInfo resolvedFilterObject = null;
-    List<String> evaluateResultListFinal =
-        metadata.getExpression().evaluate(null).getListAsString();
+    List<String> evaluateResultListFinal;
+    try {
+      evaluateResultListFinal = metadata.getExpression().evaluate(null).getListAsString();
+    } catch (FilterIllegalMemberException e) {
+      throw new FilterUnsupportedException(e);
+    }
     resolvedFilterObject = FilterUtil
         .getNoDictionaryValKeyMemberForFilter(metadata.getTableIdentifier(),
             metadata.getColumnExpression(), evaluateResultListFinal, metadata.isIncludeFilter());

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/filterexpr/FilterProcessorTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/filterexpr/FilterProcessorTestCase.scala
@@ -88,6 +88,12 @@ class FilterProcessorTestCase extends QueryTest with BeforeAndAfterAll {
       Seq(Row(4), Row(6))
     )
   }
+    test("Multi column with invalid member filter") {
+    checkAnswer(
+      sql("select id from filtertestTablesWithNull " + "where id = salary"),
+      Seq()
+    )
+  }
 
   test("Greater Than Filter") {
     checkAnswer(


### PR DESCRIPTION
Row level scanning filters while filtering invalid member giving exception, as per the hive compatibility
empty rows will be displayed .

Problem:
While performng Row level scanning to apply Multi dimension filters, if any non parseable data present
filter layer was throwing out run time exception.

Solution:
Filter layer shall provide empty resultset in this scenario, if any NumberFormatException happens while comparison, catch the same and pass empty resultset.