### PR TITLE
[CARBONDATA-94] fixed load data when delimiter is '|' and data with header

### DIFF
--- a/integration/spark/src/test/resources/datadelimiter.csv
+++ b/integration/spark/src/test/resources/datadelimiter.csv
@@ -1,0 +1,11 @@
+empno|empname|designation|doj|workgroupcategory|workgroupcategoryname|deptno|deptname|projectcode|projectjoindate|projectenddate|attendance|utilization|salary
+11|arvind|SE|17-01-2007|1|developer|10|network|928478|17-02-2007|29-11-2016|96|96.2|5040.56
+12|krithin|SSE|29-05-2008|1|developer|11|protocol|928378|29-06-2008|30-12-2016|85|95.1|7124.21
+13|madhan|TPL|07-07-2009|2|tester|10|network|928478|07-08-2009|30-12-2016|88|99|9054.235
+14|anandh|SA|29-12-2010|3|manager|11|protocol|928278|29-01-2011|29-06-2016|77|92.2|11248.25
+15|ayushi|SSA|09-11-2011|1|developer|12|security|928375|09-12-2011|29-05-2016|99|91.5|13245.48
+16|pramod|SE|14-10-2012|1|developer|13|configManagement|928478|14-11-2012|29-12-2016|86|93|5040.56
+17|gawrav|PL|22-09-2013|2|tester|12|security|928778|22-10-2013|15-11-2016|78|97.45|9574.24
+18|sibi|TL|15-08-2014|2|tester|14|Learning|928176|15-09-2014|29-05-2016|84|98.23|7245.25
+19|shivani|PL|12-05-2015|1|developer|10|network|928977|12-06-2015|12-11-2016|88|91.678|11254.24
+20|bill|PM|01-12-2015|3|manager|14|Learning|928479|01-01-2016|30-11-2016|75|94.22|13547.25

--- a/processing/src/main/java/org/carbondata/processing/csvload/GraphExecutionUtil.java
+++ b/processing/src/main/java/org/carbondata/processing/csvload/GraphExecutionUtil.java
@@ -126,6 +126,7 @@ public final class GraphExecutionUtil {
     }
 
     if (null != readLine) {
+      delimiter = delimiterConverter(delimiter);
       String[] columnNames = readLine.split(delimiter);
       TextFileInputField[] textFileInputFields = new TextFileInputField[columnNames.length];
 
@@ -289,6 +290,7 @@ public final class GraphExecutionUtil {
     String readLine = readCSVFile(csvFilePath);
 
     if (null != readLine) {
+      delimiter = delimiterConverter(delimiter);
       String[] columnFromCSV = readLine.toLowerCase().split(delimiter);
 
       List<String> csvColumnsList = new ArrayList<String>(CarbonCommonConstants.CONSTANT_SIZE_TEN);
@@ -324,5 +326,34 @@ public final class GraphExecutionUtil {
       }
     }
     return columnNames;
+  }
+
+  /**
+   * special char delimiter Converter
+   *
+   * @param delimiter
+   * @return delimiter
+   */
+  public static String delimiterConverter(String delimiter) {
+    switch (delimiter) {
+      case "|":
+      case "*":
+      case ".":
+      case ":":
+      case "^":
+      case "\\":
+      case"$":
+      case "+":
+      case "?":
+      case "(":
+      case ")":
+      case "{":
+      case "}":
+      case "[":
+      case "]":
+        return "\\" + delimiter;
+      default:
+        return delimiter;
+    }
   }
 }


### PR DESCRIPTION
load data when delimiter is '|' and data with header
catch exception:
```
ERROR 22-07 02:49:14,460 - [Executor task launch worker-1][partitionID:default_carbontable1_d0526816-36cd-4b1c-8547-723601e8a1d2] CSV File provided is not proper. Column names in schema and csv header are not same. CSVFile Name : datadelimiter.csv
ERROR 22-07 02:49:14,464 - [Executor task launch worker-1][partitionID:default_carbontable1_d0526816-36cd-4b1c-8547-723601e8a1d2] 
org.carbondata.processing.etl.DataLoadingException: CSV File provided is not proper. Column names in schema and csv header are not same. CSVFile Name : datadelimiter.csv
	at org.carbondata.processing.csvload.DataGraphExecuter.validateCSV(DataGraphExecuter.java:139)
	at org.carbondata.processing.csvload.DataGraphExecuter.validateCSVFiles(DataGraphExecuter.java:534)
	at org.carbondata.processing.csvload.DataGraphExecuter.executeGraph(DataGraphExecuter.java:148)
	at org.carbondata.spark.load.CarbonLoaderUtil.executeGraph(CarbonLoaderUtil.java:178)
	at org.carbondata.spark.rdd.CarbonDataLoadRDD$$anon$1.<init>(CarbonDataLoadRDD.scala:196)
	at org.carbondata.spark.rdd.CarbonDataLoadRDD.compute(CarbonDataLoadRDD.scala:154)
```