### PR TITLE
[CARBONDATA-113] handle quering sum(decimal(30,10))+10

### DIFF
--- a/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
@@ -116,7 +116,7 @@ case class AverageCarbon(child: Expression, castedDataType: DataType = null)
       AverageCarbonFinal(partialSum.toAttribute,
         child.dataType match {
           case IntegerType | StringType | LongType | TimestampType => DoubleType
-          case _ => child.dataType
+          case _ => CarbonScalaUtil.updateDataType(child.dataType)
         }),
       partialSum :: Nil)
   }
@@ -156,7 +156,7 @@ case class SumCarbon(child: Expression, castedDataType: DataType = null)
         if (castedDataType != null) {
           castedDataType
         } else {
-          CarbonScalaUtil.updatedDataTypeForSum(child.dataType)
+          CarbonScalaUtil.updateDataType(child.dataType)
         }),
       partialSum :: Nil)
   }
@@ -269,7 +269,7 @@ case class SumDistinctCarbon(child: Expression, castedDataType: DataType = null)
         if (castedDataType != null) {
           castedDataType
         } else {
-          CarbonScalaUtil.updatedDataTypeForSum(child.dataType)
+          CarbonScalaUtil.updateDataType(child.dataType)
         }),
       partialSum :: Nil)
   }
@@ -373,10 +373,7 @@ case class AverageFunctionCarbon(expr: Expression, base: AggregateExpression1, f
       } else {
         avg match {
           case avg: AvgBigDecimalAggregator =>
-            val decimalValue: BigDecimal = avg.getBigDecimalValue
-            val updatedDataType = CarbonScalaUtil
-              .getDecimalDataTypeWithUpdatedPrecision(decimalValue, base.dataType)
-            Cast(Literal(decimalValue), updatedDataType).eval(null)
+            Cast(Literal(avg.getBigDecimalValue), base.dataType).eval(null)
           case avg: AvgLongAggregator =>
             Cast(Literal(avg.getDoubleValue), base.dataType).eval(null)
           case avg: AvgTimestampAggregator =>

--- a/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
@@ -153,7 +153,11 @@ case class SumCarbon(child: Expression, castedDataType: DataType = null)
     val partialSum = Alias(SumCarbon(child), "PartialSum")()
     SplitEvaluation(
       SumCarbonFinal(partialSum.toAttribute,
-        if (castedDataType != null) castedDataType else child.dataType),
+        if (castedDataType != null) {
+          castedDataType
+        } else {
+          CarbonScalaUtil.updatedDataTypeForSum(child.dataType)
+        }),
       partialSum :: Nil)
   }
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
@@ -269,7 +269,7 @@ case class SumDistinctCarbon(child: Expression, castedDataType: DataType = null)
         if (castedDataType != null) {
           castedDataType
         } else {
-          child.dataType
+          CarbonScalaUtil.updatedDataTypeForSum(child.dataType)
         }),
       partialSum :: Nil)
   }
