### PR TITLE
[CARBONDATA-132] Parse some Spark exception from executor side and show them directly on driver.

### DIFF
--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.util.control.Breaks._
 import scala.util.Random
+
 import org.apache.hadoop.conf.{Configurable, Configuration}
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.input.FileSplit

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -29,7 +29,7 @@ import scala.util.Random
 import org.apache.hadoop.conf.{Configurable, Configuration}
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
-import org.apache.spark.{Logging, Partition, SparkContext, SparkEnv}
+import org.apache.spark.{Logging, Partition, SparkContext, SparkEnv, SparkException}
 import org.apache.spark.sql.{CarbonEnv, CarbonRelation, SQLContext}
 import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionCallableModel,
 CompactionModel, Partitioner}

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -28,7 +28,7 @@ import scala.util.Random
 import org.apache.hadoop.conf.{Configurable, Configuration}
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
-import org.apache.spark.{Logging, Partition, SparkContext, SparkEnv}
+import org.apache.spark.{util => _, _}
 import org.apache.spark.sql.{CarbonEnv, CarbonRelation, SQLContext}
 import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionCallableModel, CompactionModel, Partitioner}
 import org.apache.spark.sql.hive.DistributionUtil
@@ -830,10 +830,8 @@ object CarbonDataRDDFactory extends Logging {
           logInfo("DataLoad failure")
           logger.error(ex)
           ex match {
-            case loadException: DataLoadingException =>
-              if (loadException.getErrorCode == DataProcessorConstants.CSV_VALIDATION_ERRROR_CODE) {
-                executorMessage = loadException.getMessage
-              }
+            case sparkException: SparkException =>
+              executorMessage = sparkException.getCause.getMessage
             case _ =>
           }
       }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -831,7 +831,9 @@ object CarbonDataRDDFactory extends Logging {
           logger.error(ex)
           ex match {
             case sparkException: SparkException =>
-              executorMessage = sparkException.getCause.getMessage
+              if (sparkException.getCause.isInstanceOf[DataLoadingException]) {
+                executorMessage = sparkException.getCause.getMessage
+              }
             case _ =>
           }
       }

--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -19,7 +19,7 @@
 package org.carbondata.spark.rdd
 
 import java.util
-import java.util.concurrent.{ExecutorService, Executors, Future}
+import java.util.concurrent.{Executors, ExecutorService, Future}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -28,11 +28,13 @@ import scala.util.Random
 import org.apache.hadoop.conf.{Configurable, Configuration}
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
-import org.apache.spark.{util => _, _}
+import org.apache.spark.{Logging, Partition, SparkContext, SparkEnv}
 import org.apache.spark.sql.{CarbonEnv, CarbonRelation, SQLContext}
-import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionCallableModel, CompactionModel, Partitioner}
+import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionCallableModel,
+CompactionModel, Partitioner}
 import org.apache.spark.sql.hive.DistributionUtil
 import org.apache.spark.util.{FileUtils, SplitUtils}
+
 import org.carbondata.common.logging.LogServiceFactory
 import org.carbondata.core.carbon.CarbonDataLoadSchema
 import org.carbondata.core.carbon.datastore.block.{Distributable, TableBlockInfo}
@@ -44,7 +46,6 @@ import org.carbondata.core.locks.{CarbonLockFactory, ICarbonLock, LockUsage}
 import org.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.carbondata.integration.spark.merger.{CompactionCallable, CompactionType}
 import org.carbondata.lcm.status.SegmentStatusManager
-import org.carbondata.processing.constants.DataProcessorConstants
 import org.carbondata.processing.etl.DataLoadingException
 import org.carbondata.processing.util.CarbonDataProcessorUtil
 import org.carbondata.spark._


### PR DESCRIPTION
Why raise this pr:
For example, when data load is failed because of wrong csv file header in load DDL, the exception message only shows in executor side like `"CSV header provided in DDL is not proper. Column names in schema and CSV header are not the same"` but the user using beeline can not get it from driver side because dirver only shows `"Dataload Faluire"` , it is very inconvenient for user to get the reason unless he check the executor log info.
  
How to solve:
Get the SparkException on driver side and parse the cause, when it is DataLoadingException, we can show the DataLoadingException message to driver. Show DataLoadingException is because that it is mainly about CSV file and wrapped in understandable message which can be shown to the user.