### PR TITLE
[CARBONDATA-137]Fixed detail limit query statistics issue

### DIFF
--- a/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
+++ b/integration/spark/src/main/scala/org/carbondata/spark/rdd/CarbonQueryRDD.scala
@@ -232,7 +232,7 @@ class CarbonQueryRDD[V: ClassTag](
           if (null != queryModel.getStatisticsRecorder) {
             val queryStatistic = new QueryStatistic
             queryStatistic
-              .addStatistics("Total Time taken to execute the query in executor Side",
+              .addFixedTimeStatistic("Total Time taken to execute the query in executor Side",
                 System.currentTimeMillis - queryStartTime
               )
             queryModel.getStatisticsRecorder.recordStatistics(queryStatistic);
@@ -253,7 +253,7 @@ class CarbonQueryRDD[V: ClassTag](
           if (null != queryModel.getStatisticsRecorder) {
             val queryStatistic = new QueryStatistic
             queryStatistic
-              .addStatistics("Total Time taken to execute the query in executor Side",
+              .addFixedTimeStatistic("Total Time taken to execute the query in executor Side",
                 System.currentTimeMillis - queryStartTime
               )
             queryModel.getStatisticsRecorder.recordStatistics(queryStatistic);


### PR DESCRIPTION
Problem:In case of detail query with limit it total query execution time in statistics is printing negative values as wrong method is getting called
Solution:Need to call correct method