### PR TITLE
[Bug] Timestamp with different format compare to spark date format is failing while query

### DIFF
--- a/core/src/main/java/org/carbondata/core/keygenerator/directdictionary/DirectDictionaryGenerator.java
+++ b/core/src/main/java/org/carbondata/core/keygenerator/directdictionary/DirectDictionaryGenerator.java
@@ -40,4 +40,17 @@ public interface DirectDictionaryGenerator {
    */
   Object getValueFromSurrogate(int key);
 
+  /**
+   * The method generate and returns the dictionary / surrogate key for direct dictionary column
+   * This Method is called while executing filter queries for getting direct surrogate members.
+   * Currently the query engine layer only supports yyyy-MM-dd HH:mm:ss date format no matter
+   * in which format the data is been stored, so while retrieving the direct surrogate value for
+   * filter member first it should be converted in date form as per above format and needs to
+   * retrieve time stamp.
+   *
+   * @param member The member string value
+   * @return returns dictionary/ surrogate value
+   */
+  int generateDirectSurrogateKey(String memberStr, String format);
+
 }

--- a/core/src/main/java/org/carbondata/core/keygenerator/directdictionary/timestamp/TimeStampDirectDictionaryGenerator.java
+++ b/core/src/main/java/org/carbondata/core/keygenerator/directdictionary/timestamp/TimeStampDirectDictionaryGenerator.java
@@ -40,12 +40,6 @@ import static org.carbondata.core.keygenerator.directdictionary.timestamp.TimeSt
 public class TimeStampDirectDictionaryGenerator implements DirectDictionaryGenerator {
 
   /**
-   * Logger instance
-   */
-  private static final LogService LOGGER =
-      LogServiceFactory.getLogService(TimeStampDirectDictionaryGenerator.class.getName());
-
-  /**
    * The value of 1 unit of the SECOND, MINUTE, HOUR, or DAY in millis.
    */
   public static final long granularityFactor;
@@ -55,6 +49,11 @@ public class TimeStampDirectDictionaryGenerator implements DirectDictionaryGener
    * customized the start of position. for example "January 1, 2000"
    */
   public static final long cutOffTimeStamp;
+  /**
+   * Logger instance
+   */
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(TimeStampDirectDictionaryGenerator.class.getName());
 
   /**
    * initialization block for granularityFactor and cutOffTimeStamp
@@ -119,6 +118,27 @@ public class TimeStampDirectDictionaryGenerator implements DirectDictionaryGener
         .equals(CarbonCommonConstants.MEMBER_DEFAULT_VAL)) {
       return 1;
     }
+    return getDirectSurrogateForMember(memberStr, timeParser);
+  }
+
+  /**
+   * The method take member String as input and converts
+   * and returns the dictionary key
+   *
+   * @param memberStr date format string
+   * @return dictionary value
+   */
+  public int generateDirectSurrogateKey(String memberStr, String format) {
+    SimpleDateFormat timeParser = new SimpleDateFormat(format);
+    timeParser.setLenient(false);
+    if (null == memberStr || memberStr.trim().isEmpty() || memberStr
+        .equals(CarbonCommonConstants.MEMBER_DEFAULT_VAL)) {
+      return 1;
+    }
+    return getDirectSurrogateForMember(memberStr, timeParser);
+  }
+
+  private int getDirectSurrogateForMember(String memberStr, SimpleDateFormat timeParser) {
     Date dateToStr = null;
     try {
       dateToStr = timeParser.parse(memberStr);

--- a/core/src/main/java/org/carbondata/query/expression/ExpressionResult.java
+++ b/core/src/main/java/org/carbondata/query/expression/ExpressionResult.java
@@ -243,9 +243,12 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
     try {
       switch (this.getDataType()) {
         case StringType:
-          SimpleDateFormat parser = new SimpleDateFormat(CarbonProperties.getInstance()
-              .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
-                  CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
+          // Currently the query engine layer only supports yyyy-MM-dd HH:mm:ss date format
+          // no matter in which format the data is been stored, so while retrieving the direct
+          // surrogate value for filter member first it should be converted in date form as per
+          // above format and needs to retrieve time stamp.
+          SimpleDateFormat parser =
+              new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT);
           Date dateToStr;
           try {
             dateToStr = parser.parse(value.toString());

--- a/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/CustomTypeDictionaryVisitor.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/CustomTypeDictionaryVisitor.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
+import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
 import org.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
 import org.carbondata.query.expression.ColumnExpression;
@@ -71,7 +72,8 @@ public class CustomTypeDictionaryVisitor implements ResolvedFilterInfoVisitorInt
         .getDirectDictionaryGenerator(columnExpression.getDimension().getDataType());
     // Reading the dictionary value direct
     for (String filterMember : evaluateResultListFinal) {
-      surrogates.add(directDictionaryGenerator.generateDirectSurrogateKey(filterMember));
+      surrogates.add(directDictionaryGenerator.generateDirectSurrogateKey(filterMember,
+          CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
     }
     Collections.sort(surrogates);
     DimColumnFilterInfo columnFilterInfo = null;

--- a/integration/spark/src/test/resources/data2_DiffTimeFormat.csv
+++ b/integration/spark/src/test/resources/data2_DiffTimeFormat.csv
@@ -1,0 +1,4 @@
+ID,date,country,name,phonetype,serialname,salary
+4,07-10-2014 00:00:00,china,aaa4,phone2435,ASD66902,4
+8,07-20-2014 00:00:00,china,aaa5,phone2441,ASD90633,10
+6,07-25-2014 00:00:00,china,aaa6,phone294,ASD59961,15005


### PR DESCRIPTION
Timestamp with different format compare to spark date format will fail to provide filter result. this is because while querying the engine is trying to get the direct surrogate based in user defined time format in properties file.