### PR TITLE
[CARBONDATA-127] Decimal datatype result in cast exception in compaction

### DIFF
--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/MajorCompactionStopsAfterCompaction.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/datacompaction/MajorCompactionStopsAfterCompaction.scala
@@ -23,7 +23,7 @@ class MajorCompactionStopsAfterCompaction extends QueryTest with BeforeAndAfterA
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "mm/dd/yyyy")
     sql(
-      "CREATE TABLE IF NOT EXISTS stopmajor (country String, ID Int, date Timestamp, name " +
+      "CREATE TABLE IF NOT EXISTS stopmajor (country String, ID decimal(7,4), date Timestamp, name " +
         "String, " +
         "phonetype String, serialname String, salary Int) STORED BY 'org.apache.carbondata" +
         ".format'"

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/joinquery/EquiJoinTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/joinquery/EquiJoinTestCase.scala
@@ -7,6 +7,10 @@ import org.apache.spark.sql.execution.joins.BroadCastFilterPushJoin
 
 class EquiJoinTestCase extends QueryTest with BeforeAndAfterAll  {
    override def beforeAll {
+    sql("drop table if exists employee_hive")
+    sql("drop table if exists mobile_hive")
+    sql("drop table if exists employee")
+    sql("drop table if exists mobile")
     //loading to hive table
     sql("create table employee_hive (empid string,empname string,mobilename string,mobilecolor string,salary int)row format delimited fields terminated by ','")
     sql("create table mobile_hive (mobileid string,mobilename string, mobilecolor string, sales int)row format delimited fields terminated by ','");

--- a/processing/src/main/java/org/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -907,7 +907,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
           // in compaction flow the measure with decimal type will come as spark decimal.
           // need to convert it to byte array.
           if (this.compactionFlow) {
-            BigDecimal bigDecimal = ((Decimal) row[customMeasureIndex[i]]).toJavaBigDecimal();
+            BigDecimal bigDecimal = ((Decimal) row[count]).toJavaBigDecimal();
             buff = DataTypeUtil.bigDecimalToByte(bigDecimal);
           } else {
             buff = (byte[]) row[count];

--- a/processing/src/main/java/org/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -360,6 +360,8 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
         CarbonUtil.identifyDimensionType(carbonTable.getDimensionByTableName(tableName));
 
     this.compactionFlow = carbonFactDataHandlerModel.isCompactionFlow();
+    // in compaction flow the measure with decimal type will come as spark decimal.
+    // need to convert it to byte array.
     if (compactionFlow) {
       try {
         numberOfCores = Integer.parseInt(CarbonProperties.getInstance()
@@ -902,6 +904,8 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
           decimal[count] = (decimal[count] > num ? decimal[count] : num);
         } else if (type[count] == CarbonCommonConstants.BIG_DECIMAL_MEASURE) {
           byte[] buff = null;
+          // in compaction flow the measure with decimal type will come as spark decimal.
+          // need to convert it to byte array.
           if (this.compactionFlow) {
             BigDecimal bigDecimal = ((Decimal) row[customMeasureIndex[i]]).toJavaBigDecimal();
             buff = DataTypeUtil.bigDecimalToByte(bigDecimal);


### PR DESCRIPTION
in case of decimal measure we will get spark Decimal data type.
but in writer it expects byte array. so converting decimal to byte array.

adding test cases for same.
and correcting equijoin test case.