### PR TITLE
[CARBONDATA-68] Log Executor Query statistics

### DIFF
--- a/common/src/main/java/org/carbondata/common/logging/LogService.java
+++ b/common/src/main/java/org/carbondata/common/logging/LogService.java
@@ -37,4 +37,11 @@ public interface LogService {
   void error(Throwable throwable, String message);
 
   void audit(String message);
+
+  /**
+   * Below method will be used to log the statistic information
+   *
+   * @param message statistic message
+   */
+  void statistic(String message);
 }

--- a/common/src/main/java/org/carbondata/common/logging/impl/StandardLogService.java
+++ b/common/src/main/java/org/carbondata/common/logging/impl/StandardLogService.java
@@ -204,6 +204,8 @@ public final class StandardLogService implements LogService {
           logWarnMessage(throwable, message);
         } else if (Level.AUDIT.toString().equalsIgnoreCase(logLevel.toString())) {
           audit(message);
+        } else if (Level.STATISTICS == logLevel) {
+          statistic(message);
         }
 
       } catch (Throwable t) {
@@ -283,9 +285,12 @@ public final class StandardLogService implements LogService {
     } catch (IOException e) {
       username = "unknown";
     }
-    logger.log(AuditLevel.AUDIT, "[" + hostName + "]"
-        + "[" + username + "]"
-        + "[Thread-" +  threadid + "]" + msg);
+    logger.log(AuditLevel.AUDIT,
+        "[" + hostName + "]" + "[" + username + "]" + "[Thread-" + threadid + "]" + msg);
+  }
+
+  @Override public void statistic(String message) {
+    logger.log(StatisticLevel.STATISTIC, message);
   }
 
   /**
@@ -296,9 +301,10 @@ public final class StandardLogService implements LogService {
     NONE(0),
     DEBUG(1),
     INFO(2),
-    ERROR(3),
-    AUDIT(4),
-    WARN(5);
+    STATISTICS(3),
+    ERROR(4),
+    AUDIT(5),
+    WARN(6);
 
     /**
      * Constructor.

--- a/common/src/main/java/org/carbondata/common/logging/impl/StatisticLevel.java
+++ b/common/src/main/java/org/carbondata/common/logging/impl/StatisticLevel.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.carbondata.common.logging.impl;
+
+import org.apache.log4j.Level;
+
+/**
+ * Extended log level class to log the statistic details
+ */
+public class StatisticLevel extends Level {
+
+  public static final StatisticLevel STATISTIC = new StatisticLevel(55000, "STATISTIC", 0);
+
+  private static final long serialVersionUID = -209614723183147373L;
+
+  /**
+   * Constructor
+   *
+   * @param level            log level
+   * @param levelStr         log level string
+   * @param syslogEquivalent syslogEquivalent
+   */
+  protected StatisticLevel(int level, String levelStr, int syslogEquivalent) {
+    super(level, levelStr, syslogEquivalent);
+  }
+
+  /**
+   * Returns custom level for debug type log message
+   *
+   * @param val          value
+   * @param defaultLevel level
+   * @return custom level
+   */
+  public static StatisticLevel toLevel(int val, Level defaultLevel) {
+    return STATISTIC;
+  }
+
+  /**
+   * Returns custom level for debug type log message
+   *
+   * @param sArg         sArg
+   * @param defaultLevel level
+   * @return custom level
+   */
+  public static StatisticLevel toLevel(String sArg, Level defaultLevel) {
+    return STATISTIC;
+  }
+}

--- a/core/src/main/java/org/carbondata/core/carbon/querystatistics/QueryStatistic.java
+++ b/core/src/main/java/org/carbondata/core/carbon/querystatistics/QueryStatistic.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.carbondata.core.carbon.querystatistics;
+
+import java.io.Serializable;
+
+/**
+ * Wrapper class to maintain the query statistics for each phase of the query
+ */
+public class QueryStatistic implements Serializable {
+
+  /**
+   * serialization id
+   */
+  private static final long serialVersionUID = -5667106646135905848L;
+
+  /**
+   * statistic message
+   */
+  private String message;
+
+  /**
+   * total time take of the phase
+   */
+  private long timeTaken;
+
+  /**
+   * starttime of the phase
+   */
+  private long startTime;
+
+  public QueryStatistic() {
+    this.startTime = System.currentTimeMillis();
+  }
+
+  /**
+   * below method will be used to add the statistic
+   *
+   * @param message     Statistic message
+   * @param currentTime current time
+   */
+  public void addStatistics(String message, long currentTime) {
+    this.timeTaken = currentTime - startTime;
+    this.message = message;
+  }
+
+  /**
+   * Below method will be used to get the statistic message, which will
+   * be used to log
+   *
+   * @param queryWithTaskId query with task id to append in the message
+   * @return statistic message
+   */
+  public String getStatistics(String queryWithTaskId) {
+    return message + " for the taskid : " + queryWithTaskId + " Is : " + timeTaken;
+  }
+}

