### PR TITLE
[CARBONDATA-135]Fixed multiple hdfs client creation issue

### DIFF
--- a/core/src/main/java/org/carbondata/core/datastorage/store/impl/DFSFileHolderImpl.java
+++ b/core/src/main/java/org/carbondata/core/datastorage/store/impl/DFSFileHolderImpl.java
@@ -28,10 +28,10 @@ import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.constants.CarbonCommonConstants;
 import org.carbondata.core.datastorage.store.FileHolder;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
 
 public class DFSFileHolderImpl implements FileHolder {
 
@@ -66,7 +66,7 @@ public class DFSFileHolderImpl implements FileHolder {
     try {
       if (null == fileChannel) {
         Path pt = new Path(filePath);
-        FileSystem fs = pt.getFileSystem(new Configuration());
+        FileSystem fs = FileSystem.get(FileFactory.getConfiguration());
         fileChannel = fs.open(pt);
         fileNameAndStreamCache.put(filePath, fileChannel);
       }

--- a/core/src/main/java/org/carbondata/core/datastorage/store/impl/FileFactory.java
+++ b/core/src/main/java/org/carbondata/core/datastorage/store/impl/FileFactory.java
@@ -124,7 +124,7 @@ public final class FileFactory {
       case HDFS:
       case VIEWFS:
         Path pt = new Path(path);
-        FileSystem fs = pt.getFileSystem(configuration);
+        FileSystem fs = FileSystem.get(configuration);
         FSDataInputStream stream = fs.open(pt);
         return new DataInputStream(new BufferedInputStream(stream));
       default:
@@ -141,7 +141,7 @@ public final class FileFactory {
       case HDFS:
       case VIEWFS:
         Path pt = new Path(path);
-        FileSystem fs = pt.getFileSystem(configuration);
+        FileSystem fs = FileSystem.get(configuration);
         FSDataInputStream stream = fs.open(pt, bufferSize);
         return new DataInputStream(new BufferedInputStream(stream));
       default:
@@ -166,7 +166,7 @@ public final class FileFactory {
       case HDFS:
       case VIEWFS:
         Path pt = new Path(path);
-        FileSystem fs = pt.getFileSystem(configuration);
+        FileSystem fs = FileSystem.get(configuration);
         FSDataInputStream stream = fs.open(pt, bufferSize);
         stream.seek(offset);
         return new DataInputStream(new BufferedInputStream(stream));


### PR DESCRIPTION
Problem:When opening a input stream we are creating client every time and each time it is taking around 400 ms, In case of detail query we are opening for each blocklet and it is impacting the query performance
Solution:As query execution is a reading operation we can open only one client 
Impact Area:Query execution and compaction