### PR TITLE
double or decimal dataType should not be set as DICTIONARY_EXCLUDE

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -778,7 +778,7 @@ class CarbonSqlParser()
     dimensionType.exists(x => x.equalsIgnoreCase(dimensionDataType))
   }
 
-  /**
+   /**
     * detects whether double or decimal column is part of dictionary_exclude
     */
   def isDoubleDecimalColDictionaryExclude(columnDataType: String): Boolean = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -691,6 +691,13 @@ class CarbonSqlParser()
             val errormsg = "DICTIONARY_EXCLUDE is unsupported for complex datatype column: " +
               dictExcludeCol
             throw new MalformedCarbonCommandException(errormsg)
+          } else if (isDoubleDecimalColDictionaryExclude(fields.find (x =>
+            x.column.equalsIgnoreCase(dictExcludeCol)).get.dataType.get)) {
+            val dataType = fields.find (x =>
+              x.column.equalsIgnoreCase(dictExcludeCol)).get.dataType.get
+            val errorMsg = "DICTIONARY_EXCLUDE is unsupported for " + dataType.toLowerCase() +
+              " data type column: " + dictExcludeCol
+            throw new MalformedCarbonCommandException(errorMsg)
           }
         }
     }
@@ -769,6 +776,14 @@ class CarbonSqlParser()
   def isComplexDimDictionaryExclude(dimensionDataType: String): Boolean = {
     val dimensionType = Array("array", "struct")
     dimensionType.exists(x => x.equalsIgnoreCase(dimensionDataType))
+  }
+
+  /**
+    * detects whether double or decimal column is part of dictionary_exclude
+    */
+  def isDoubleDecimalColDictionaryExclude(columnDataType: String): Boolean = {
+    val dataTypes = Array("double", "decimal")
+    dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }
 
   /**

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -686,18 +686,18 @@ class CarbonSqlParser()
             val errormsg = "DICTIONARY_EXCLUDE column: " + dictExcludeCol +
               " does not exist in table. Please check create table statement."
             throw new MalformedCarbonCommandException(errormsg)
-          } else if (isComplexDimDictionaryExclude(fields.find (x =>
-              x.column.equalsIgnoreCase(dictExcludeCol)).get.dataType.get)) {
-            val errormsg = "DICTIONARY_EXCLUDE is unsupported for complex datatype column: " +
-              dictExcludeCol
-            throw new MalformedCarbonCommandException(errormsg)
-          } else if (isDoubleDecimalColDictionaryExclude(fields.find (x =>
-            x.column.equalsIgnoreCase(dictExcludeCol)).get.dataType.get)) {
+          } else {
             val dataType = fields.find (x =>
               x.column.equalsIgnoreCase(dictExcludeCol)).get.dataType.get
-            val errorMsg = "DICTIONARY_EXCLUDE is unsupported for " + dataType.toLowerCase() +
-              " data type column: " + dictExcludeCol
-            throw new MalformedCarbonCommandException(errorMsg)
+            if (isComplexDimDictionaryExclude(dataType)) {
+              val errormsg = "DICTIONARY_EXCLUDE is unsupported for complex datatype column: " +
+                dictExcludeCol
+              throw new MalformedCarbonCommandException(errormsg)
+            } else if (isDoubleDecimalColDictionaryExclude(dataType)) {
+              val errorMsg = "DICTIONARY_EXCLUDE is unsupported for " + dataType.toLowerCase() +
+                " data type column: " + dictExcludeCol
+              throw new MalformedCarbonCommandException(errorMsg)
+            }
           }
         }
     }

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
@@ -19,7 +19,6 @@
 
 package org.carbondata.spark.testsuite.createtable
 
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.CarbonHiveContext._
 import org.apache.spark.sql.common.util.QueryTest
 
@@ -53,6 +52,33 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
     } catch {
       case e : MalformedCarbonCommandException => {
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE is unsupported for complex datatype column: mobile"))
+      }
+    }
+    sql("drop table if exists carbontable")
+  }
+
+  test("test carbon table create with double datatype as dictionary exclude") {
+    try {
+      sql("create table carbontable(id int, name string, dept string, mobile array<string>, "+
+        "country string, salary double) STORED BY 'org.apache.carbondata.format' " +
+        "TBLPROPERTIES('DICTIONARY_EXCLUDE'='salary')")
+    } catch {
+      case e : MalformedCarbonCommandException => {
+        assert(e.getMessage.equals("DICTIONARY_EXCLUDE is unsupported for double " +
+          "data type column: salary"))
+      }
+    }
+  }
+
+  test("test carbon table create with decimal datatype as dictionary exclude") {
+    try {
+      sql("create table carbontable(id int, name string, dept string, mobile array<string>, "+
+        "country string, salary decimal) STORED BY 'org.apache.carbondata.format' " +
+        "TBLPROPERTIES('DICTIONARY_EXCLUDE'='salary')")
+    } catch {
+      case e : MalformedCarbonCommandException => {
+        assert(e.getMessage.equals("DICTIONARY_EXCLUDE is unsupported for decimal " +
+          "data type column: salary"))
       }
     }
   }

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
@@ -68,6 +68,7 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
           "data type column: salary"))
       }
     }
+    sql("drop table if exists carbontable")
   }
 
   test("test carbon table create with decimal datatype as dictionary exclude") {

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/createtable/TestCreateTableSyntax.scala
@@ -49,6 +49,7 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
       sql("create table carbontable(id int, name string, dept string, mobile array<string>, "+
           "country string, salary double) STORED BY 'org.apache.carbondata.format' " +
           "TBLPROPERTIES('DICTIONARY_EXCLUDE'='dept,mobile')")
+      assert(false)
     } catch {
       case e : MalformedCarbonCommandException => {
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE is unsupported for complex datatype column: mobile"))
@@ -62,6 +63,7 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
       sql("create table carbontable(id int, name string, dept string, mobile array<string>, "+
         "country string, salary double) STORED BY 'org.apache.carbondata.format' " +
         "TBLPROPERTIES('DICTIONARY_EXCLUDE'='salary')")
+      assert(false)
     } catch {
       case e : MalformedCarbonCommandException => {
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE is unsupported for double " +
@@ -76,6 +78,7 @@ class TestCreateTableSyntax extends QueryTest with BeforeAndAfterAll {
       sql("create table carbontable(id int, name string, dept string, mobile array<string>, "+
         "country string, salary decimal) STORED BY 'org.apache.carbondata.format' " +
         "TBLPROPERTIES('DICTIONARY_EXCLUDE'='salary')")
+      assert(false)
     } catch {
       case e : MalformedCarbonCommandException => {
         assert(e.getMessage.equals("DICTIONARY_EXCLUDE is unsupported for decimal " +


### PR DESCRIPTION
when we create table, set double or decimal dataType column as  DICTIONARY_EXCLUDE

`create table carbontable(id int, name string, dept string, mobile array<string>, country string, salary double) STORED BY 'org.apache.carbondata.format'`

the system should throw exception, and create table failed