### PR TITLE
[CARBONDATA-115][Issue] Log level updation for better maintainability of logs

### DIFF
--- a/core/src/main/java/org/carbondata/query/filters/FilterExpressionProcessor.java
+++ b/core/src/main/java/org/carbondata/query/filters/FilterExpressionProcessor.java
@@ -94,7 +94,7 @@ public class FilterExpressionProcessor implements FilterProcessor {
     List<DataRefNode> listOfDataBlocksToScan = new ArrayList<DataRefNode>();
     // getting the start and end index key based on filter for hitting the
     // selected block reference nodes based on filter resolver tree.
-    LOGGER.info("preparing the start and end key for finding"
+    LOGGER.debug("preparing the start and end key for finding"
         + "start and end block as per filter resolver");
     List<IndexKey> listOfStartEndKeys = new ArrayList<IndexKey>(2);
     FilterUtil.traverseResolverTreeAndGetStartAndEndKey(tableSegment.getSegmentProperties(),
@@ -115,7 +115,11 @@ public class FilterExpressionProcessor implements FilterProcessor {
       }
     }
 
-    LOGGER.info("Successfully retrieved the start and end key");
+    LOGGER.debug(
+        "Successfully retrieved the start and end key" + "Dictionary Start Key: " + searchStartKey
+            .getDictionaryKeys() + "No Dictionary Start Key " + searchStartKey.getNoDictionaryKeys()
+            + "Dictionary End Key: " + searchEndKey.getDictionaryKeys() + "No Dictionary End Key "
+            + searchEndKey.getNoDictionaryKeys());
     long startTimeInMillis = System.currentTimeMillis();
     DataRefNodeFinder blockFinder = new BTreeDataRefNodeFinder(
         tableSegment.getSegmentProperties().getEachDimColumnValueSize());


### PR DESCRIPTION
The log level has been changed to debug since its been repeatedly getting logged for each block, so if any detail level analysis is required
The developer can verify the debug level log to know how much time is taken to generate start and end key.
Also as part of log start and end key for the block will be logged.