### PR TITLE
[Bug] Order by with limit in case of non aggregation query shall not …

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonStrategies.scala
@@ -77,35 +77,6 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
           isGroupByPresent = false,
           detailQuery = true) :: Nil
 
-      case Limit(IntegerLiteral(limit),
-      Sort(order, _,
-      p@PartialAggregation(namedGroupingAttributes,
-      rewrittenAggregateExpressions,
-      groupingExpressions,
-      partialComputation,
-      PhysicalOperation(
-      projectList,
-      predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _))))) =>
-        val aggPlan = handleAggregation(plan, p, projectList, predicates, carbonRelation,
-          partialComputation, groupingExpressions, namedGroupingAttributes,
-          rewrittenAggregateExpressions)
-        org.apache.spark.sql.execution.TakeOrderedAndProject(limit,
-          order,
-          None,
-          aggPlan.head) :: Nil
-
-      case Limit(IntegerLiteral(limit), p@PartialAggregation(
-      namedGroupingAttributes,
-      rewrittenAggregateExpressions,
-      groupingExpressions,
-      partialComputation,
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)))) =>
-        val aggPlan = handleAggregation(plan, p, projectList, predicates, carbonRelation,
-          partialComputation, groupingExpressions, namedGroupingAttributes,
-          rewrittenAggregateExpressions)
-        org.apache.spark.sql.execution.Limit(limit, aggPlan.head) :: Nil
 
       case PartialAggregation(
       namedGroupingAttributes,
@@ -126,17 +97,6 @@ class CarbonStrategies(sqlContext: SQLContext) extends QueryPlanner[SparkPlan] {
           substitutesortExprs, limitExpr, isGroupByPresent = false, detailQuery = true)
         org.apache.spark.sql.execution.Limit(limit, s) :: Nil
 
-      case Limit(IntegerLiteral(limit),
-      Sort(order, _,
-      PhysicalOperation(projectList, predicates,
-      l@LogicalRelation(carbonRelation: CarbonDatasourceRelation, _)))) =>
-        val (_, _, _, _, groupExprs, substitutesortExprs, limitExpr) = extractPlan(plan)
-        val s = carbonScan(projectList, predicates, carbonRelation.carbonRelation, groupExprs,
-          substitutesortExprs, limitExpr, isGroupByPresent = false, detailQuery = true)
-        org.apache.spark.sql.execution.TakeOrderedAndProject(limit,
-          order,
-          None,
-          s) :: Nil
 
       case ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, condition,
       PhysicalOperation(projectList, predicates,

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/filterexpr/FilterProcessorTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/filterexpr/FilterProcessorTestCase.scala
@@ -108,6 +108,7 @@ class FilterProcessorTestCase extends QueryTest with BeforeAndAfterAll {
     )
   }
   
+  
     test("Between  filter") {
     checkAnswer(
       sql("select date from filtertestTablesWithNull " + " where date between '2014-01-20 00:00:00' and '2014-01-28 00:00:00'"),
@@ -140,7 +141,20 @@ class FilterProcessorTestCase extends QueryTest with BeforeAndAfterAll {
       Seq(Row(999), Row(1000))
     )
   }
+  
+    test("Greater Than equal to Filter with limit") {
+    checkAnswer(
+      sql("select id from filtertestTables " + "where id >=999 limit 1"),
+      Seq(Row(1000))
+    )
+  }
 
+      test("Greater Than equal to Filter with aggregation limit") {
+    checkAnswer(
+      sql("select count(id),country from filtertestTables " + "where id >=999 group by country limit 1"),
+      Seq(Row(2,"china"))
+    )
+  }
   test("Greater Than equal to Filter with decimal") {
     checkAnswer(
       sql("select id from filtertestTables " + "where id >=999"),


### PR DESCRIPTION
Order by with limit in case of non aggregation query shall not be pushed down to carbon layer, since  it was pushing down queries were failing which consists of order by limit