### PR TITLE
[CARBONDATA-96] Make zookeeper lock as default if zookeeper url is configured.

### DIFF
--- a/core/src/main/java/org/carbondata/core/locks/CarbonLockFactory.java
+++ b/core/src/main/java/org/carbondata/core/locks/CarbonLockFactory.java
@@ -33,7 +33,7 @@ public class CarbonLockFactory {
   private static String lockTypeConfigured;
 
   static {
-    CarbonLockFactory.updateZooKeeperLockingStatus();
+    CarbonLockFactory.getLockTypeConfigured();
   }
 
   /**
@@ -63,10 +63,9 @@ public class CarbonLockFactory {
   /**
    * This method will set the zookeeper status whether zookeeper to be used for locking or not.
    */
-  private static void updateZooKeeperLockingStatus() {
+  private static void getLockTypeConfigured() {
     lockTypeConfigured = CarbonProperties.getInstance()
         .getProperty(CarbonCommonConstants.LOCK_TYPE, CarbonCommonConstants.LOCK_TYPE_DEFAULT);
-
   }
 
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -221,6 +221,7 @@ class CarbonMetastoreCatalog(hive: HiveContext, val storePath: String, client: C
     val zookeeperUrl: String = hive.getConf("spark.deploy.zookeeper.url",null)
     if (zookeeperUrl != null) {
       ZookeeperInit.getInstance(zookeeperUrl)
+      LOGGER.info("Zookeeper url is configured. Taking the zookeeper as lock type.")
       CarbonProperties.getInstance
         .addProperty(CarbonCommonConstants.LOCK_TYPE,
           CarbonCommonConstants.CARBON_LOCK_TYPE_ZOOKEEPER

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -218,11 +218,13 @@ class CarbonMetastoreCatalog(hive: HiveContext, val storePath: String, client: C
 
     // creating zookeeper instance once.
     // if zookeeper is configured as carbon lock type.
-    if (CarbonProperties.getInstance()
-      .getProperty(CarbonCommonConstants.LOCK_TYPE, CarbonCommonConstants.LOCK_TYPE_DEFAULT)
-      .equalsIgnoreCase(CarbonCommonConstants.CARBON_LOCK_TYPE_ZOOKEEPER)) {
-      val zookeeperUrl = hive.getConf("spark.deploy.zookeeper.url", "127.0.0.1:2181")
+    val zookeeperUrl: String = hive.getConf("spark.deploy.zookeeper.url",null)
+    if (zookeeperUrl != null) {
       ZookeeperInit.getInstance(zookeeperUrl)
+      CarbonProperties.getInstance
+        .addProperty(CarbonCommonConstants.LOCK_TYPE,
+          CarbonCommonConstants.CARBON_LOCK_TYPE_ZOOKEEPER
+        )
     }
 
     if (metadataPath == null) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetastoreCatalog.scala
@@ -218,7 +218,7 @@ class CarbonMetastoreCatalog(hive: HiveContext, val storePath: String, client: C
 
     // creating zookeeper instance once.
     // if zookeeper is configured as carbon lock type.
-    val zookeeperUrl: String = hive.getConf("spark.deploy.zookeeper.url",null)
+    val zookeeperUrl: String = hive.getConf("spark.deploy.zookeeper.url", null)
     if (zookeeperUrl != null) {
       ZookeeperInit.getInstance(zookeeperUrl)
       LOGGER.info("Zookeeper url is configured. Taking the zookeeper as lock type.")


### PR DESCRIPTION
make the lock type as zookeeper if zookeeper URL is present in the spark conf.
if spark.deploy.zookeeper.url property is set in spark-default.conf then need to take the zookeeper locking.