### PR TITLE
[CARBONDATA-126]Stream not getting close for last block in data loading

### DIFF
--- a/processing/src/main/java/org/carbondata/processing/csvreaderstep/UnivocityCsvParser.java
+++ b/processing/src/main/java/org/carbondata/processing/csvreaderstep/UnivocityCsvParser.java
@@ -153,6 +153,7 @@ public class UnivocityCsvParser {
   public boolean hasMoreRecords() throws IOException {
     row = parser.parseNext();
     if (row == null && blockCounter + 1 >= this.csvParserVo.getBlockDetailsList().size()) {
+      close();
       return false;
     }
     if (row == null) {


### PR DESCRIPTION
Problem:Last Block stream was not getting closed when reading the csv file in data load.
Fix:Closing the stream when all the records are processed.
Impact Area: Data Loading 