### PR TITLE
[CARBONDATA-130]Adapt kettle home when  "carbon.kettle.home" configuration is wrong

### DIFF
--- a/conf/carbon.properties.template
+++ b/conf/carbon.properties.template
@@ -6,10 +6,7 @@ carbon.ddl.base.hdfs.url=hdfs://hacluster/opt/data
 #Path where the bad records are stored
 carbon.badRecords.location=/opt/Carbon/Spark/badrecords
 #Mandatory. path to kettle home
-#when running in local mode
 carbon.kettle.home=$<SPARK_HOME>/carbonlib/carbonplugins
-#when running in cluster mode
-carbon.cluster.kettle.home=$<CLUSTER_SPARK_HOME>/carbonlib/carbonplugins
 
 #################### Performance Configuration ##################
 ######## DataLoading Configuration ########

--- a/conf/carbon.properties.template
+++ b/conf/carbon.properties.template
@@ -6,7 +6,10 @@ carbon.ddl.base.hdfs.url=hdfs://hacluster/opt/data
 #Path where the bad records are stored
 carbon.badRecords.location=/opt/Carbon/Spark/badrecords
 #Mandatory. path to kettle home
+#when running in local mode
 carbon.kettle.home=$<SPARK_HOME>/carbonlib/carbonplugins
+#when running in cluster mode
+carbon.cluster.kettle.home=$<CLUSTER_SPARK_HOME>/carbonlib/carbonplugins
 
 #################### Performance Configuration ##################
 ######## DataLoading Configuration ########

