### PR TITLE
Fixed length key updation issue in case of multiple load and single load

### DIFF
--- a/core/src/main/java/org/carbondata/query/carbon/aggregator/impl/ListBasedResultAggregator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/aggregator/impl/ListBasedResultAggregator.java
@@ -106,13 +106,13 @@ public class ListBasedResultAggregator implements ScannedResultAggregator {
     this.measureDatatypes = tableBlockExecutionInfos.getAggregatorInfo().getMeasureDataTypes();
   }
 
-  @Override
   /**
    * This method will add a record both key and value to list object
    * it will keep track of how many record is processed, to handle limit scenario
    * @param scanned result
    *
    */
+  @Override
   public int aggregateData(AbstractScannedResult scannedResult) {
     this.listBasedResult =
         new ArrayList<>(limit == -1 ? scannedResult.numberOfOutputRows() : limit);
@@ -122,7 +122,7 @@ public class ListBasedResultAggregator implements ScannedResultAggregator {
     ListBasedResultWrapper resultWrapper;
     while (scannedResult.hasNext() && (limit == -1 || rowCounter < limit)) {
       resultWrapper = new ListBasedResultWrapper();
-      if(tableBlockExecutionInfos.isDimensionsExistInQuery()) {
+      if (tableBlockExecutionInfos.isDimensionsExistInQuery()) {
         wrapper = new ByteArrayWrapper();
         wrapper.setDictionaryKey(scannedResult.getDictionaryKeyArray());
         wrapper.setNoDictionaryKeys(scannedResult.getNoDictionaryKeyArray());
@@ -131,7 +131,7 @@ public class ListBasedResultAggregator implements ScannedResultAggregator {
       } else {
         scannedResult.incrementCounter();
       }
-      if(isMsrsPresent) {
+      if (isMsrsPresent) {
         Object[] msrValues = new Object[measureDatatypes.length];
         fillMeasureData(msrValues, scannedResult);
         resultWrapper.setValue(msrValues);
@@ -147,9 +147,8 @@ public class ListBasedResultAggregator implements ScannedResultAggregator {
       // if measure exists is block then pass measure column
       // data chunk to the aggregator
       if (isMeasureExistsInCurrentBlock[i]) {
-        msrValues[i] =
-            getMeasureData(scannedResult.getMeasureChunk(measuresOrdinal[i]),
-                scannedResult.getCurrenrRowId(),measureDatatypes[i]);
+        msrValues[i] = getMeasureData(scannedResult.getMeasureChunk(measuresOrdinal[i]),
+            scannedResult.getCurrenrRowId(), measureDatatypes[i]);
       } else {
         // if not then get the default value and use that value in aggregation
         msrValues[i] = measureDefaultValue[i];
@@ -180,7 +179,8 @@ public class ListBasedResultAggregator implements ScannedResultAggregator {
    */
   @Override public Result<List<ListBasedResultWrapper>, Object> getAggregatedResult() {
     Result<List<ListBasedResultWrapper>, Object> result = new ListBasedResult();
-    if (!tableBlockExecutionInfos.isFixedKeyUpdateRequired()) {
+    if (tableBlockExecutionInfos.isFixedKeyUpdateRequired() && tableBlockExecutionInfos
+        .isDimensionsExistInQuery()) {
       updateKeyWithLatestBlockKeygenerator();
       result.addScannedResult(listBasedResult);
     } else {
@@ -188,8 +188,6 @@ public class ListBasedResultAggregator implements ScannedResultAggregator {
     }
     return result;
   }
-
-
 
   /**
    * Below method will be used to update the fixed length key with the

--- a/core/src/main/java/org/carbondata/query/carbon/aggregator/impl/MapBasedResultAggregator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/aggregator/impl/MapBasedResultAggregator.java
@@ -88,8 +88,14 @@ public class MapBasedResultAggregator implements ScannedResultAggregator {
     restructureInfos = tableBlockExecutionInfos.getKeyStructureInfo();
   }
 
-  @Override public int aggregateData(AbstractScannedResult scannedResult) {
-
+  /**
+   * Below method will be used to aggregate the scanned result
+   *
+   * @param scannedResult scanned result
+   * @return how many records was aggregated
+   */
+  @Override
+  public int aggregateData(AbstractScannedResult scannedResult) {
     while (scannedResult.hasNext()) {
       // fill the keys
       wrapper.setDictionaryKey(scannedResult.getDictionaryKeyArray());
@@ -128,8 +134,8 @@ public class MapBasedResultAggregator implements ScannedResultAggregator {
    * Below method will used to get the result
    */
   @Override
-  public Result<Map<ByteArrayWrapper, MeasureAggregator[]>, MeasureAggregator> getAggregatedResult()
-  {
+  public Result<Map<ByteArrayWrapper, MeasureAggregator[]>, MeasureAggregator>
+        getAggregatedResult() {
     Result<Map<ByteArrayWrapper, MeasureAggregator[]>, MeasureAggregator> result =
         new MapBasedResult();
     updateAggregatedResult();
@@ -144,7 +150,8 @@ public class MapBasedResultAggregator implements ScannedResultAggregator {
    * @return updated block
    */
   private void updateAggregatedResult() {
-    if (!tableBlockExecutionInfos.isFixedKeyUpdateRequired()) {
+    if (!tableBlockExecutionInfos.isFixedKeyUpdateRequired() || !tableBlockExecutionInfos
+        .isDimensionsExistInQuery()) {
       return;
     }
     try {

--- a/core/src/main/java/org/carbondata/query/carbon/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/impl/AbstractQueryExecutor.java
@@ -265,7 +265,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
         .setTotalNumberOfMeasureBlock(segmentProperties.getMeasuresOrdinalToBlockMapping().size());
     // to check whether older block key update is required or not
     blockExecutionInfo.setFixedKeyUpdateRequired(
-        blockKeyGenerator.equals(queryProperties.keyStructureInfo.getKeyGenerator()));
+        !blockKeyGenerator.equals(queryProperties.keyStructureInfo.getKeyGenerator()));
     IndexKey startIndexKey = null;
     IndexKey endIndexKey = null;
     if (null != queryModel.getFilterExpressionResolverTree()) {


### PR DESCRIPTION
In case of multiple load and single load or multiple load when  key generator is same then also we were updating the key with the latest segment keygeenerator. problem was when number of records are more then it not required and it will add overhead during query execution for more number of records as bit packing and unpacking is a costly operation.Fixed the same 