### PR TITLE
[BUG] Changing the minor compaction behavior to work on segment numbers.

### DIFF
--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -1040,6 +1040,16 @@ public final class CarbonCommonConstants {
   public static final String FILTER_INVALID_MEMBER = " Invalid Record(s) are present "
                                                      + "while filter evaluation. ";
 
+  /**
+   * Number of unmerged segments to be merged.
+   */
+  public static final String COMPACTION_UNMERGE_SEG_COUNT = "carbon.compaction.level.threshold";
+
+  /**
+   * Default count for Number of segments to be merged in levels is 4,3
+   */
+  public static final String DEFAULT_COMPACTION_UNMERGE_SEG_COUNT = "4,3";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -1043,7 +1043,8 @@ public final class CarbonCommonConstants {
   /**
    * Number of unmerged segments to be merged.
    */
-  public static final String COMPACTION_UNMERGE_SEG_COUNT = "carbon.compaction.level.threshold";
+  public static final String COMPACTION_SEGMENT_LEVEL_THRESHOLD =
+      "carbon.compaction.level.threshold";
 
   /**
    * Default count for Number of segments to be merged in levels is 4,3

--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -1049,7 +1049,7 @@ public final class CarbonCommonConstants {
   /**
    * Default count for Number of segments to be merged in levels is 4,3
    */
-  public static final String DEFAULT_COMPACTION_UNMERGE_SEG_COUNT = "4,3";
+  public static final String DEFAULT_SEGMENT_LEVEL_THRESHOLD = "4,3";
 
   private CarbonCommonConstants() {
   }

--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -881,16 +881,6 @@ public final class CarbonCommonConstants {
   public static final String INVALID_SEGMENT_ID = "-1";
 
   /**
-   * Size of Minor Compaction in MBs
-   */
-  public static final String MINOR_COMPACTION_SIZE = "carbon.minor.compaction.size";
-
-  /**
-   * By default size of minor compaction in MBs.
-   */
-  public static final String DEFAULT_MINOR_COMPACTION_SIZE = "256";
-
-  /**
    * Size of Major Compaction in MBs
    */
   public static final String MAJOR_COMPACTION_SIZE = "carbon.major.compaction.size";
@@ -989,18 +979,6 @@ public final class CarbonCommonConstants {
    */
   public static final String SEGMENT_COMPACTED = "Compacted";
 
-  /**
-   * whether to include the compacted segments again for compaction or not.
-   */
-  public static final String INCLUDE_ALREADY_COMPACTED_SEGMENTS =
-      "carbon.include.compacted.segments";
-
-  /**
-   * whether to include the compacted segments again for compaction or not. default value is false.
-   * compacted load will not be compacted again in minor compaction.
-   */
-  public static final String INCLUDE_ALREADY_COMPACTED_SEGMENTS_DEFAULT =
-      "false";
   /**
    * property for number of core to load the blocks in driver
    */

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -771,7 +771,7 @@ public final class CarbonProperties {
     int i = 0;
     for (String levelSize : levels) {
       try {
-        int size = Integer.parseInt(levelSize);
+        int size = Integer.parseInt(levelSize.trim());
         if(validate(size,100,0,-1) < 0 ){
           // if given size is out of boundary then take default value for all levels.
           return null;

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -766,23 +766,59 @@ public final class CarbonProperties {
     String commaSeparatedLevels;
 
     commaSeparatedLevels = getProperty(CarbonCommonConstants.COMPACTION_SEGMENT_LEVEL_THRESHOLD,
-        CarbonCommonConstants.DEFAULT_COMPACTION_UNMERGE_SEG_COUNT);
+        CarbonCommonConstants.DEFAULT_SEGMENT_LEVEL_THRESHOLD);
+    int[] compactionSize = getIntArray(commaSeparatedLevels);
+
+    if(null == compactionSize){
+      compactionSize = getIntArray(CarbonCommonConstants.DEFAULT_SEGMENT_LEVEL_THRESHOLD);
+    }
+
+    return compactionSize;
+  }
+
+  /**
+   *
+   * @param commaSeparatedLevels
+   * @return
+   */
+  private int[] getIntArray(String commaSeparatedLevels) {
     String[] levels = commaSeparatedLevels.split(",");
     int[] compactionSize = new int[levels.length];
-
+    int i = 0;
     for (String levelSize : levels) {
       try {
-        Integer.parseInt(levelSize);
+        int size = Integer.parseInt(levelSize);
+        if(validate(size,100,0,-1) < 0 ){
+          // if given size is out of boundary then take default value for all levels.
+          return null;
+        }
+        compactionSize[i++] = size;
       }
       catch(NumberFormatException e){
         LOGGER.error(
             "Given value for property" + CarbonCommonConstants.COMPACTION_SEGMENT_LEVEL_THRESHOLD
-                + " is not proper. Taking the default value.");
+                + " is not proper. Taking the default value "
+                + CarbonCommonConstants.DEFAULT_SEGMENT_LEVEL_THRESHOLD);
+        return null;
       }
-
     }
-
     return compactionSize;
+  }
+
+  /**
+   * Validate the restrictions
+   *
+   * @param actual
+   * @param max
+   * @param min
+   * @param defaultVal
+   * @return
+   */
+  public int validate(int actual, int max, int min, int defaultVal) {
+    if (actual <= max && actual >= min) {
+      return actual;
+    }
+    return defaultVal;
   }
 
 }

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -762,37 +762,26 @@ public final class CarbonProperties {
    * gettting the unmerged segment numbers to be merged.
    * @return
    */
-  public int getCompactionUnmergeSegmentCount() {
-    int compactionSize;
-    try {
-      compactionSize = Integer.parseInt(
-          getProperty(CarbonCommonConstants.COMPACTION_UNMERGE_SEG_COUNT,
-              CarbonCommonConstants.DEFAULT_COMPACTION_UNMERGE_SEG_COUNT));
-    } catch (NumberFormatException e) {
-      LOGGER.error("specified number is not correct for property "
-          + CarbonCommonConstants.COMPACTION_UNMERGE_SEG_COUNT + ". Taking the default value "
-          + CarbonCommonConstants.DEFAULT_COMPACTION_UNMERGE_SEG_COUNT);
-      compactionSize = Integer.parseInt(CarbonCommonConstants.DEFAULT_COMPACTION_UNMERGE_SEG_COUNT);
-    }
-    return compactionSize;
-  }
+  public int[] getCompactionSegmentLevelCount() {
+    String commaSeparatedLevels;
 
-  /**
-   *
-   * @return
-   */
-  public int getCompactionMergeSegmentCount() {
-    int compactionSize;
-    try {
-      compactionSize = Integer.parseInt(
-          getProperty(CarbonCommonConstants.COMPACTION_MERGE_SEG_COUNT,
-              CarbonCommonConstants.DEFAULT_COMPACTION_MERGE_SEG_COUNT));
-    } catch (NumberFormatException e) {
-      LOGGER.error("specified number is not correct for property "
-          + CarbonCommonConstants.COMPACTION_MERGE_SEG_COUNT + ". Taking the default value "
-          + CarbonCommonConstants.DEFAULT_COMPACTION_MERGE_SEG_COUNT);
-      compactionSize = Integer.parseInt(CarbonCommonConstants.DEFAULT_COMPACTION_MERGE_SEG_COUNT);
+    commaSeparatedLevels = getProperty(CarbonCommonConstants.COMPACTION_SEGMENT_LEVEL_THRESHOLD,
+        CarbonCommonConstants.DEFAULT_COMPACTION_UNMERGE_SEG_COUNT);
+    String[] levels = commaSeparatedLevels.split(",");
+    int[] compactionSize = new int[levels.length];
+
+    for (String levelSize : levels) {
+      try {
+        Integer.parseInt(levelSize);
+      }
+      catch(NumberFormatException e){
+        LOGGER.error(
+            "Given value for property" + CarbonCommonConstants.COMPACTION_SEGMENT_LEVEL_THRESHOLD
+                + " is not proper. Taking the default value.");
+      }
+
     }
+
     return compactionSize;
   }
 

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -758,4 +758,42 @@ public final class CarbonProperties {
     LOGGER.info(carbonProperties.toString());
   }
 
+  /**
+   * gettting the unmerged segment numbers to be merged.
+   * @return
+   */
+  public int getCompactionUnmergeSegmentCount() {
+    int compactionSize;
+    try {
+      compactionSize = Integer.parseInt(
+          getProperty(CarbonCommonConstants.COMPACTION_UNMERGE_SEG_COUNT,
+              CarbonCommonConstants.DEFAULT_COMPACTION_UNMERGE_SEG_COUNT));
+    } catch (NumberFormatException e) {
+      LOGGER.error("specified number is not correct for property "
+          + CarbonCommonConstants.COMPACTION_UNMERGE_SEG_COUNT + ". Taking the default value "
+          + CarbonCommonConstants.DEFAULT_COMPACTION_UNMERGE_SEG_COUNT);
+      compactionSize = Integer.parseInt(CarbonCommonConstants.DEFAULT_COMPACTION_UNMERGE_SEG_COUNT);
+    }
+    return compactionSize;
+  }
+
+  /**
+   *
+   * @return
+   */
+  public int getCompactionMergeSegmentCount() {
+    int compactionSize;
+    try {
+      compactionSize = Integer.parseInt(
+          getProperty(CarbonCommonConstants.COMPACTION_MERGE_SEG_COUNT,
+              CarbonCommonConstants.DEFAULT_COMPACTION_MERGE_SEG_COUNT));
+    } catch (NumberFormatException e) {
+      LOGGER.error("specified number is not correct for property "
+          + CarbonCommonConstants.COMPACTION_MERGE_SEG_COUNT + ". Taking the default value "
+          + CarbonCommonConstants.DEFAULT_COMPACTION_MERGE_SEG_COUNT);
+      compactionSize = Integer.parseInt(CarbonCommonConstants.DEFAULT_COMPACTION_MERGE_SEG_COUNT);
+    }
+    return compactionSize;
+  }
+
 }

--- a/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonProperties.java
@@ -712,22 +712,6 @@ public final class CarbonProperties {
   }
 
   /**
-   * returns minor compaction size value from carbon properties or default value if it is not valid
-   *
-   * @return
-   */
-  public long getMinorCompactionSize() {
-    long compactionSize;
-    try {
-      compactionSize = Long.parseLong(getProperty(CarbonCommonConstants.MINOR_COMPACTION_SIZE,
-          CarbonCommonConstants.DEFAULT_MINOR_COMPACTION_SIZE));
-    } catch (NumberFormatException e) {
-      compactionSize = Long.parseLong(CarbonCommonConstants.DEFAULT_MINOR_COMPACTION_SIZE);
-    }
-    return compactionSize;
-  }
-
-  /**
    * returns the number of loads to be preserved.
    *
    * @return

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -506,12 +506,25 @@ public final class CarbonDataMergerUtil {
     int[] noOfSegmentLevelsCount =
         CarbonProperties.getInstance().getCompactionSegmentLevelCount();
 
-    int level1Size = noOfSegmentLevelsCount[0];
-    int level2Size = noOfSegmentLevelsCount[1];
+    int level1Size = 0;
+    int level2Size = 0;
+    boolean first = true;
+
+    for(int levelCount : noOfSegmentLevelsCount){
+      if(first){
+        level1Size = levelCount;
+        first = false;
+      }
+      else{
+        level2Size = levelCount;
+        break;
+        // breaking as we are doing only 2 levels
+      }
+
+    }
 
     int unMergeCounter = 0;
     int mergeCounter = 0;
-    boolean isMergeConditionMet = false;
 
     // check size of each segment , sum it up across partitions
     for (LoadMetadataDetails segment : listOfSegmentsAfterPreserve) {

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -656,10 +656,6 @@ public final class CarbonDataMergerUtil {
 
     long compactionSize = 0;
     switch (compactionType) {
-      case MINOR_COMPACTION:
-        compactionSize = CarbonProperties.getInstance().getMinorCompactionSize();
-        break;
-
       case MAJOR_COMPACTION:
         compactionSize = CarbonProperties.getInstance().getMajorCompactionSize();
         break;

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -435,6 +435,7 @@ public final class CarbonDataMergerUtil {
           // reset the total length to 0.
           segmentsToBeMerged.removeAll(segmentsToBeMerged);
           totalLength = 0;
+          sizeOfOneSegmentAcrossPartition = 0;
           continue;
         }
       }

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -498,10 +498,11 @@ public final class CarbonDataMergerUtil {
     List<LoadMetadataDetails> unMergedSegments =
         new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
 
-    int noOfUnmergeSegmentsCount =
+    int[] noOfSegmentLevelsCount =
         CarbonProperties.getInstance().getCompactionSegmentLevelCount();
 
-    int noOfMergedSegmentsCount = CarbonProperties.getInstance().getCompactionMergeSegmentCount();
+    int level1Size = noOfSegmentLevelsCount[0];
+    int level2Size = noOfSegmentLevelsCount[1];
 
     int unMergeCounter = 0;
     int mergeCounter = 0;
@@ -524,13 +525,13 @@ public final class CarbonDataMergerUtil {
         //if it is an unmerged segment then increment counter
         unMergeCounter++;
         unMergedSegments.add(segment);
-        if (unMergeCounter == (noOfUnmergeSegmentsCount)) {
+        if (unMergeCounter == (level1Size)) {
           return unMergedSegments;
         }
       } else {
         mergeCounter++;
         mergedSegments.add(segment);
-        if (mergeCounter == (noOfMergedSegmentsCount)) {
+        if (mergeCounter == (level2Size)) {
           return mergedSegments;
         }
       }

--- a/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/merger/CarbonDataMergerUtil.java
@@ -499,7 +499,7 @@ public final class CarbonDataMergerUtil {
         new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
 
     int noOfUnmergeSegmentsCount =
-        CarbonProperties.getInstance().getCompactionUnmergeSegmentCount();
+        CarbonProperties.getInstance().getCompactionSegmentLevelCount();
 
     int noOfMergedSegmentsCount = CarbonProperties.getInstance().getCompactionMergeSegmentCount();
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -424,9 +424,9 @@ object CarbonDataRDDFactory extends Logging {
     }
 
     /**
-      * This will scan all the segments and submit the loads to be merged into the executor.
-      * @param futureList
-      */
+     * This will scan all the segments and submit the loads to be merged into the executor.
+     * @param futureList
+     */
     def scanSegmentsAndSubmitJob(futureList: util.List[Future[Void]]): Unit = {
       breakable {
         while (true) {

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -301,7 +301,6 @@ object CarbonDataRDDFactory extends Logging {
       compactionType = CompactionType.MAJOR_COMPACTION
     }
     else {
-      compactionSize = CarbonDataMergerUtil.getCompactionSize(CompactionType.MINOR_COMPACTION)
       compactionType = CompactionType.MINOR_COMPACTION
     }
 
@@ -478,7 +477,7 @@ object CarbonDataRDDFactory extends Logging {
           .audit("Compaction request received for table " + carbonLoadModel
             .getDatabaseName + "." + carbonLoadModel.getTableName
           )
-        val compactionSize = CarbonDataMergerUtil.getCompactionSize(CompactionType.MINOR_COMPACTION)
+        val compactionSize = 0
 
         val compactionModel = CompactionModel(compactionSize,
           CompactionType.MINOR_COMPACTION,


### PR DESCRIPTION
1. minor compaction will take the number of segments to be merged instead of size.
2. 2 levels of merging is possible. 1st level will merge the segments which are not merged. 2nd level will merge the 1st level of merged segments.
3. suppose if the user has configured the property "carbon.compaction.level.threshold" as "4,3"  then the first level of threshold is 4 . i.e 4 segments will keep on getting merged.
2nd level threshold is 3. so that 3 segments which are already merged in 1st level will get merged together.
4. default value of the threshold is 4,3 so that 12 segments will get merged together.
5. fixed the bug in the Major compaction segment identification based on size.