--- a/core/src/main/java/org/carbondata/core/carbon/querystatistics/QueryStatisticsRecorder.java
+++ b/core/src/main/java/org/carbondata/core/carbon/querystatistics/QueryStatisticsRecorder.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.carbondata.core.carbon.querystatistics;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.carbondata.common.logging.LogService;
+import org.carbondata.common.logging.LogServiceFactory;
+
+/**
+ * Class will be used to record and log the query statistics
+ */
+public class QueryStatisticsRecorder implements Serializable {
+
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(QueryStatisticsRecorder.class.getName());
+  /**
+   * serialization version
+   */
+  private static final long serialVersionUID = -5719752001674467864L;
+
+  /**
+   * list for statistics to record time taken
+   * by each phase of the query for example aggregation
+   * scanning,block loading time etc.
+   */
+  private List<QueryStatistic> queryStatistics;
+
+  /**
+   * query with taskd
+   */
+  private String queryIWthTask;
+
+  public QueryStatisticsRecorder(String queryId) {
+    queryStatistics = new ArrayList<QueryStatistic>();
+    this.queryIWthTask = queryId;
+  }
+
+  /**
+   * Below method will be used to add the statistics
+   *
+   * @param statistic
+   */
+  public synchronized void recordStatistics(QueryStatistic statistic) {
+    queryStatistics.add(statistic);
+  }
+
+  /**
+   * Below method will be used to log the statistic
+   */
+  public void logStatistics() {
+    for (QueryStatistic statistic : queryStatistics) {
+      LOGGER.info(statistic.getStatistics(queryIWthTask));
+    }
+  }
+}

--- a/core/src/main/java/org/carbondata/core/carbon/querystatistics/QueryStatisticsRecorder.java
+++ b/core/src/main/java/org/carbondata/core/carbon/querystatistics/QueryStatisticsRecorder.java
@@ -68,7 +68,7 @@ public class QueryStatisticsRecorder implements Serializable {
    */
   public void logStatistics() {
     for (QueryStatistic statistic : queryStatistics) {
-      LOGGER.info(statistic.getStatistics(queryIWthTask));
+      LOGGER.statistic(statistic.getStatistics(queryIWthTask));
     }
   }
 }

--- a/core/src/main/java/org/carbondata/query/carbon/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/impl/AbstractQueryExecutor.java
@@ -37,6 +37,8 @@ import org.carbondata.core.carbon.metadata.datatype.DataType;
 import org.carbondata.core.carbon.metadata.encoder.Encoding;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
+import org.carbondata.core.carbon.querystatistics.QueryStatistic;
+import org.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.impl.FileFactory;
 import org.carbondata.core.keygenerator.KeyGenException;
@@ -90,9 +92,12 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
         queryModel.getQueryId());
     LOGGER.info("Query will be executed on table: " + queryModel.getAbsoluteTableIdentifier()
         .getCarbonTableIdentifier().getTableName());
-
+    // Initializing statistics list to record the query statistics
+    // creating copy on write to handle concurrent scenario
+    queryProperties.queryStatisticsRecorder = new QueryStatisticsRecorder(queryModel.getQueryId());
+    queryModel.setStatisticsRecorder(queryProperties.queryStatisticsRecorder);
     QueryUtil.resolveQueryModel(queryModel);
-
+    QueryStatistic queryStatistic = new QueryStatistic();
     // get the table blocks
     try {
       queryProperties.dataBlocks = BlockIndexStore.getInstance()
@@ -101,6 +106,9 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     } catch (IndexBuilderException e) {
       throw new QueryExecutionException(e);
     }
