### PR TITLE
Fixed issue of dataframe query filters are not pushed down

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -449,7 +449,7 @@ class CarbonOptimizer(optimizer: Optimizer, conf: CatalystConf)
   // get the carbon relation from plan.
   def collectCarbonRelation(plan: LogicalPlan): Seq[CarbonDecoderRelation] = {
     plan collect {
-      case Subquery(alias, l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)) =>
+      case l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _) =>
         CarbonDecoderRelation(l.attributeMap, carbonRelation)
     }
   }


### PR DESCRIPTION
Query filters which are applied through dataframe are not pushed down to carbon layer. This PR fixes that problem.