### PR TITLE
[issue-717] select id from table_x where salary is not null; returnin…

### DIFF
--- a/core/src/main/java/org/carbondata/query/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/executer/RowLevelFilterExecuterImpl.java
@@ -244,7 +244,9 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
                   blockChunkHolder.getMeasureDataChunk()[msrColumnEvalutorInfo.getColumnIndex()]
                       .getMeasureDataHolder().getReadableDoubleValueByIndex(index);
           }
-          record[msrColumnEvalutorInfo.getRowIndex()] = msrValue;
+          record[msrColumnEvalutorInfo.getRowIndex()] =
+              blockChunkHolder.getMeasureDataChunk()[msrColumnEvalutorInfo.getColumnIndex()]
+                  .getNullValueIndexHolder().getBitSet().get(index) ? null : msrValue;
 
         }
       }

--- a/integration/spark/src/test/resources/datawithnullmeasure.csv
+++ b/integration/spark/src/test/resources/datawithnullmeasure.csv
@@ -1,0 +1,5 @@
+ID,date,country,name,phonetype,serialname,salary
+1,2015/7/23,china,aaa1,phone197,ASD69643,0
+2,2015/7/24,china,aaa2,phone756,ASD42892,
+3,2015/7/25,china,aaa3,phone1904,ASD37014
+4,2015/7/26,china,aaa4,phone2435,ASD66902,0

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/filterexpr/NullMeasureValueTestCaseFilter.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/filterexpr/NullMeasureValueTestCaseFilter.scala
@@ -1,0 +1,39 @@
+package org.carbondata.spark.testsuite.filterexpr
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.carbondata.core.constants.CarbonCommonConstants
+import org.carbondata.core.util.CarbonProperties
+import org.scalatest.BeforeAndAfterAll
+
+class NullMeasureValueTestCaseFilter extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql(
+      "CREATE TABLE IF NOT EXISTS t3 (ID Int, date Timestamp, country String, name String, " +
+        "phonetype String, serialname String, salary Int) STORED BY 'org.apache.carbondata.format'"
+    )
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/mm/dd")
+    sql("LOAD DATA LOCAL INPATH './src/test/resources/datawithnullmeasure.csv' into table t3");
+  }
+
+  test("select ID from t3 where salary is not null") {
+    checkAnswer(
+      sql("select ID from t3 where salary is not null"),
+      Seq(Row(1.0),Row(4.0)))
+  }
+
+  test("select ID from t3 where salary is null") {
+    checkAnswer(
+      sql("select ID from t3 where salary is null"),
+      Seq(Row(2.0),Row(3.0)))
+  }
+
+  override def afterAll {
+    sql("drop cube t3")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+  }
+}


### PR DESCRIPTION
…g the empty result even though null data is available

Problem  and solution:
For storing the null value we are giving the value  (minValue-1) and  mainting the null indexes in bitset,
While applying the filter we were not  comparison with actual null value instead doing with the minValue-1.
Now while creating the row instances, assigning the null value at the null index.