+    queryStatistic
+        .addStatistics("Time taken to load the Blocks In Executor", System.currentTimeMillis());
+    queryProperties.queryStatisticsRecorder.recordStatistics(queryStatistic);
     //
     // // updating the restructuring infos for the query
     queryProperties.keyStructureInfo = getKeyStructureInfo(queryModel,
@@ -159,12 +167,16 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
 
     queryProperties.complexFilterDimension =
         QueryUtil.getAllFilterDimensions(queryModel.getFilterExpressionResolverTree());
+    queryStatistic = new QueryStatistic();
     // dictionary column unique column id to dictionary mapping
     // which will be used to get column actual data
     queryProperties.columnToDictionayMapping = QueryUtil
         .getDimensionDictionaryDetail(queryModel.getQueryDimension(),
             queryModel.getDimAggregationInfo(), queryModel.getExpressions(),
             queryProperties.complexFilterDimension, queryModel.getAbsoluteTableIdentifier());
+    queryStatistic
+        .addStatistics("Time taken to load the Dictionary In Executor", System.currentTimeMillis());
+    queryProperties.queryStatisticsRecorder.recordStatistics(queryStatistic);
     queryModel.setColumnToDictionaryMapping(queryProperties.columnToDictionayMapping);
     // setting the sort dimension index. as it will be updated while getting the sort info
     // so currently setting it to default 0 means sort is not present in any dimension
@@ -253,7 +265,8 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     blockExecutionInfo.setAggregatorInfo(getAggregatorInfoForBlock(queryModel, blockIndex));
     // adding custom aggregate expression of query
     blockExecutionInfo.setCustomAggregateExpressions(queryModel.getExpressions());
-
+    // adding query statistics list to record the statistics
+    blockExecutionInfo.setStatisticsRecorder(queryProperties.queryStatisticsRecorder);
     // setting the limit
     blockExecutionInfo.setLimit(queryModel.getLimit());
     // setting whether detail query or not

--- a/core/src/main/java/org/carbondata/query/carbon/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/impl/AbstractQueryExecutor.java
@@ -107,7 +107,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
       throw new QueryExecutionException(e);
     }
     queryStatistic
-        .addStatistics("Time taken to load the Blocks In Executor", System.currentTimeMillis());
+        .addStatistics("Time taken to load the Block(s) In Executor", System.currentTimeMillis());
     queryProperties.queryStatisticsRecorder.recordStatistics(queryStatistic);
     //
     // // updating the restructuring infos for the query

--- a/core/src/main/java/org/carbondata/query/carbon/executor/impl/QueryExecutorProperties.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/impl/QueryExecutorProperties.java
@@ -26,6 +26,7 @@ import org.carbondata.core.cache.dictionary.Dictionary;
 import org.carbondata.core.carbon.datastore.block.AbstractIndex;
 import org.carbondata.core.carbon.metadata.datatype.DataType;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
+import org.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
 import org.carbondata.query.aggregator.MeasureAggregator;
 import org.carbondata.query.carbon.executor.infos.KeyStructureInfo;
 import org.carbondata.query.complex.querytypes.GenericQueryType;
@@ -81,7 +82,12 @@ public class QueryExecutorProperties {
    */
   public Set<CarbonDimension> complexFilterDimension;
   /**
+   * to record the query execution details phase wise
+   */
+  public QueryStatisticsRecorder queryStatisticsRecorder;
+  /**
    * list of blocks in which query will be executed
    */
   protected List<AbstractIndex> dataBlocks;
+
 }

--- a/core/src/main/java/org/carbondata/query/carbon/executor/infos/BlockExecutionInfo.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/infos/BlockExecutionInfo.java
@@ -25,6 +25,7 @@ import org.carbondata.core.cache.dictionary.Dictionary;
 import org.carbondata.core.carbon.datastore.DataRefNode;
 import org.carbondata.core.carbon.datastore.IndexKey;
 import org.carbondata.core.carbon.datastore.block.AbstractIndex;
+import org.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
 import org.carbondata.core.datastorage.store.impl.FileFactory.FileType;
 import org.carbondata.core.keygenerator.KeyGenerator;
 import org.carbondata.query.carbon.aggregator.dimension.DimensionDataAggregator;
