### PR TITLE
[CARBONDATA-136]Fixed Query data mismatch issue after compaction

### DIFF
--- a/core/src/main/java/org/carbondata/query/carbon/executor/internal/impl/InternalDetailQueryExecutor.java
+++ b/core/src/main/java/org/carbondata/query/carbon/executor/internal/impl/InternalDetailQueryExecutor.java
@@ -64,19 +64,16 @@ public class InternalDetailQueryExecutor implements InternalQueryExecutor {
 
     // in case of compaction we will pass the in memory record size.
     int inMemoryRecordSizeInModel = queryModel.getInMemoryRecordSize();
-    if(inMemoryRecordSizeInModel > 0){
+    if (inMemoryRecordSizeInModel > 0) {
       recordSize = inMemoryRecordSizeInModel;
-    }
-    else {
+    } else {
       String defaultInMemoryRecordsSize =
           CarbonProperties.getInstance().getProperty(CarbonCommonConstants.INMEMORY_REOCRD_SIZE);
-      if (null != defaultInMemoryRecordsSize) {
-        try {
-          recordSize = Integer.parseInt(defaultInMemoryRecordsSize);
-        } catch (NumberFormatException ne) {
-          LOGGER.error("Invalid inmemory records size. Using default value");
-          recordSize = CarbonCommonConstants.INMEMORY_REOCRD_SIZE_DEFAULT;
-        }
+      try {
+        recordSize = Integer.parseInt(defaultInMemoryRecordsSize);
+      } catch (NumberFormatException ne) {
+        LOGGER.error("Invalid inmemory records size. Using default value");
+        recordSize = CarbonCommonConstants.INMEMORY_REOCRD_SIZE_DEFAULT;
       }
     }
     LOGGER.info("In memory record size considered is: " + recordSize);
@@ -97,8 +94,7 @@ public class InternalDetailQueryExecutor implements InternalQueryExecutor {
    * @param sliceIndexes   slice indexes to be executed
    * @return query result
    */
-  @Override public CarbonIterator<Result> executeQuery(
-      List<BlockExecutionInfo> executionInfos,
+  @Override public CarbonIterator<Result> executeQuery(List<BlockExecutionInfo> executionInfos,
       int[] sliceIndexes) throws QueryExecutionException {
     long startTime = System.currentTimeMillis();
     QueryRunner task;

--- a/core/src/main/java/org/carbondata/query/carbon/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/carbondata/query/carbon/result/iterator/AbstractDetailQueryResultIterator.java
@@ -97,10 +97,18 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
   public AbstractDetailQueryResultIterator(List<BlockExecutionInfo> infos,
       QueryExecutorProperties executerProperties, QueryModel queryModel,
       InternalQueryExecutor queryExecutor) {
+    // below code will be used to update the number of cores based on number
+    // records we
+    // can keep in memory while executing the query execution
     int recordSize = 0;
-    String defaultInMemoryRecordsSize =
-        CarbonProperties.getInstance().getProperty(CarbonCommonConstants.INMEMORY_REOCRD_SIZE);
-    if (null != defaultInMemoryRecordsSize) {
+
+    // in case of compaction we will pass the in memory record size.
+    int inMemoryRecordSizeInModel = queryModel.getInMemoryRecordSize();
+    if (inMemoryRecordSizeInModel > 0) {
+      recordSize = inMemoryRecordSizeInModel;
+    } else {
+      String defaultInMemoryRecordsSize =
+          CarbonProperties.getInstance().getProperty(CarbonCommonConstants.INMEMORY_REOCRD_SIZE);
       try {
         recordSize = Integer.parseInt(defaultInMemoryRecordsSize);
       } catch (NumberFormatException ne) {


### PR DESCRIPTION
Problem: During compaction we are calling query execution, for compaction we are doing merge sort for merge sort all the bucket must be sorted in so as we are calling query execution we can only execute one blocklet at a time, currently we are executing multiple blocklet of difference blocks. Because of this bucket records are not sorted.
Solution:Need to execute one blocklet a time during compaction