### PR TITLE
if activeNodes contains the list of ip's of active nodes and the block…

### DIFF
--- a/integration/spark/src/main/java/org/carbondata/spark/load/CarbonLoaderUtil.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/load/CarbonLoaderUtil.java
@@ -1233,10 +1233,20 @@ public final class CarbonLoaderUtil {
     // are assigned first
     Collections.sort(multiBlockRelations);
 
+    Set<String> validActiveNodes = new HashSet<String>();
+    // find all the valid active nodes
     for (NodeMultiBlockRelation nodeMultiBlockRelation : multiBlockRelations) {
       String nodeName = nodeMultiBlockRelation.getNode();
       //assign the block to the node only if the node is active
-      if (null != activeNodes && !isActiveExecutor(activeNodes, nodeName)) {
+      if (null != activeNodes && isActiveExecutor(activeNodes, nodeName)) {
+        validActiveNodes.add(nodeName);
+      }
+    }
+
+    for (NodeMultiBlockRelation nodeMultiBlockRelation : multiBlockRelations) {
+      String nodeName = nodeMultiBlockRelation.getNode();
+      //assign the block to the node only if the node is active
+      if (!validActiveNodes.isEmpty() && !validActiveNodes.contains(nodeName)) {
         continue;
       }
       // this loop will be for each NODE
@@ -1284,6 +1294,13 @@ public final class CarbonLoaderUtil {
       try {
         String hostName = InetAddress.getLocalHost().getHostName();
         isActiveNode = activeNode.contains(hostName);
+      } catch (UnknownHostException ue) {
+        isActiveNode = false;
+      }
+    } else {
+      try {
+        String hostAddress = InetAddress.getLocalHost().getHostAddress();
+        isActiveNode = activeNode.contains(hostAddress);
       } catch (UnknownHostException ue) {
         isActiveNode = false;
       }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
@@ -119,13 +119,15 @@ class CarbonQueryRDD[V: ClassTag](
             confExecutors = sparkContext.getConf.get("spark.dynamicAllocation.maxExecutors")
           }
         }
+        val startTime = System.currentTimeMillis
         val activeNodes = DistributionUtil
           .ensureExecutorsAndGetNodeList(requiredExecutors, confExecutors, sparkContext)
         val nodeBlockMapping =
           CarbonLoaderUtil.nodeBlockTaskMapping(blockList.asJava, -1, defaultParallelism,
             activeNodes.toList.asJava
           )
-
+        val timeElapsed: Long = System.currentTimeMillis - startTime
+        LOGGER.info("Total Time taken in block allocation : " + timeElapsed)
         var i = 0
         // Create Spark Partition for each task and assign blocks
         nodeBlockMapping.asScala.foreach { entry =>


### PR DESCRIPTION
if activeNodes contains the list of ip's of active nodes and the block info contains the the host name vs  no of block, then node allocation was not working.
Modification:
getting the hostaddress and then checking whether the the ip exist in the activeNodes.