--- a/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/carbondata/core/constants/CarbonCommonConstants.java
@@ -73,6 +73,10 @@ public final class CarbonCommonConstants {
    */
   public static final String STORE_LOCATION_DEFAULT_VAL = "../carbon.store";
   /**
+   * the folder name of kettle home path
+   */
+  public static final String KETTLE_HOME_NAME = "carbonplugins";
+  /**
    * CARDINALITY_INCREMENT_DEFAULT_VALUE
    */
   public static final int CARDINALITY_INCREMENT_VALUE_DEFAULT_VAL = 10;

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1230,7 +1230,7 @@ private[sql] case class AlterTableCompaction(alterTableModel: AlterTableModel) e
     carbonLoadModel.setStorePath(relation.cubeMeta.storePath)
 
     val partitioner = relation.cubeMeta.partitioner
-    val kettleHomePath = CarbonDataRDDFactory.getKettleHome(sqlContext)
+    val kettleHomePath = CarbonScalaUtil.getKettleHome(sqlContext)
 
     var storeLocation = CarbonProperties.getInstance
       .getProperty(CarbonCommonConstants.STORE_LOCATION_TEMP_PATH,
@@ -1518,7 +1518,7 @@ private[sql] case class LoadCube(
       storeLocation = storeLocation + "/carbonstore/" + System.nanoTime()
 
       val columinar = sqlContext.getConf("carbon.is.columnar.storage", "true").toBoolean
-      val kettleHomePath = CarbonDataRDDFactory.getKettleHome(sqlContext)
+      val kettleHomePath = CarbonScalaUtil.getKettleHome(sqlContext)
 
       val delimiter = partionValues.getOrElse("delimiter", ",")
       val quoteChar = partionValues.getOrElse("quotechar", "\"")
@@ -1709,7 +1709,7 @@ private[sql] case class LoadAggregationTable(
         System.getProperty("java.io.tmpdir"))
     storeLocation = storeLocation + "/carbonstore/" + System.currentTimeMillis()
     val columinar = sqlContext.getConf("carbon.is.columnar.storage", "true").toBoolean
-    val kettleHomePath = CarbonDataRDDFactory.getKettleHome(sqlContext)
+    val kettleHomePath = CarbonScalaUtil.getKettleHome(sqlContext)
 
     CarbonDataRDDFactory.loadCarbonData(
       sqlContext,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -1230,14 +1230,8 @@ private[sql] case class AlterTableCompaction(alterTableModel: AlterTableModel) e
     carbonLoadModel.setStorePath(relation.cubeMeta.storePath)
 
     val partitioner = relation.cubeMeta.partitioner
+    val kettleHomePath = CarbonDataRDDFactory.getKettleHome(sqlContext)
 
-    var kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
-    if (null == kettleHomePath) {
-      kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
-    }
-    if (kettleHomePath == null) {
-      sys.error(s"carbon.kettle.home is not set")
-    }
     var storeLocation = CarbonProperties.getInstance
       .getProperty(CarbonCommonConstants.STORE_LOCATION_TEMP_PATH,
         System.getProperty("java.io.tmpdir")
@@ -1524,13 +1518,7 @@ private[sql] case class LoadCube(
       storeLocation = storeLocation + "/carbonstore/" + System.nanoTime()
 
       val columinar = sqlContext.getConf("carbon.is.columnar.storage", "true").toBoolean
-      var kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
-      if (null == kettleHomePath) {
-        kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
-      }
-      if (kettleHomePath == null) {
-        sys.error(s"carbon.kettle.home is not set")
-      }
+      val kettleHomePath = CarbonDataRDDFactory.getKettleHome(sqlContext)
 
       val delimiter = partionValues.getOrElse("delimiter", ",")
       val quoteChar = partionValues.getOrElse("quotechar", "\"")
@@ -1721,13 +1709,8 @@ private[sql] case class LoadAggregationTable(
         System.getProperty("java.io.tmpdir"))
     storeLocation = storeLocation + "/carbonstore/" + System.currentTimeMillis()
     val columinar = sqlContext.getConf("carbon.is.columnar.storage", "true").toBoolean
-    var kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
-    if (null == kettleHomePath) {
-      kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
-    }
-    if (kettleHomePath == null) {
-      sys.error(s"carbon.kettle.home is not set")
-    }
+    val kettleHomePath = CarbonDataRDDFactory.getKettleHome(sqlContext)
+
     CarbonDataRDDFactory.loadCarbonData(
       sqlContext,
       carbonLoadModel,

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -18,6 +18,7 @@
 
 package org.carbondata.spark.rdd
 
+import java.io.File
 import java.util
 import java.util.concurrent.{Executors, ExecutorService, Future}
 
@@ -997,6 +998,11 @@ object CarbonDataRDDFactory extends Logging {
           val carbonLibPath = jarFile.getParentFile.getPath
           kettleHomePath = carbonLibPath + File.separator + "carbonplugins"
           logInfo(s"'carbon.kettle.home' path is not exists, reset it as $kettleHomePath")
+          val newKettleHomeFileType = FileFactory.getFileType(kettleHomePath)
+          val newKettleHomeFile = FileFactory.getCarbonFile(kettleHomePath, newKettleHomeFileType)
+          if (!newKettleHomeFile.exists()) {
+            sys.error(s"Failed to reset 'carbon.kettle.home'!")
+          }
         }
       }
     } else {

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
@@ -19,10 +19,6 @@ package org.carbondata.spark.util
 
 import java.io.File
 
-import org.carbondata.core.datastorage.store.impl.FileFactory
-import org.carbondata.core.util.CarbonProperties
-import org.carbondata.spark.rdd.CarbonDataRDDFactory._
-
 import scala.collection.JavaConverters._
 
 import org.apache.spark.Logging
@@ -35,6 +31,8 @@ import org.carbondata.core.carbon.metadata.datatype.DataType
 import org.carbondata.core.carbon.metadata.encoder.Encoding
 import org.carbondata.core.carbon.metadata.schema.table.CarbonTable
 import org.carbondata.core.constants.CarbonCommonConstants
+import org.carbondata.core.datastorage.store.impl.FileFactory
+import org.carbondata.core.util.CarbonProperties
 import org.carbondata.query.expression.{DataType => CarbonDataType}
 
 object CarbonScalaUtil extends Logging {

--- a/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/util/CarbonScalaUtil.scala
@@ -17,8 +17,15 @@
 
 package org.carbondata.spark.util
 
+import java.io.File
+
+import org.carbondata.core.datastorage.store.impl.FileFactory
+import org.carbondata.core.util.CarbonProperties
+import org.carbondata.spark.rdd.CarbonDataRDDFactory._
+
 import scala.collection.JavaConverters._
 
+import org.apache.spark.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.command.Level
 import org.apache.spark.sql.hive.{CarbonMetaData, DictionaryMap}
@@ -30,7 +37,7 @@ import org.carbondata.core.carbon.metadata.schema.table.CarbonTable
 import org.carbondata.core.constants.CarbonCommonConstants
 import org.carbondata.query.expression.{DataType => CarbonDataType}
 
-object CarbonScalaUtil {
+object CarbonScalaUtil extends Logging {
   def convertSparkToCarbonDataType(
       dataType: org.apache.spark.sql.types.DataType): CarbonDataType = {
     dataType match {
@@ -142,4 +149,48 @@ object CarbonScalaUtil {
     }
   }
 
+  def getKettleHome(sqlContext: SQLContext): String = {
+    var kettleHomePath = sqlContext.getConf("carbon.kettle.home", null)
+    if (null == kettleHomePath) {
+      kettleHomePath = CarbonProperties.getInstance.getProperty("carbon.kettle.home")
+    }
+    if (kettleHomePath != null) {
+      val sparkMaster = sqlContext.sparkContext.getConf.get("spark.master").toLowerCase()
+      // get spark master, if local, need to correct the kettle home
+      // e.g: --master local, the executor running in local machine
+      if (sparkMaster.startsWith("local")) {
+        val kettleHomeFileType = FileFactory.getFileType(kettleHomePath)
+        val kettleHomeFile = FileFactory.getCarbonFile(kettleHomePath, kettleHomeFileType)
+        // check if carbon.kettle.home path is exists
+        if (!kettleHomeFile.exists()) {
+          // get the path of this class
+          // e.g: file:/srv/bigdata/install/spark/sparkJdbc/carbonlib/carbon-
+          // xxx.jar!/org/carbondata/spark/rdd/
+          var jarFilePath = this.getClass.getResource("").getPath
+          val endIndex = jarFilePath.indexOf(".jar!") + 4
+          // get the jar file path
+          // e.g: file:/srv/bigdata/install/spark/sparkJdbc/carbonlib/carbon-*.jar
+          jarFilePath = jarFilePath.substring(0, endIndex)
+          val jarFileType = FileFactory.getFileType(jarFilePath)
+          val jarFile = FileFactory.getCarbonFile(jarFilePath, jarFileType)
+          // get the parent folder of the jar file
+          // e.g:file:/srv/bigdata/install/spark/sparkJdbc/carbonlib
+          val carbonLibPath = jarFile.getParentFile.getPath
+          // find the kettle home under the previous folder
+          // e.g:file:/srv/bigdata/install/spark/sparkJdbc/carbonlib/cabonplugins
+          kettleHomePath = carbonLibPath + File.separator + CarbonCommonConstants.KETTLE_HOME_NAME
+          logInfo(s"carbon.kettle.home path is not exists, reset it as $kettleHomePath")
+          val newKettleHomeFileType = FileFactory.getFileType(kettleHomePath)
+          val newKettleHomeFile = FileFactory.getCarbonFile(kettleHomePath, newKettleHomeFileType)
+          // check if the found kettle home exists
+          if (!newKettleHomeFile.exists()) {
+            sys.error("Kettle home not found. Failed to reset carbon.kettle.home")
+          }
+        }
+      }
+    } else {
+      sys.error("carbon.kettle.home is not set")
+    }
+    kettleHomePath
+  }
 }


### PR DESCRIPTION
jira url: https://issues.apache.org/jira/browse/CARBONDATA-130
when  we configurate "carbon.kettle.home" as a wrong path in carbon.properties
this adapter can help to find proper kettle home.
the function details as the following:
if "carbon.kettle.home" path is not exists, and run carbon in local mode,
According to the clues: `this class -> carbon jar path ->carbonlib -> kettle home path`
then we can get the proper kettle home