### PR TITLE
[CARBONDATA-57] BLOCK distribution un wanted wait for the executor node even though the sufficient nodes are available

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
@@ -122,14 +122,17 @@ object DistributionUtil {
       confExecutors
     } else {nodeMapping.size()}
 
+    var startTime = System.currentTimeMillis();
     CarbonContext.ensureExecutors(sparkContext, requiredExecutors)
     var nodes = DistributionUtil.getNodeList(sparkContext)
     var maxTimes = 30;
-    while (nodes.length != requiredExecutors && maxTimes > 0) {
+    while (nodes.length < requiredExecutors && maxTimes > 0) {
       Thread.sleep(500);
       nodes = DistributionUtil.getNodeList(sparkContext)
       maxTimes = maxTimes - 1;
     }
+    var timDiff = System.currentTimeMillis() - startTime;
+    LOGGER.info("Total Time taken to ensure the required executors : " + timDiff)
     LOGGER.info("Time elapsed to allocate the required executors : " + (30 - maxTimes) * 500)
     nodes
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -247,7 +247,7 @@ class CarbonMergerRDD[K, V](
       + ", no.of.nodes where data present=" + nodeMapping.size())
     var nodes = DistributionUtil.getNodeList(sparkContext)
     var maxTimes = 30
-    while (nodes.length != requiredExecutors && maxTimes > 0) {
+    while (nodes.length < requiredExecutors && maxTimes > 0) {
       Thread.sleep(500)
       nodes = DistributionUtil.getNodeList(sparkContext)
       maxTimes = maxTimes - 1


### PR DESCRIPTION
Modification:
No need to wait if the existing executors are more than or equal to the required executors.