@@ -493,10 +493,7 @@ case class SumFunctionCarbon(expr: Expression, base: AggregateExpression1, final
       } else {
         sum match {
           case s: SumBigDecimalAggregator =>
-            val decimalValue: BigDecimal = sum.getBigDecimalValue
-            val updatedDataType = CarbonScalaUtil
-              .getDecimalDataTypeWithUpdatedPrecision(decimalValue, base.dataType)
-            Cast(Literal(decimalValue), updatedDataType).eval(input)
+            Cast(Literal(sum.getBigDecimalValue), base.dataType).eval(input)
           case s: SumLongAggregator =>
             Cast(Literal(sum.getLongValue), base.dataType).eval(input)
           case _ =>
@@ -693,13 +690,7 @@ case class SumDisctinctFunctionCarbon(expr: Expression, base: AggregateExpressio
         null
       }
       else {
-        val updatedDataType = base.dataType match {
-          case decimal: DecimalType =>
-            CarbonScalaUtil
-              .getDecimalDataTypeWithUpdatedPrecision(distinct.getBigDecimalValue, base.dataType)
-          case _ => base.dataType
-        }
-        Cast(Literal(distinct.getValueObject), updatedDataType).eval(null)
+        Cast(Literal(distinct.getValueObject), base.dataType).eval(null)
       }
     }
     else {

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
@@ -117,6 +117,18 @@ object CarbonScalaUtil {
     newDataType
   }
 
+  def updatedDataTypeForSum(
+      currentDataType: org.apache.spark.sql.types.DataType): org.apache.spark.sql.types.DataType = {
+    var newDataType: org.apache.spark.sql.types.DataType = currentDataType
+    if (currentDataType.isInstanceOf[DecimalType]) {
+      val precision = currentDataType.asInstanceOf[DecimalType].precision
+      val scale = currentDataType.asInstanceOf[DecimalType].scale
+      if (precision > 27) {
+        newDataType = DecimalType(DecimalType.MAX_PRECISION, scale)
+      }
+    }
+    newDataType
+  }
 
   case class TransformHolder(rdd: Any, mataData: CarbonMetaData)
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
@@ -105,19 +105,7 @@ object CarbonScalaUtil {
     }
   }
 
-  def getDecimalDataTypeWithUpdatedPrecision(decimalValue: java.math.BigDecimal,
-      currentDataType: org.apache.spark.sql.types.DataType): org.apache.spark.sql.types.DataType = {
-    var newDataType: org.apache.spark.sql.types.DataType = currentDataType
-    if (null != decimalValue) {
-      val precision = decimalValue.precision
-      if (precision <= DecimalType.MAX_PRECISION) {
-        newDataType = DecimalType(precision, decimalValue.scale())
-      }
-    }
-    newDataType
-  }
-
-  def updatedDataTypeForSum(
+  def updateDataType(
       currentDataType: org.apache.spark.sql.types.DataType): org.apache.spark.sql.types.DataType = {
     currentDataType match {
       case decimal: DecimalType =>

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
@@ -119,15 +119,13 @@ object CarbonScalaUtil {
 
   def updatedDataTypeForSum(
       currentDataType: org.apache.spark.sql.types.DataType): org.apache.spark.sql.types.DataType = {
-    var newDataType: org.apache.spark.sql.types.DataType = currentDataType
-    if (currentDataType.isInstanceOf[DecimalType]) {
-      val precision = currentDataType.asInstanceOf[DecimalType].precision
-      val scale = currentDataType.asInstanceOf[DecimalType].scale
-      if (precision > 27) {
-        newDataType = DecimalType(DecimalType.MAX_PRECISION, scale)
-      }
+    currentDataType match {
+      case decimal: DecimalType =>
+        val scale = currentDataType.asInstanceOf[DecimalType].scale
+        DecimalType(DecimalType.MAX_PRECISION, scale)
+      case _ =>
+        currentDataType
     }
-    newDataType
   }
 
   case class TransformHolder(rdd: Any, mataData: CarbonMetaData)

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
@@ -136,7 +136,17 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
 
     sql("drop table if exists decimalDictLookUp")
   }
-  
+
+  test("test sum aggregation on big decimal column with high precision") {
+    sql("drop table if exists carbonBigDecimal")
+    sql("create table if not exists carbonBigDecimal (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(30, 10)) STORED BY 'org.apache.carbondata.format'")
+    sql("LOAD DATA LOCAL INPATH './src/test/resources/decimalBoundaryDataCarbon.csv' into table carbonBigDecimal")
+
+    checkAnswer(sql("select sum(salary)+10 from carbonBigDecimal"),
+      sql("select sum(salary)+10 from hiveBigDecimal"))
+
+    sql("drop table if exists carbonBigDecimal")
+  }
 
   override def afterAll {
     sql("drop table if exists carbonTable")

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
@@ -148,6 +148,17 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbonBigDecimal")
   }
 
+  test("test sum-distinct aggregation on big decimal column with high precision") {
+    sql("drop table if exists carbonBigDecimal")
+    sql("create table if not exists carbonBigDecimal (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(30, 10)) STORED BY 'org.apache.carbondata.format'")
+    sql("LOAD DATA LOCAL INPATH './src/test/resources/decimalBoundaryDataCarbon.csv' into table carbonBigDecimal")
+
+    checkAnswer(sql("select sum(distinct(salary))+10 from carbonBigDecimal"),
+      sql("select sum(distinct(salary))+10 from hiveBigDecimal"))
+
+    sql("drop table if exists carbonBigDecimal")
+  }
+
   override def afterAll {
     sql("drop table if exists carbonTable")
     sql("drop table if exists hiveTable")


### PR DESCRIPTION
CARBONDATA-113 url：
`https://issues.apache.org/jira/browse/CARBONDATA-113?filter=-1`

analysis:
after debuged , and found that:

1. when using decimal(27,10) (percision < 28)
logical plan keep the same with physical plan
// spark plan 
`CarbonAggregate false, [CheckOverflow((promote_precision(`cast`(SUMCarbonFinal(PartialSum#16) `as` decimal(38,10))) + 10.0000000000), DecimalType(38,10)) AS _c0#14]`

2. when using decimal(30,10)
logical plan to physical plan: the "cast ... as decimal()" has been Cut off
// spark plan 
`CarbonAggregate false, [CheckOverflow((promote_precision(SUMCarbonFinal(PartialSum#16)) + 10.0000000000), DecimalType(38,10)) AS _c0#14]`

3. for SUM + N Aggregation，the spark will cast the sum of decimal to another decimaltype
`decimal(m, n) => decimal(m+11, n)`
once the precision is bigger than 27, spark will not  cast it to decimal(m+11),
maybe because `28+11 is larger than 38(MAX_PRECISION)`

4. when the precision is bigger than 27, we should cast it to decimal(38,n) by carbon