### PR TITLE
Fixed data loading failure in Spark1.6 spark shell

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -93,6 +93,7 @@
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/vfs-providers.xml</exclude>
               </excludes>
             </filter>
           </filters>


### PR DESCRIPTION
It seems spark1.6 URL classloader server is buggy, it returns `META-INF/vfs-providers.xml` two times from jar file even though it is only one file. Because of this reason commons-vfs is failing. Any way we don't required this xml file to read as we are already handling in code.
So I am excluding it in assembly file. It works fine now both in Spark 1.5 and 1.6.