### PR TITLE
Fixed complex query execution issue.

### DIFF
--- a/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/carbondata/core/carbon/metadata/schema/table/CarbonTable.java
@@ -131,13 +131,13 @@ public class CarbonTable implements Serializable {
               new CarbonDimension(columnSchema, dimensionOrdinal++, -1, -1, complexTypeOrdinal++);
           complexDimension.initializeChildDimensionsList(columnSchema.getNumberOfChild());
           dimensions.add(complexDimension);
+          int lastDimensionOrdianl=dimensionOrdinal;
           dimensionOrdinal =
               readAllComplexTypeChildrens(dimensionOrdinal, columnSchema.getNumberOfChild(),
                   listOfColumns, complexDimension, complexTypeOrdinal);
           i = dimensionOrdinal - 1;
-          complexTypeOrdinal = complexDimension.getListOfChildDimensions()
-              .get(complexDimension.getListOfChildDimensions().size() - 1).getComplexTypeOrdinal();
-          complexTypeOrdinal++;
+          int incrementInOrdinal=dimensionOrdinal-lastDimensionOrdianl;
+          complexTypeOrdinal+=incrementInOrdinal;
         } else {
           if (!columnSchema.getEncodingList().contains(Encoding.DICTIONARY)) {
             dimensions.add(new CarbonDimension(columnSchema, dimensionOrdinal++, -1, -1, -1));

--- a/core/src/main/java/org/carbondata/query/carbon/executor/util/QueryUtil.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/util/QueryUtil.java
@@ -873,7 +873,7 @@ public class QueryUtil {
           && queryDimension.getDimension().numberOfChild() == 0) {
         dictionaryDimensionBlockIndex
             .add(columnOrdinalToBlockIndexMapping.get(queryDimension.getDimension().getOrdinal()));
-      } else {
+      } else if(queryDimension.getDimension().numberOfChild() == 0){
         noDictionaryDimensionBlockIndex
             .add(columnOrdinalToBlockIndexMapping.get(queryDimension.getDimension().getOrdinal()));
       }


### PR DESCRIPTION
array of array complex column query execution was failing because key size of the primitive column was not proper. This is because while adding the dimension to carbon table complex dimension ordinal was not incremented properly. so complex dimension ordinal for primitive type was not proper and it was pointing to wrong keysize and throwing bufferunderflow execption 