### PR TITLE
[Issue #746] Is dictionary file exists

### DIFF
--- a/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -320,7 +320,12 @@ object GlobalDictionaryUtil extends Logging {
           dictFilePaths(f._2) = carbonTablePath.getDictionaryFilePath(f._1.getColumnId)
           dictFileExists(f._2) =
             fileNamesMap.get(CarbonTablePath.getDictionaryFileName(f._1.getColumnId)) match {
-              case None => false
+              case None =>
+                if (!dictFilePaths(f._2).startsWith(dictfolderPath)) {
+                  FileFactory.isFileExist(dictFilePaths(f._2), fileType)
+                } else {
+                  false
+                }
               case Some(_) => true
             }
         }


### PR DESCRIPTION
If dictionary file doesn't exist based on primitive calculation then change is done
to check if dictionary file path starts with metdata folder. If it doesn't start with metdata folder then
we check on filesystem for its existence.