### PR TITLE
[CARBONDATA-76][Bug] Null members should not display in NotEquals Filter

### DIFF
--- a/core/src/main/java/org/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
+++ b/core/src/main/java/org/carbondata/core/cache/dictionary/ColumnDictionaryInfo.java
@@ -186,7 +186,12 @@ public class ColumnDictionaryInfo extends AbstractColumnDictionaryInfo {
     List<Integer> sortedSurrogates = sortOrderReference.get();
     int low = 0;
     for (byte[] byteValueOfFilterMember : byteValuesOfFilterMembers) {
-      String filterKey = new String(byteValueOfFilterMember);
+      String filterKey = new String(byteValueOfFilterMember,
+          Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+      if (CarbonCommonConstants.MEMBER_DEFAULT_VAL.equals(filterKey)) {
+        surrogates.add(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY);
+        continue;
+      }
       int high = sortedSurrogates.size() - 1;
       while (low <= high) {
         int mid = (low + high) >>> 1;

--- a/core/src/main/java/org/carbondata/query/expression/conditional/EqualToExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/EqualToExpression.java
@@ -30,9 +30,15 @@ import org.carbondata.query.expression.exception.FilterUnsupportedException;
 public class EqualToExpression extends BinaryConditionalExpression {
 
   private static final long serialVersionUID = 1L;
+  private boolean isNull;
 
   public EqualToExpression(Expression left, Expression right) {
     super(left, right);
+  }
+
+  public EqualToExpression(Expression left, Expression right, boolean isNull) {
+    super(left, right);
+    this.isNull = isNull;
   }
 
   @Override public ExpressionResult evaluate(RowIntf value)
@@ -46,9 +52,12 @@ public class EqualToExpression extends BinaryConditionalExpression {
     ExpressionResult val2 = erRes;
 
     if (elRes.isNull() || erRes.isNull()) {
-      result = elRes.isNull() && erRes.isNull();
-      val1.set(DataType.BooleanType, result);
-      return val1;
+      if (isNull) {
+        elRes.set(DataType.BooleanType, elRes.isNull() == erRes.isNull());
+      } else {
+        elRes.set(DataType.BooleanType, false);
+      }
+      return elRes;
     }
     //default implementation if the data types are different for the resultsets
     if (elRes.getDataType() != erRes.getDataType()) {

--- a/core/src/main/java/org/carbondata/query/expression/conditional/NotEqualsExpression.java
+++ b/core/src/main/java/org/carbondata/query/expression/conditional/NotEqualsExpression.java
@@ -30,6 +30,11 @@ import org.carbondata.query.expression.exception.FilterUnsupportedException;
 public class NotEqualsExpression extends BinaryConditionalExpression {
 
   private static final long serialVersionUID = 8684006025540863973L;
+  private boolean isNotNull = false;
+  public NotEqualsExpression(Expression left, Expression right, boolean isNotNull) {
+    super(left, right);
+    this.isNotNull = isNotNull;
+  }
 
   public NotEqualsExpression(Expression left, Expression right) {
     super(left, right);
@@ -43,13 +48,14 @@ public class NotEqualsExpression extends BinaryConditionalExpression {
     boolean result = false;
     ExpressionResult val1 = elRes;
     ExpressionResult val2 = erRes;
-
     if (elRes.isNull() || erRes.isNull()) {
-      result = elRes.isNull() != erRes.isNull();
-      val1.set(DataType.BooleanType, result);
-      return val1;
+      if (isNotNull) {
+        elRes.set(DataType.BooleanType, elRes.isNull() != erRes.isNull());
+      } else {
+        elRes.set(DataType.BooleanType, false);
+      }
+      return elRes;
     }
-
     //default implementation if the data types are different for the resultsets
     if (elRes.getDataType() != erRes.getDataType()) {
       //            result = elRes.getString().equals(erRes.getString());

--- a/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/DictionaryColumnVisitor.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/DictionaryColumnVisitor.java
@@ -18,6 +18,7 @@
  */
 package org.carbondata.query.filter.resolver.resolverinfo.visitor;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.carbondata.common.logging.LogService;
@@ -57,6 +58,12 @@ public class DictionaryColumnVisitor implements ResolvedFilterInfoVisitorIntf {
       resolvedFilterObject = FilterUtil
           .getFilterValues(metadata.getTableIdentifier(), metadata.getColumnExpression(),
               evaluateResultListFinal, metadata.isIncludeFilter());
+      if (!metadata.isIncludeFilter() && null != resolvedFilterObject) {
+        // Adding default surrogate key of null member inorder to not display the same while
+        // displaying the report as per hive compatibility.
+        resolvedFilterObject.getFilterList().add(1);
+        Collections.sort(resolvedFilterObject.getFilterList());
+      }
     } catch (QueryExecutionException e) {
       throw new FilterUnsupportedException(e);
     }

--- a/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/NoDictionaryTypeVisitor.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/resolverinfo/visitor/NoDictionaryTypeVisitor.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.carbondata.common.logging.LogService;
 import org.carbondata.common.logging.LogServiceFactory;
+import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.query.expression.exception.FilterIllegalMemberException;
 import org.carbondata.query.expression.exception.FilterUnsupportedException;
 import org.carbondata.query.filter.resolver.metadata.FilterResolverMetadata;
@@ -51,6 +52,12 @@ public class NoDictionaryTypeVisitor implements ResolvedFilterInfoVisitorIntf {
     List<String> evaluateResultListFinal;
     try {
       evaluateResultListFinal = metadata.getExpression().evaluate(null).getListAsString();
+      // Adding default  null member inorder to not display the same while
+      // displaying the report as per hive compatibility.
+      if (!metadata.isIncludeFilter() && !evaluateResultListFinal
+          .contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL)) {
+        evaluateResultListFinal.add(CarbonCommonConstants.MEMBER_DEFAULT_VAL);
+      }
     } catch (FilterIllegalMemberException e) {
       throw new FilterUnsupportedException(e);
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonOperators.scala
@@ -429,7 +429,10 @@ case class CarbonTableScan(
           NotEqualsExpression(transformExpression(left), transformExpression(right))
       case IsNotNull(child)
         if (isCarbonSupportedDataTypes(child)) => new
-          NotEqualsExpression(transformExpression(child), transformExpression(Literal(null)))
+          NotEqualsExpression(transformExpression(child), transformExpression(Literal(null)), true)
+        case IsNull(child)
+        if (isCarbonSupportedDataTypes(child)) => new
+          EqualToExpression(transformExpression(child), transformExpression(Literal(null)), true)
       case Not(In(left, right))
         if (isCarbonSupportedDataTypes(left)) => new
           NotInExpression(transformExpression(left),

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/detailquery/HighCardinalityDataTypesTestCase.scala
@@ -36,6 +36,7 @@ class NO_DICTIONARY_COL_TestCase extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
     //For the Hive table creation and data loading
+    sql("drop table if exists filtertestTables")
     sql(
       "create table NO_DICTIONARY_HIVE_6(empno int,empname string,designation string,doj " +
         "Timestamp,workgroupcategory int, " +
@@ -239,7 +240,7 @@ test("filter with arithmetic expression") {
         
 
   override def afterAll {
-    //sql("drop cube NO_DICTIONARY_HIVE_1")
+    sql("drop table if exists filtertestTables")
     //sql("drop cube NO_DICTIONARY_CARBON_1")
   }
 }


### PR DESCRIPTION
if the user was applying filte to list down non null members. When user applies Not Equals filter in any non null members the system shall not display null members in report as per Hive compatibility.