@@ -230,6 +231,11 @@ public class BlockExecutionInfo {
    * complex dimension parent block indexes;
    */
   private int[] complexColumnParentBlockIndexes;
+
+  /**
+   * to record the statistics
+   */
+  private QueryStatisticsRecorder statisticsRecorder;
 
   /**
    * @return the tableBlock
@@ -693,8 +699,7 @@ public class BlockExecutionInfo {
   /**
    * @param complexDimensionInfoMap the complexParentIndexToQueryMap to set
    */
-  public void setComplexDimensionInfoMap(
-      Map<Integer, GenericQueryType> complexDimensionInfoMap) {
+  public void setComplexDimensionInfoMap(Map<Integer, GenericQueryType> complexDimensionInfoMap) {
     this.complexParentIndexToQueryMap = complexDimensionInfoMap;
   }
 
@@ -710,5 +715,13 @@ public class BlockExecutionInfo {
    */
   public void setComplexColumnParentBlockIndexes(int[] complexColumnParentBlockIndexes) {
     this.complexColumnParentBlockIndexes = complexColumnParentBlockIndexes;
+  }
+
+  public QueryStatisticsRecorder getStatisticsRecorder() {
+    return statisticsRecorder;
+  }
+
+  public void setStatisticsRecorder(QueryStatisticsRecorder statisticsRecorder) {
+    this.statisticsRecorder = statisticsRecorder;
   }
 }

--- a/core/src/main/java/org/carbondata/query/carbon/executor/internal/impl/InternalAbstractQueryExecutor.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/internal/impl/InternalAbstractQueryExecutor.java
@@ -31,6 +31,7 @@ import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.carbon.datastore.DataRefNode;
 import org.carbondata.core.carbon.datastore.DataRefNodeFinder;
 import org.carbondata.core.carbon.datastore.impl.btree.BTreeDataRefNodeFinder;
+import org.carbondata.core.carbon.querystatistics.QueryStatistic;
 import org.carbondata.core.iterator.CarbonIterator;
 import org.carbondata.query.carbon.executor.exception.QueryExecutionException;
 import org.carbondata.query.carbon.executor.infos.BlockExecutionInfo;
@@ -79,6 +80,9 @@ public abstract class InternalAbstractQueryExecutor implements InternalQueryExec
     BlockExecutionInfo latestInfo =
         tableBlockExecutionInfosList.get(tableBlockExecutionInfosList.size() - 1);
     execService = Executors.newFixedThreadPool(numberOfCores);
+
+    QueryStatistic statistic = new QueryStatistic();
+
     ScannedResultMerger scannedResultProcessor = null;
     if (null != latestInfo.getSortInfo()
         && latestInfo.getSortInfo().getSortDimensionIndex().length > 0) {
@@ -102,7 +106,6 @@ public abstract class InternalAbstractQueryExecutor implements InternalQueryExec
       }
       execService.shutdown();
       execService.awaitTermination(2, TimeUnit.DAYS);
-      LOGGER.info("Total time taken for scan " + (System.currentTimeMillis() - startTime));
       for (Future future : listFutureObjects) {
         try {
           future.get();
@@ -110,7 +113,12 @@ public abstract class InternalAbstractQueryExecutor implements InternalQueryExec
           throw new QueryExecutionException(e.getMessage());
         }
       }
-      return scannedResultProcessor.getQueryResultIterator();
+      CarbonIterator<Result> queryResultIterator = scannedResultProcessor.getQueryResultIterator();
+      statistic
+          .addStatistics("Time taken to scan " + tableBlockExecutionInfosList.size() + " blocks ",
+              System.currentTimeMillis());
+      latestInfo.getStatisticsRecorder().recordStatistics(statistic);
+      return queryResultIterator;
     } catch (QueryExecutionException e) {
       LOGGER.error(e, e.getMessage());
       throw new QueryExecutionException(e);

--- a/core/src/main/java/org/carbondata/query/carbon/executor/internal/impl/InternalAbstractQueryExecutor.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/internal/impl/InternalAbstractQueryExecutor.java
@@ -115,7 +115,7 @@ public abstract class InternalAbstractQueryExecutor implements InternalQueryExec
       }
       CarbonIterator<Result> queryResultIterator = scannedResultProcessor.getQueryResultIterator();
       statistic
-          .addStatistics("Time taken to scan " + tableBlockExecutionInfosList.size() + " blocks ",
+          .addStatistics("Time taken to scan " + tableBlockExecutionInfosList.size() + " block(s) ",
               System.currentTimeMillis());
       latestInfo.getStatisticsRecorder().recordStatistics(statistic);
       return queryResultIterator;

--- a/core/src/main/java/org/carbondata/query/carbon/model/QueryModel.java
+++ b/core/src/main/java/org/carbondata/query/carbon/model/QueryModel.java
@@ -31,6 +31,7 @@ import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonColumn;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonDimension;
 import org.carbondata.core.carbon.metadata.schema.table.column.CarbonMeasure;
+import org.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.util.CarbonUtil;
 import org.carbondata.query.expression.ColumnExpression;
@@ -50,73 +51,68 @@ public class QueryModel implements Serializable {
    * serialization version
    */
   private static final long serialVersionUID = -4674677234007089052L;
-
+  /**
+   * this will hold the information about the dictionary dimension
+   * which to
+   */
+  public transient Map<String, Dictionary> columnToDictionaryMapping;
+  /**
+   * Number of records to keep in memory.
+   */
+  public int inMemoryRecordSize;
   /**
    * list of dimension selected for in query
    */
   private List<QueryDimension> queryDimension;
-
   /**
    * list of dimension in which sorting is applied
    */
   private List<QueryDimension> sortDimension;
-
   /**
    * list of measure selected in query
    */
   private List<QueryMeasure> queryMeasures;
-
   /**
    * query id
    */
   private String queryId;
-
   /**
    * to check if it a aggregate table
    */
   private boolean isAggTable;
-
   /**
    * filter tree
    */
   private FilterResolverIntf filterExpressionResolverTree;
-
   /**
    * in case of lime query we need to know how many
    * records will passed from executor
    */
   private int limit;
-
   /**
    * for applying aggregation on dimension
    */
   private List<DimensionAggregatorInfo> dimAggregationInfo;
-
   /**
    * custom aggregate expression
    */
   private List<CustomAggregateExpression> expressions;
-
   /**
    * to check if it is a count star query , so processing will be different
    */
   private boolean isCountStarQuery;
-
   /**
    * to check whether aggregation is required during query execution
    */
   private boolean detailQuery;
-
   /**
    * table block information in which query will be executed
    */
   private List<TableBlockInfo> tableBlockInfos;
-
   /**
    * sort in which dimension will be get sorted
    */
   private byte[] sortOrder;
-
   /**
    * absolute table identifier
    */
@@ -126,29 +122,15 @@ public class QueryModel implements Serializable {
    * to this location will be used to write the temp file in this location
    */
   private String queryTempLocation;
-
   /**
    * To handle most of the computation in query engines like spark and hive, carbon should give
    * raw detailed records to it.
    */
   private boolean forcedDetailRawQuery;
-
   /**
    * paritition column list
    */
   private List<String> paritionColumns;
-
-  /**
-   * this will hold the information about the dictionary dimension
-   * which to
-   */
-  public transient Map<String, Dictionary> columnToDictionaryMapping;
-
-  /**
-   * Number of records to keep in memory.
-   */
-  public int inMemoryRecordSize;
-
   /**
    * table on which query will be executed
    * TODO need to remove this ad pass only the path
@@ -156,18 +138,17 @@ public class QueryModel implements Serializable {
    */
   private CarbonTable table;
 
+  private QueryStatisticsRecorder statisticsRecorder;
+
   public QueryModel() {
     tableBlockInfos = new ArrayList<TableBlockInfo>();
-    dimAggregationInfo =
-        new ArrayList<DimensionAggregatorInfo>();
-    expressions =
-        new ArrayList<CustomAggregateExpression>();
+    dimAggregationInfo = new ArrayList<DimensionAggregatorInfo>();
+    expressions = new ArrayList<CustomAggregateExpression>();
     queryDimension = new ArrayList<QueryDimension>();
     queryMeasures = new ArrayList<QueryMeasure>();
     sortDimension = new ArrayList<QueryDimension>();
     sortOrder = new byte[0];
     paritionColumns = new ArrayList<String>();
-
   }
 
   public static QueryModel createModel(AbsoluteTableIdentifier absoluteTableIdentifier,
@@ -192,8 +173,7 @@ public class QueryModel implements Serializable {
     queryModel.setAbsoluteTableIdentifier(carbonTable.getAbsoluteTableIdentifier());
     queryModel.setQueryDimension(queryPlan.getDimensions());
     fillSortInfoInModel(queryModel, queryPlan.getSortedDimemsions());
-    queryModel.setQueryMeasures(
-        queryPlan.getMeasures());
+    queryModel.setQueryMeasures(queryPlan.getMeasures());
     if (null != queryPlan.getFilterExpression()) {
       processFilterExpression(queryPlan.getFilterExpression(),
           carbonTable.getDimensionByTableName(factTableName),
@@ -233,8 +213,8 @@ public class QueryModel implements Serializable {
     executorModel.setDimAggregationInfo(dimensionAggregatorInfos);
   }
 
-  public static void processFilterExpression(
-      Expression filterExpression, List<CarbonDimension> dimensions, List<CarbonMeasure> measures) {
+  public static void processFilterExpression(Expression filterExpression,
+      List<CarbonDimension> dimensions, List<CarbonMeasure> measures) {
     if (null != filterExpression) {
       if (null != filterExpression.getChildren() && filterExpression.getChildren().size() == 0) {
         if (filterExpression instanceof ConditionalExpression) {
@@ -295,8 +275,7 @@ public class QueryModel implements Serializable {
    */
   public CarbonColumn[] getProjectionColumns() {
     CarbonColumn[] carbonColumns =
-        new CarbonColumn[getQueryDimension().size() + getQueryMeasures()
-            .size()];
+        new CarbonColumn[getQueryDimension().size() + getQueryMeasures().size()];
     for (QueryDimension dimension : getQueryDimension()) {
       carbonColumns[dimension.getQueryOrder()] = dimension.getDimension();
     }
@@ -566,5 +545,13 @@ public class QueryModel implements Serializable {
 
   public void setInMemoryRecordSize(int inMemoryRecordSize) {
     this.inMemoryRecordSize = inMemoryRecordSize;
+  }
+
+  public QueryStatisticsRecorder getStatisticsRecorder() {
+    return statisticsRecorder;
+  }
+
+  public void setStatisticsRecorder(QueryStatisticsRecorder statisticsRecorder) {
+    this.statisticsRecorder = statisticsRecorder;
   }
 }

--- a/core/src/main/java/org/carbondata/query/carbon/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/result/iterator/AbstractDetailQueryResultIterator.java
@@ -143,7 +143,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
       return true;
     }
     statistic.addStatistics(
-        "Time taken to processed " + blockExecutionInfos.size() + " block of output record size: "
+        "Time taken to processed " + blockExecutionInfos.size() + " block(s) of output record size: "
             + totalNumberOfOutputRecords, System.currentTimeMillis());
     blockExecutionInfos.get(0).getStatisticsRecorder().recordStatistics(statistic);
     return false;

--- a/core/src/main/java/org/carbondata/query/carbon/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/result/iterator/AbstractDetailQueryResultIterator.java
@@ -142,9 +142,9 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
     if (currentCounter < totalNumberOfNode) {
       return true;
     }
-    statistic.addStatistics(
-        "Time taken to processed " + blockExecutionInfos.size() + " block(s) of output record size: "
-            + totalNumberOfOutputRecords, System.currentTimeMillis());
+    statistic.addStatistics("Time taken to processed " + blockExecutionInfos.size()
+            + " block(s) of output record size: " + totalNumberOfOutputRecords,
+        System.currentTimeMillis());
     blockExecutionInfos.get(0).getStatisticsRecorder().recordStatistics(statistic);
     return false;
   }

--- a/core/src/main/java/org/carbondata/query/carbon/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/result/iterator/AbstractDetailQueryResultIterator.java
@@ -26,6 +26,7 @@ import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.carbon.datastore.DataRefNode;
 import org.carbondata.core.carbon.datastore.DataRefNodeFinder;
 import org.carbondata.core.carbon.datastore.impl.btree.BTreeDataRefNodeFinder;
+import org.carbondata.core.carbon.querystatistics.QueryStatistic;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.iterator.CarbonIterator;
 import org.carbondata.core.util.CarbonProperties;
@@ -56,36 +57,38 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
    * executor which will execute the query
    */
   protected InternalQueryExecutor executor;
-
-  /**
-   * number of cores which can be used
-   */
-  private long numberOfCores;
-
-  /**
-   * keep track of number of blocklet per block
-   */
-  private long[] totalNumberBlockletPerSlice;
-
-  /**
-   * total number of blocklet to be executed
-   */
-  private long totalNumberOfNode;
-
   /**
    * current counter to check how blocklet has been executed
    */
   protected long currentCounter;
-
-  /**
-   * keep the track of number of blocklet of a block has been executed
-   */
-  private long[] numberOfBlockletExecutedPerBlock;
-
   /**
    * block index to be executed
    */
   protected int[] blockIndexToBeExecuted;
+  /**
+   * to store the statistics
+   */
+  protected QueryStatistic statistic;
+  /**
+   * total number of records processed
+   */
+  protected long totalNumberOfOutputRecords;
+  /**
+   * number of cores which can be used
+   */
+  private long numberOfCores;
+  /**
+   * keep track of number of blocklet per block
+   */
+  private long[] totalNumberBlockletPerSlice;
+  /**
+   * total number of blocklet to be executed
+   */
+  private long totalNumberOfNode;
+  /**
+   * keep the track of number of blocklet of a block has been executed
+   */
+  private long[] numberOfBlockletExecutedPerBlock;
 
   public AbstractDetailQueryResultIterator(List<BlockExecutionInfo> infos,
       QueryExecutorProperties executerProperties, QueryModel queryModel,
@@ -110,6 +113,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
     executor = queryExecutor;
     this.blockExecutionInfos = infos;
     this.blockIndexToBeExecuted = new int[(int) numberOfCores];
+    statistic = new QueryStatistic();
     intialiseInfos();
   }
 
@@ -135,7 +139,14 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
   }
 
   @Override public boolean hasNext() {
-    return currentCounter < totalNumberOfNode;
+    if (currentCounter < totalNumberOfNode) {
+      return true;
+    }
+    statistic.addStatistics(
+        "Time taken to processed " + blockExecutionInfos.size() + " block of output record size: "
+            + totalNumberOfOutputRecords, System.currentTimeMillis());
+    blockExecutionInfos.get(0).getStatisticsRecorder().recordStatistics(statistic);
+    return false;
   }
 
   protected int updateSliceIndexToBeExecuted() {

--- a/core/src/main/java/org/carbondata/query/carbon/result/iterator/DetailQueryResultIterator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/result/iterator/DetailQueryResultIterator.java
@@ -20,8 +20,6 @@ package org.carbondata.query.carbon.result.iterator;
 
 import java.util.List;
 
-import org.carbondata.common.logging.LogService;
-import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.iterator.CarbonIterator;
 import org.carbondata.query.carbon.executor.exception.QueryExecutionException;
 import org.carbondata.query.carbon.executor.impl.QueryExecutorProperties;
@@ -40,12 +38,6 @@ import org.carbondata.query.carbon.result.preparator.impl.DetailQueryResultPrepa
  * call will come it will execute the block and return the result
  */
 public class DetailQueryResultIterator extends AbstractDetailQueryResultIterator {
-
-  /**
-   * LOGGER.
-   */
-  private static final LogService LOGGER =
-      LogServiceFactory.getLogService(DetailQueryResultIterator.class.getName());
 
   /**
    * to prepare the result
@@ -78,6 +70,7 @@ public class DetailQueryResultIterator extends AbstractDetailQueryResultIterator
     if (null != result) {
       Result next = result.next();
       if (next.size() > 0) {
+        totalNumberOfOutputRecords += next.size();
         return queryResultPreparator.prepareQueryResult(next);
       } else {
         return new BatchResult();

--- a/hadoop/src/main/java/org/carbondata/hadoop/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/carbondata/hadoop/CarbonInputFormat.java
@@ -47,6 +47,8 @@ import org.carbondata.core.carbon.datastore.impl.btree.BlockBTreeLeafNode;
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable;
 import org.carbondata.core.carbon.path.CarbonStorePath;
 import org.carbondata.core.carbon.path.CarbonTablePath;
+import org.carbondata.core.carbon.querystatistics.QueryStatistic;
+import org.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.keygenerator.KeyGenException;
 import org.carbondata.core.util.CarbonProperties;
@@ -440,6 +442,8 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       AbsoluteTableIdentifier absoluteTableIdentifier, FilterResolverIntf resolver,
       String segmentId) throws IndexBuilderException, IOException {
 
+    QueryStatisticsRecorder recorder = new QueryStatisticsRecorder("");
+    QueryStatistic statistic = new QueryStatistic();
     Map<String, AbstractIndex> segmentIndexMap =
         getSegmentAbstractIndexs(job, absoluteTableIdentifier, segmentId);
 
@@ -464,6 +468,10 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       }
       resultFilterredBlocks.addAll(filterredBlocks);
     }
+    statistic.addStatistics("Time taken to load the Block(s) in Driver Side",
+        System.currentTimeMillis());
+    recorder.recordStatistics(statistic);
+    recorder.logStatistics();
     return resultFilterredBlocks;
   }
 
@@ -515,8 +523,8 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       IndexKey endIndexKey = FilterUtil.prepareDefaultEndIndexKey(segmentProperties);
 
       // Add all blocks of btree into result
-      DataRefNodeFinder blockFinder = new BTreeDataRefNodeFinder(
-          segmentProperties.getEachDimColumnValueSize());
+      DataRefNodeFinder blockFinder =
+          new BTreeDataRefNodeFinder(segmentProperties.getEachDimColumnValueSize());
       DataRefNode startBlock =
           blockFinder.findFirstDataBlock(abstractIndex.getDataRefNode(), startIndexKey);
       DataRefNode endBlock =

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
@@ -209,6 +209,7 @@ class CarbonQueryRDD[V: ClassTag](
         }
         if (finished) {
           clearDictionaryCache(queryModel.getColumnToDictionaryMapping)
+          queryModel.getStatisticsRecorder.logStatistics();
         }
         !finished
       }
@@ -231,10 +232,6 @@ class CarbonQueryRDD[V: ClassTag](
             .clearColumnDictionaryCache(columnToDictionaryMap)
         }
       }
-
-      logInfo("*************************** Total Time Taken to execute the query in Carbon Side: " +
-        (System.currentTimeMillis - queryStartTime)
-      )
     }
     iter
   }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
@@ -209,7 +209,9 @@ class CarbonQueryRDD[V: ClassTag](
         }
         if (finished) {
           clearDictionaryCache(queryModel.getColumnToDictionaryMapping)
-          queryModel.getStatisticsRecorder.logStatistics();
+          if(null!=queryModel.getStatisticsRecorder) {
+            queryModel.getStatisticsRecorder.logStatistics();
+          }
         }
         !finished
       }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
@@ -224,6 +224,9 @@ class CarbonQueryRDD[V: ClassTag](
         recordCount += 1
         if (queryModel.getLimit != -1 && recordCount >= queryModel.getLimit) {
           clearDictionaryCache(queryModel.getColumnToDictionaryMapping)
+           if(null!=queryModel.getStatisticsRecorder) {
+            queryModel.getStatisticsRecorder.logStatistics();
+          }
         }
         valueClass.getValue(rowIterator.next())
       }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
@@ -18,6 +18,7 @@
 
 package org.carbondata.spark.rdd
 
+
 import java.util
 
 import scala.collection.JavaConverters._
@@ -32,6 +33,7 @@ import org.apache.spark.sql.hive.DistributionUtil
 import org.carbondata.common.logging.LogServiceFactory
 import org.carbondata.core.cache.dictionary.Dictionary
 import org.carbondata.core.carbon.datastore.block.{Distributable, TableBlockInfo}
+import org.carbondata.core.carbon.querystatistics.{QueryStatistic, QueryStatisticsRecorder}
 import org.carbondata.core.iterator.CarbonIterator
 import org.carbondata.hadoop.{CarbonInputFormat, CarbonInputSplit}
 import org.carbondata.query.carbon.executor.QueryExecutorFactory
@@ -73,6 +75,7 @@ class CarbonQueryRDD[V: ClassTag](
   val defaultParallelism = sc.defaultParallelism
 
   override def getPartitions: Array[Partition] = {
+    val statisticRecorder = new QueryStatisticsRecorder(queryModel.getQueryId)
     val startTime = System.currentTimeMillis()
     val (carbonInputFormat: CarbonInputFormat[RowResult], job: Job) =
       QueryPlanUtil.createCarbonInputFormat(queryModel.getAbsoluteTableIdentifier)
@@ -109,6 +112,7 @@ class CarbonQueryRDD[V: ClassTag](
       if (blockList.nonEmpty) {
         // group blocks to nodes, tasks
         val startTime = System.currentTimeMillis
+        var statistic = new QueryStatistic
         val activeNodes = DistributionUtil
           .ensureExecutorsAndGetNodeList(blockList.toArray, sparkContext)
         val nodeBlockMapping =
@@ -116,7 +120,9 @@ class CarbonQueryRDD[V: ClassTag](
             activeNodes.toList.asJava
           )
         val timeElapsed: Long = System.currentTimeMillis - startTime
-        LOGGER.info("Total Time taken in block allocation : " + timeElapsed)
+        statistic.addStatistics("Total Time taken in block(s) allocation", System.currentTimeMillis)
+        statisticRecorder.recordStatistics(statistic);
+        statistic = new QueryStatistic
         var i = 0
         // Create Spark Partition for each task and assign blocks
         nodeBlockMapping.asScala.foreach { entry =>
@@ -126,7 +132,8 @@ class CarbonQueryRDD[V: ClassTag](
               result
                 .add(new CarbonSparkPartition(id, i, Seq(entry._1).toArray, tableBlockInfo.asJava))
               i += 1
-            }}
+            }
+          }
           }
         }
         val noOfBlocks = blockList.size
@@ -136,9 +143,9 @@ class CarbonQueryRDD[V: ClassTag](
           + s"parallelism: $defaultParallelism , " +
           s"no.of.nodes: $noOfNodes, no.of.tasks: $noOfTasks"
         )
-        logInfo("Time taken to identify Blocks to scan : " +
-          (System.currentTimeMillis() - startTime)
-        )
+        statistic.addStatistics("Time taken to identify Block(s) to scan", System.currentTimeMillis)
+        statisticRecorder.recordStatistics(statistic);
+        statisticRecorder.logStatistics
         result.asScala.foreach { r =>
           val cp = r.asInstanceOf[CarbonSparkPartition]
           logInfo(s"Node : " + cp.locations.toSeq.mkString(",")


### PR DESCRIPTION
added executor side query execution statistics

Message details
Detail Query:
INFO  17-07 03:10:36,236 - [Executor task launch worker-0][partitionID:nest9;queryID:2776118908102_0] Time taken to load the Blocks In Executor for the taskid : 2776118908102_0 Is : 109
INFO  17-07 03:10:36,236 - [Executor task launch worker-0][partitionID:nest9;queryID:2776118908102_0] Time taken to load the Dictionary In Executor for the taskid : 2776118908102_0 Is : 31
INFO  17-07 03:10:36,236 - [Executor task launch worker-0][partitionID:nest9;queryID:2776118908102_0] Time taken to processed 1 block of output record size: 4 for the taskid : 2776118908102_0 Is : 266

Aggregation Query

INFO  17-07 03:11:57,188 - [Executor task launch worker-0][partitionID:nest9;queryID:2856578524673_0] Time taken to load the Blocks In Executor for the taskid : 2856578524673_0 Is : 109
INFO  17-07 03:11:57,188 - [Executor task launch worker-0][partitionID:nest9;queryID:2856578524673_0] Time taken to load the Dictionary In Executor for the taskid : 2856578524673_0 Is : 31
INFO  17-07 03:11:57,188 - [Executor task launch worker-0][partitionID:nest9;queryID:2856578524673_0] Time taken to scan 1 blocks  for the taskid : 2856578524673_0 Is : 31
INFO  17-07 03:11:57,188 - [Executor task launch worker-0][partitionID:nest9;queryID:2856578524673_0] Time take to prepare query result of size 4 for the taskid : 2856578524673_0 Is : 0

Logs are added under "statistic" category to track the time taken and Performance logs.
How ever detailed statistics module has to be added as per #356 , for complete solution.