### PR TITLE
[CARBONDATA-138] Avg aggregation for decimal type keeping sync with hive

### DIFF
--- a/core/src/main/java/org/carbondata/query/aggregator/impl/AvgBigDecimalAggregator.java
+++ b/core/src/main/java/org/carbondata/query/aggregator/impl/AvgBigDecimalAggregator.java
@@ -25,6 +25,10 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 
+import static java.lang.Math.min;
+
+import org.apache.spark.sql.types.DecimalType;
+
 import org.carbondata.core.carbon.datastore.chunk.MeasureColumnDataChunk;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.util.DataTypeUtil;
@@ -115,7 +119,8 @@ public class AvgBigDecimalAggregator extends AbstractMeasureAggregatorBasic {
    * @return average aggregate value
    */
   @Override public BigDecimal getBigDecimalValue() {
-    int updatedScale = aggVal.scale() + 4;
+    // increase scale to avoid any precision lost in the data
+    int updatedScale = min(aggVal.scale() + 4, DecimalType.MAX_SCALE());
     return aggVal.divide(new BigDecimal(count), updatedScale, BigDecimal.ROUND_HALF_EVEN);
   }
 
@@ -140,7 +145,8 @@ public class AvgBigDecimalAggregator extends AbstractMeasureAggregatorBasic {
    * @return average value as an object
    */
   @Override public Object getValueObject() {
-    int updatedScale = aggVal.scale() + 4;
+    // increase scale to avoid any precision lost in the data
+    int updatedScale = min(aggVal.scale() + 4, DecimalType.MAX_SCALE());
     return aggVal.divide(new BigDecimal(count), updatedScale, BigDecimal.ROUND_HALF_EVEN);
   }
 

--- a/core/src/main/java/org/carbondata/query/aggregator/impl/AvgBigDecimalAggregator.java
+++ b/core/src/main/java/org/carbondata/query/aggregator/impl/AvgBigDecimalAggregator.java
@@ -115,7 +115,8 @@ public class AvgBigDecimalAggregator extends AbstractMeasureAggregatorBasic {
    * @return average aggregate value
    */
   @Override public BigDecimal getBigDecimalValue() {
-    return aggVal.divide(new BigDecimal(count), 6);
+    int updatedScale = aggVal.scale() + 4;
+    return aggVal.divide(new BigDecimal(count), updatedScale, BigDecimal.ROUND_HALF_EVEN);
   }
 
   /**
@@ -139,7 +140,8 @@ public class AvgBigDecimalAggregator extends AbstractMeasureAggregatorBasic {
    * @return average value as an object
    */
   @Override public Object getValueObject() {
-    return aggVal.divide(new BigDecimal(count));
+    int updatedScale = aggVal.scale() + 4;
+    return aggVal.divide(new BigDecimal(count), updatedScale, BigDecimal.ROUND_HALF_EVEN);
   }
 
   /**

--- a/core/src/main/java/org/carbondata/query/aggregator/impl/AvgBigDecimalAggregator.java
+++ b/core/src/main/java/org/carbondata/query/aggregator/impl/AvgBigDecimalAggregator.java
@@ -27,12 +27,12 @@ import java.nio.ByteBuffer;
 
 import static java.lang.Math.min;
 
-import org.apache.spark.sql.types.DecimalType;
-
 import org.carbondata.core.carbon.datastore.chunk.MeasureColumnDataChunk;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.util.DataTypeUtil;
 import org.carbondata.query.aggregator.MeasureAggregator;
+
+import org.apache.spark.sql.types.DecimalType;
 
 public class AvgBigDecimalAggregator extends AbstractMeasureAggregatorBasic {
 

--- a/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
@@ -118,7 +118,7 @@ case class AverageCarbon(child: Expression, castedDataType: DataType = null)
           case decimal: DecimalType =>
             val precision = decimal.asInstanceOf[DecimalType].precision
             val scale = decimal.asInstanceOf[DecimalType].scale
-            // update precision,keep sync with hive
+            // increase precision and scale to avoid any precision lost in the data
             val updatedPrecision = min(precision + 4, DecimalType.MAX_PRECISION)
             val updatedScale = min(scale + 4, DecimalType.MAX_SCALE)
             DecimalType(updatedPrecision, updatedScale)

--- a/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/agg/CarbonAggregates.scala
@@ -17,9 +17,8 @@
 
 package org.carbondata.spark.agg
 
-import java.math.BigDecimal
-
 import scala.language.implicitConversions
+import scala.math.min
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -116,7 +115,14 @@ case class AverageCarbon(child: Expression, castedDataType: DataType = null)
       AverageCarbonFinal(partialSum.toAttribute,
         child.dataType match {
           case IntegerType | StringType | LongType | TimestampType => DoubleType
-          case _ => CarbonScalaUtil.updateDataType(child.dataType)
+          case decimal: DecimalType =>
+            val precision = decimal.asInstanceOf[DecimalType].precision
+            val scale = decimal.asInstanceOf[DecimalType].scale
+            // update precision,keep sync with hive
+            val updatedPrecision = min(precision + 4, DecimalType.MAX_PRECISION)
+            val updatedScale = min(scale + 4, DecimalType.MAX_SCALE)
+            DecimalType(updatedPrecision, updatedScale)
+          case _ => child.dataType
         }),
       partialSum :: Nil)
   }

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/bigdecimal/TestBigDecimal.scala
@@ -35,6 +35,7 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbonTable")
     sql("drop table if exists hiveTable")
     sql("drop table if exists hiveBigDecimal")
+    sql("drop table if exists carbonBigDecimal_2")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.SORT_SIZE, "1")
@@ -45,6 +46,8 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
     sql("LOAD DATA local inpath './src/test/resources/decimalDataWithoutHeader.csv' INTO table hiveTable")
     sql("create table if not exists hiveBigDecimal(ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(27, 10))row format delimited fields terminated by ','")
     sql("LOAD DATA local inpath './src/test/resources/decimalBoundaryDataHive.csv' INTO table hiveBigDecimal")
+    sql("create table if not exists carbonBigDecimal_2 (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(30, 10)) STORED BY 'org.apache.carbondata.format'")
+    sql("LOAD DATA LOCAL INPATH './src/test/resources/decimalBoundaryDataCarbon.csv' into table carbonBigDecimal_2")
   }
 
   test("test detail query on big decimal column") {
@@ -139,32 +142,56 @@ class TestBigDecimal extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists decimalDictLookUp")
   }
 
-  test("test sum aggregation on big decimal column with high precision") {
-    sql("drop table if exists carbonBigDecimal")
-    sql("create table if not exists carbonBigDecimal (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(30, 10)) STORED BY 'org.apache.carbondata.format'")
-    sql("LOAD DATA LOCAL INPATH './src/test/resources/decimalBoundaryDataCarbon.csv' into table carbonBigDecimal")
-
-    checkAnswer(sql("select sum(salary)+10 from carbonBigDecimal"),
+  test("test sum+10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select sum(salary)+10 from carbonBigDecimal_2"),
       sql("select sum(salary)+10 from hiveBigDecimal"))
-
-    sql("drop table if exists carbonBigDecimal")
   }
 
-  test("test sum-distinct aggregation on big decimal column with high precision") {
-    sql("drop table if exists carbonBigDecimal")
-    sql("create table if not exists carbonBigDecimal (ID Int, date Timestamp, country String, name String, phonetype String, serialname String, salary decimal(30, 10)) STORED BY 'org.apache.carbondata.format'")
-    sql("LOAD DATA LOCAL INPATH './src/test/resources/decimalBoundaryDataCarbon.csv' into table carbonBigDecimal")
+  test("test sum*10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select sum(salary)*10 from carbonBigDecimal_2"),
+      sql("select sum(salary)*10 from hiveBigDecimal"))
+  }
 
-    checkAnswer(sql("select sum(distinct(salary))+10 from carbonBigDecimal"),
+  test("test sum/10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select sum(salary)/10 from carbonBigDecimal_2"),
+      sql("select sum(salary)/10 from hiveBigDecimal"))
+  }
+
+  test("test sum-distinct+10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select sum(distinct(salary))+10 from carbonBigDecimal_2"),
       sql("select sum(distinct(salary))+10 from hiveBigDecimal"))
+  }
 
-    sql("drop table if exists carbonBigDecimal")
+  test("test sum-distinct*10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select sum(distinct(salary))*10 from carbonBigDecimal_2"),
+      sql("select sum(distinct(salary))*10 from hiveBigDecimal"))
+  }
+
+  test("test sum-distinct/10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select sum(distinct(salary))/10 from carbonBigDecimal_2"),
+      sql("select sum(distinct(salary))/10 from hiveBigDecimal"))
+  }
+
+  test("test avg+10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select avg(salary)+10 from carbonBigDecimal_2"),
+      sql("select avg(salary)+10 from hiveBigDecimal"))
+  }
+
+  test("test avg*10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select avg(salary)*10 from carbonBigDecimal_2"),
+      sql("select avg(salary)*10 from hiveBigDecimal"))
+  }
+
+  test("test avg/10 aggregation on big decimal column with high precision") {
+    checkAnswer(sql("select avg(salary)/10 from carbonBigDecimal_2"),
+      sql("select avg(salary)/10 from hiveBigDecimal"))
   }
 
   override def afterAll {
     sql("drop table if exists carbonTable")
     sql("drop table if exists hiveTable")
     sql("drop table if exists hiveBigDecimal")
+    sql("drop table if exists carbonBigDecimal_2")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.SORT_SIZE,


### PR DESCRIPTION
when we do avg aggregation for decimal type:
hive wiil update the precision of the avg result. 
e.g: Avg(`decimal(30,10)`), the result will be cast to `decimal(34, 14) `
so, carbon should keep the sync with hive, also need to improve the precision

the details that copyed from spark source code:

```
case class Average(child: Expression) extends UnaryExpression with PartialAggregate1 {

  override def prettyName: String = "avg"

  override def nullable: Boolean = true

  override def dataType: DataType = child.dataType match {
    case DecimalType.Fixed(precision, scale) =>
      // Add 4 digits after decimal point, like Hive
      DecimalType.bounded(precision + 4, scale + 4)
    case _ =>
      DoubleType
  }
....
```