### PR TITLE
[Bug] Filter was failing when join condition

### DIFF
--- a/core/src/main/java/org/carbondata/query/expression/DataType.java
+++ b/core/src/main/java/org/carbondata/query/expression/DataType.java
@@ -21,7 +21,7 @@ package org.carbondata.query.expression;
 
 public enum DataType {
   StringType(0), DateType(1), TimestampType(2), BooleanType(1), IntegerType(3), FloatType(
-      4), LongType(5), DoubleType(6), NullType(7), DecimalType(8), ArrayType(9), StructType(10);
+      4), LongType(5), DoubleType(6), NullType(0), DecimalType(8), ArrayType(9), StructType(10);
   private int presedenceOrder;
 
   private DataType(int value) {

--- a/core/src/main/java/org/carbondata/query/expression/ExpressionResult.java
+++ b/core/src/main/java/org/carbondata/query/expression/ExpressionResult.java
@@ -365,12 +365,15 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
         case IntegerType:
           result = this.getInt().equals(objToCompare.getInt());
           break;
-
+        case LongType:
+        case TimestampType:
+          result = this.getLong().equals(objToCompare.getLong());
+          break;
         case DoubleType:
           result = this.getDouble().equals(objToCompare.getDouble());
           break;
-        case TimestampType:
-          result = this.getLong().equals(objToCompare.getLong());
+        case DecimalType:
+          result = this.getDecimal().equals(objToCompare.getDecimal());
           break;
         default:
           break;

--- a/core/src/main/java/org/carbondata/query/expression/conditional/InExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/InExpression.java
@@ -48,40 +48,36 @@ public class InExpression extends BinaryConditionalExpression {
       ExpressionResult val = null;
       setOfExprResult = new HashSet<ExpressionResult>(10);
       for (ExpressionResult expressionResVal : rightRsult.getList()) {
-
-        if (leftRsult.getDataType().name().equals(expressionResVal.getDataType().name())) {
-          if (expressionResVal.getDataType().getPresedenceOrder() < leftRsult.getDataType()
-              .getPresedenceOrder()) {
-            val = leftRsult;
-          } else {
-            val = expressionResVal;
-          }
-          switch (val.getDataType()) {
-            case StringType:
-              val = new ExpressionResult(val.getDataType(), expressionResVal.getString());
-              break;
-            case IntegerType:
-              val = new ExpressionResult(val.getDataType(), expressionResVal.getInt());
-              break;
-            case DoubleType:
-              val = new ExpressionResult(val.getDataType(), expressionResVal.getDouble());
-              break;
-            case TimestampType:
-              val = new ExpressionResult(val.getDataType(), expressionResVal.getTime());
-              break;
-            case LongType:
-              val = new ExpressionResult(val.getDataType(), expressionResVal.getLong());
-              break;
-            case DecimalType:
-              val = new ExpressionResult(val.getDataType(), expressionResVal.getDecimal());
-              break;
-            default:
-              throw new FilterUnsupportedException(
-                  "DataType: " + val.getDataType() + " not supported for the filter expression");
-          }
+        if (expressionResVal.getDataType().getPresedenceOrder() < leftRsult.getDataType()
+            .getPresedenceOrder()) {
+          val = leftRsult;
+        } else {
+          val = expressionResVal;
+        }
+        switch (val.getDataType()) {
+          case StringType:
+            val = new ExpressionResult(val.getDataType(), expressionResVal.getString());
+            break;
+          case IntegerType:
+            val = new ExpressionResult(val.getDataType(), expressionResVal.getInt());
+            break;
+          case DoubleType:
+            val = new ExpressionResult(val.getDataType(), expressionResVal.getDouble());
+            break;
+          case LongType:
+            val = new ExpressionResult(val.getDataType(), expressionResVal.getLong());
+            break;
+          case TimestampType:
+            val = new ExpressionResult(val.getDataType(), expressionResVal.getTime());
+            break;
+          case DecimalType:
+            val = new ExpressionResult(val.getDataType(), expressionResVal.getDecimal());
+            break;
+          default:
+            throw new FilterUnsupportedException(
+                "DataType: " + val.getDataType() + " not supported for the filter expression");
         }
         setOfExprResult.add(val);
-
       }
     }
     leftRsult.set(DataType.BooleanType, setOfExprResult.contains(leftRsult));

--- a/core/src/main/java/org/carbondata/query/expression/conditional/NotInExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/NotInExpression.java
@@ -41,51 +41,44 @@ public class NotInExpression extends BinaryConditionalExpression {
   @Override public ExpressionResult evaluate(RowIntf value)
       throws FilterUnsupportedException, FilterIllegalMemberException {
     ExpressionResult leftRsult = left.evaluate(value);
-
     if (setOfExprResult == null) {
       ExpressionResult val = null;
-
       ExpressionResult rightRsult = right.evaluate(value);
       setOfExprResult = new HashSet<ExpressionResult>(10);
       for (ExpressionResult exprResVal : rightRsult.getList()) {
-
-        if (leftRsult.getDataType().name().equals(exprResVal.getDataType().name())) {
-          if (exprResVal.getDataType().getPresedenceOrder() < leftRsult.getDataType()
-              .getPresedenceOrder()) {
-            val = leftRsult;
-          } else {
-            val = exprResVal;
-          }
-          switch (val.getDataType()) {
-            case StringType:
-              val = new ExpressionResult(val.getDataType(), exprResVal.getString());
-              break;
-            case IntegerType:
-              val = new ExpressionResult(val.getDataType(), exprResVal.getInt());
-              break;
-            case DoubleType:
-              val = new ExpressionResult(val.getDataType(), exprResVal.getDouble());
-              break;
-            case TimestampType:
-              val = new ExpressionResult(val.getDataType(), exprResVal.getTime());
-              break;
-            case LongType:
-              val = new ExpressionResult(val.getDataType(), exprResVal.getLong());
-              break;
-            case DecimalType:
-              val = new ExpressionResult(val.getDataType(), exprResVal.getDecimal());
-              break;
-            default:
-              throw new FilterUnsupportedException(
-                  "DataType: " + val.getDataType() + " not supported for the filter expression");
-          }
+        if (exprResVal.getDataType().getPresedenceOrder() < leftRsult.getDataType()
+            .getPresedenceOrder()) {
+          val = leftRsult;
+        } else {
+          val = exprResVal;
+        }
+        switch (val.getDataType()) {
+          case StringType:
+            val = new ExpressionResult(val.getDataType(), exprResVal.getString());
+            break;
+          case IntegerType:
+            val = new ExpressionResult(val.getDataType(), exprResVal.getInt());
+            break;
+          case DoubleType:
+            val = new ExpressionResult(val.getDataType(), exprResVal.getDouble());
+            break;
+          case TimestampType:
+            val = new ExpressionResult(val.getDataType(), exprResVal.getTime());
+            break;
+          case LongType:
+            val = new ExpressionResult(val.getDataType(), exprResVal.getLong());
+            break;
+          case DecimalType:
+            val = new ExpressionResult(val.getDataType(), exprResVal.getDecimal());
+            break;
+          default:
+            throw new FilterUnsupportedException(
+                "DataType: " + val.getDataType() + " not supported for the filter expression");
         }
         setOfExprResult.add(val);
-
       }
     }
     leftRsult.set(DataType.BooleanType, !setOfExprResult.contains(leftRsult));
-
     return leftRsult;
   }
 

--- a/core/src/main/java/org/carbondata/query/filters/FilterExpressionProcessor.java
+++ b/core/src/main/java/org/carbondata/query/filters/FilterExpressionProcessor.java
@@ -274,7 +274,7 @@ public class FilterExpressionProcessor implements FilterProcessor {
               .getCarbonColumn().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
             if (FilterUtil.checkIfExpressionContainsColumn(currentCondExpression.getLeft())
                 && FilterUtil.checkIfExpressionContainsColumn(currentCondExpression.getRight()) || (
-                FilterUtil.checkIfLeftExpressionRequireEvaluation(currentCondExpression.getRight())
+                FilterUtil.checkIfRightExpressionRequireEvaluation(currentCondExpression.getRight())
                     || FilterUtil
                     .checkIfLeftExpressionRequireEvaluation(currentCondExpression.getLeft()))) {
               return new RowLevelFilterResolverImpl(expression, isExpressionResolve, true,
@@ -306,7 +306,7 @@ public class FilterExpressionProcessor implements FilterProcessor {
               .getCarbonColumn().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
             if (FilterUtil.checkIfExpressionContainsColumn(currentCondExpression.getLeft())
                 && FilterUtil.checkIfExpressionContainsColumn(currentCondExpression.getRight()) || (
-                FilterUtil.checkIfLeftExpressionRequireEvaluation(currentCondExpression.getRight())
+                FilterUtil.checkIfRightExpressionRequireEvaluation(currentCondExpression.getRight())
                     || FilterUtil
                     .checkIfLeftExpressionRequireEvaluation(currentCondExpression.getLeft()))) {
               return new RowLevelFilterResolverImpl(expression, isExpressionResolve, false,

--- a/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
@@ -71,6 +71,7 @@ import org.carbondata.query.expression.ColumnExpression;
 import org.carbondata.query.expression.Expression;
 import org.carbondata.query.expression.ExpressionResult;
 import org.carbondata.query.expression.LiteralExpression;
+import org.carbondata.query.expression.conditional.ListExpression;
 import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 import org.carbondata.query.filter.executer.AndFilterExecuterImpl;
@@ -229,6 +230,45 @@ public final class FilterUtil {
     }
     for (Expression child : expression.getChildren()) {
       if (checkIfLeftExpressionRequireEvaluation(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * This method will check if a given literal expression is not a timestamp datatype
+   * recursively.
+   *
+   * @return
+   */
+  public static boolean checkIfDataTypeNotTimeStamp(Expression expression) {
+    if (expression.getFilterExpressionType() == ExpressionType.LITERAL) {
+      if (!(((LiteralExpression) expression).getLiteralExpDataType()
+          == org.carbondata.query.expression.DataType.TimestampType)) {
+        return true;
+      }
+    }
+    for (Expression child : expression.getChildren()) {
+      if (checkIfDataTypeNotTimeStamp(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  /**
+   * This method will check if a given expression contains a column expression
+   * recursively.
+   *
+   * @return
+   */
+  public static boolean checkIfRightExpressionRequireEvaluation(Expression expression) {
+    if (expression.getFilterExpressionType() == ExpressionType.UNKNOWN
+        || !(expression instanceof LiteralExpression) && !(expression instanceof ListExpression)) {
+      return true;
+    }
+    for (Expression child : expression.getChildren()) {
+      if (checkIfRightExpressionRequireEvaluation(child)) {
         return true;
       }
     }

--- a/integration/spark/src/test/resources/big_int_Decimal.csv
+++ b/integration/spark/src/test/resources/big_int_Decimal.csv
@@ -1,0 +1,3 @@
+imei,age,task,name,country,city,sale,num,level,quest,productdate,enddate,pointid,score
+imei0,2147,9279,fegt,china,hangzhou,10000,100.05,100.055,10,2016-05-01 12:25:36,2016-05-01 21:14:48,1,1.005
+imei1,-2148,-9807,lrhkr,America,NewYork,1000,10.05,100.05,100,2016-05-02 19:25:15,2016-05-02 22:25:46,2,1.05


### PR DESCRIPTION
Filter was failing when join condition is been applied between two tables,spark will send optimized logical plan for execution where
timestamp type will change to Long and this since the left expression and right expression was getting different data type issue was happening in case of Timestamp type column filters, For other filter like BigInt and Decimal, expression result was not handling such data type while comparing the expression results.