### PR TITLE
[CARBONDATA-77]removing the segment folder after the clean up.

### DIFF
--- a/integration/spark/src/main/java/org/carbondata/spark/load/DeleteLoadFolders.java
+++ b/integration/spark/src/main/java/org/carbondata/spark/load/DeleteLoadFolders.java
@@ -202,6 +202,15 @@ public final class DeleteLoadFolders {
             }
           }
         }
+        // need to delete the complete folder.
+        if(status){
+          if(!file.delete()){
+            LOGGER.warn("Unable to delete the folder as per delete command "
+                + file.getAbsolutePath());
+            status = false;
+          }
+        }
+
       } else {
         status = false;
       }


### PR DESCRIPTION
removing the segment folder after the clean up.

If a segment is deleted using the delete segment by ID DDl , then the contents inside the segment folder is getting deleted by the folder will remain in the store .
The complete folder itself can be deleted.