### PR TITLE
[BUG]Handle delimiter = '\"' in load DML

### DIFF
--- a/core/src/main/java/org/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/carbondata/core/util/CarbonUtil.java
@@ -1226,6 +1226,12 @@ public final class CarbonUtil {
       case "\\n":
         return "\n";
       default:
+        if (parseStr.length() == 2) {
+          char[] delimiter = parseStr.toCharArray();
+          if (delimiter[0] == '\\' && delimiter[1] == '\"') {
+            return String.valueOf(delimiter[1]);
+          }
+        }
         return parseStr;
     }
   }


### PR DESCRIPTION
the csv data is just like below
name"age"country

in setup, when load with options('delimiter'='\"'), it will show load success, but query result is null.
this  problem only exists in setup, not in windows carbon Example.

the reason is because  '\"' is transferred to univocity-parser, but not treated as " , and then data is not parsed correctly, so the query result is not right.