### PR TITLE
[Bug] Fix the bug of Block Prune

### DIFF
--- a/core/src/main/java/org/carbondata/query/filter/resolver/AndFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/AndFilterResolverImpl.java
@@ -43,8 +43,10 @@ public class AndFilterResolverImpl extends LogicalFilterResolverImpl {
       AbsoluteTableIdentifier tableIdentifier, long[] startKeys,
       SortedMap<Integer, byte[]> noDicStartKeys, List<long[]> startKeyList)
       throws QueryExecutionException {
-    leftEvalutor.getStartKey(segmentProperties, startKeys, noDicStartKeys, startKeyList);
-    rightEvalutor.getStartKey(segmentProperties, startKeys, noDicStartKeys, startKeyList);
+    leftEvalutor.getStartKey(segmentProperties, tableIdentifier, startKeys, noDicStartKeys,
+        startKeyList);
+    rightEvalutor.getStartKey(segmentProperties, tableIdentifier, startKeys, noDicStartKeys,
+        startKeyList);
   }
 
   @Override public void getEndKey(SegmentProperties segmentProperties,

--- a/core/src/main/java/org/carbondata/query/filter/resolver/AndFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/AndFilterResolverImpl.java
@@ -18,6 +18,7 @@
  */
 package org.carbondata.query.filter.resolver;
 
+import java.util.List;
 import java.util.SortedMap;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
@@ -38,16 +39,19 @@ public class AndFilterResolverImpl extends LogicalFilterResolverImpl {
     super(leftEvalutor, rightEvalutor, expression);
   }
 
-  @Override public void getStartKey(SegmentProperties segmentProperties, long[] startKeys,
-      SortedMap<Integer, byte[]> noDicStartKeys) {
-    leftEvalutor.getStartKey(segmentProperties, startKeys, noDicStartKeys);
-    rightEvalutor.getStartKey(segmentProperties, startKeys, noDicStartKeys);
+  @Override public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier tableIdentifier, long[] startKeys,
+      SortedMap<Integer, byte[]> noDicStartKeys, List<long[]> startKeyList)
+      throws QueryExecutionException {
+    leftEvalutor.getStartKey(segmentProperties, startKeys, noDicStartKeys, startKeyList);
+    rightEvalutor.getStartKey(segmentProperties, startKeys, noDicStartKeys, startKeyList);
   }
 
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier tableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> noDicEndKeys) throws QueryExecutionException {
-    leftEvalutor.getEndKey(segmentProperties, tableIdentifier, endKeys, noDicEndKeys);
-    rightEvalutor.getEndKey(segmentProperties, tableIdentifier, endKeys, noDicEndKeys);
+      SortedMap<Integer, byte[]> noDicEndKeys, List<long[]> endKeyList)
+      throws QueryExecutionException {
+    leftEvalutor.getEndKey(segmentProperties, tableIdentifier, endKeys, noDicEndKeys, endKeyList);
+    rightEvalutor.getEndKey(segmentProperties, tableIdentifier, endKeys, noDicEndKeys, endKeyList);
   }
 }

--- a/core/src/main/java/org/carbondata/query/filter/resolver/ConditionalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/ConditionalFilterResolverImpl.java
@@ -186,11 +186,15 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
   /**
    * method will calculates the start key based on the filter surrogates
    */
-  public void getStartKey(SegmentProperties segmentProperties, long[] startKey,
-      SortedMap<Integer, byte[]> setOfStartKeyByteArray) {
+  public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier absoluteTableIdentifier, long[] startKey,
+      SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
+      throws QueryExecutionException {
     if (null == dimColResolvedFilterInfo.getStarIndexKey()) {
+      FilterUtil.getStartKey(dimColResolvedFilterInfo.getDimensionResolvedFilterInstance(),
+          absoluteTableIdentifier, startKey, segmentProperties, startKeyList);
       FilterUtil.getStartKeyForNoDictionaryDimension(dimColResolvedFilterInfo, segmentProperties,
-          setOfStartKeyByteArray);
+          setOfStartKeyByteArray, startKeyList);
     }
   }
 
@@ -202,12 +206,13 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
    */
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier absoluteTableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> setOfEndKeyByteArray) throws QueryExecutionException {
+      SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> endKeyList)
+      throws QueryExecutionException {
     if (null == dimColResolvedFilterInfo.getEndIndexKey()) {
       FilterUtil.getEndKey(dimColResolvedFilterInfo.getDimensionResolvedFilterInstance(),
-          absoluteTableIdentifier, endKeys, segmentProperties);
+          absoluteTableIdentifier, endKeys, segmentProperties, endKeyList);
       FilterUtil.getEndKeyForNoDictionaryDimension(dimColResolvedFilterInfo, segmentProperties,
-          setOfEndKeyByteArray);
+          setOfEndKeyByteArray, endKeyList);
     }
   }
 

--- a/core/src/main/java/org/carbondata/query/filter/resolver/FilterResolverIntf.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/FilterResolverIntf.java
@@ -19,6 +19,7 @@
 package org.carbondata.query.filter.resolver;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.SortedMap;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
@@ -72,8 +73,9 @@ public interface FilterResolverIntf extends Serializable {
    * @param startKey
    * @param setOfStartKeyByteArray
    */
-  void getStartKey(SegmentProperties segmentProperties, long[] startKey,
-      SortedMap<Integer, byte[]> setOfStartKeyByteArray);
+  void getStartKey(SegmentProperties segmentProperties, AbsoluteTableIdentifier tableIdentifier,
+      long[] startKey, SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
+      throws QueryExecutionException;
 
   /**
    * API will read the end key based on the max surrogate of
@@ -85,7 +87,7 @@ public interface FilterResolverIntf extends Serializable {
    * @throws QueryExecutionException
    */
   void getEndKey(SegmentProperties segmentProperties, AbsoluteTableIdentifier tableIdentifier,
-      long[] endKeys, SortedMap<Integer, byte[]> setOfEndKeyByteArray)
+      long[] endKeys, SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> endKeyList)
       throws QueryExecutionException;
 
   /**

--- a/core/src/main/java/org/carbondata/query/filter/resolver/LogicalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/LogicalFilterResolverImpl.java
@@ -86,7 +86,8 @@ public class LogicalFilterResolverImpl implements FilterResolverIntf {
     return null;
   }
 
-  @Override public void getStartKey(SegmentProperties segmentProperties, long[] startKey,
+  @Override public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier tableIdentifier, long[] startKey,
       SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
       throws QueryExecutionException {
 

--- a/core/src/main/java/org/carbondata/query/filter/resolver/LogicalFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/LogicalFilterResolverImpl.java
@@ -18,6 +18,7 @@
  */
 package org.carbondata.query.filter.resolver;
 
+import java.util.List;
 import java.util.SortedMap;
 
 import org.carbondata.core.carbon.AbsoluteTableIdentifier;
@@ -86,13 +87,16 @@ public class LogicalFilterResolverImpl implements FilterResolverIntf {
   }
 
   @Override public void getStartKey(SegmentProperties segmentProperties, long[] startKey,
-      SortedMap<Integer, byte[]> setOfStartKeyByteArray) {
+      SortedMap<Integer, byte[]> setOfStartKeyByteArray, List<long[]> startKeyList)
+      throws QueryExecutionException {
 
   }
 
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier tableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> setOfEndKeyByteArray) throws QueryExecutionException {
+      SortedMap<Integer, byte[]> setOfEndKeyByteArray, List<long[]> endKeyList)
+      throws QueryExecutionException {
+
   }
 
   @Override public FilterExecuterType getFilterExecuterType() {

--- a/core/src/main/java/org/carbondata/query/filter/resolver/RestructureFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/RestructureFilterResolverImpl.java
@@ -181,8 +181,9 @@ public class RestructureFilterResolverImpl implements FilterResolverIntf {
    * For restructure resolver no implementation is required for getting
    * the start key since it already has default values
    */
-  @Override public void getStartKey(SegmentProperties segmentProperties, long[] startKeys,
-      SortedMap<Integer, byte[]> noDicStartKeys) {
+  @Override public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier tableIdentifier, long[] startKeys,
+      SortedMap<Integer, byte[]> noDicStartKeys, List<long[]> startKeyList) {
 
   }
 
@@ -194,7 +195,7 @@ public class RestructureFilterResolverImpl implements FilterResolverIntf {
    */
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier tableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> noDicEndKeys) {
+      SortedMap<Integer, byte[]> noDicEndKeys, List<long[]> endKeyList) {
   }
 
   /**

--- a/core/src/main/java/org/carbondata/query/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -98,13 +98,19 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
    *
    * @return start IndexKey
    */
-  public void getStartKey(SegmentProperties segmentProperties, long[] startKey,
-      SortedMap<Integer, byte[]> noDictStartKeys) {
+  public void getStartKey(SegmentProperties segmentProperties,
+      AbsoluteTableIdentifier absoluteTableIdentifier, long[] startKey,
+      SortedMap<Integer, byte[]> noDictStartKeys, List<long[]> startKeyList) {
     if (null == dimColEvaluatorInfoList.get(0).getStarIndexKey()) {
-      FilterUtil.getStartKey(dimColEvaluatorInfoList.get(0), segmentProperties, startKey);
-      FilterUtil
-          .getStartKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), segmentProperties,
-              noDictStartKeys);
+      try {
+        FilterUtil.getStartKey(dimColEvaluatorInfoList.get(0).getDimensionResolvedFilterInstance(),
+            absoluteTableIdentifier, startKey, segmentProperties, startKeyList);
+        FilterUtil
+            .getStartKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), segmentProperties,
+                noDictStartKeys, startKeyList);
+      } catch (QueryExecutionException e) {
+        LOGGER.error("Can not get the start key during block prune");
+      }
     }
   }
 
@@ -115,17 +121,17 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
    */
   @Override public void getEndKey(SegmentProperties segmentProperties,
       AbsoluteTableIdentifier absoluteTableIdentifier, long[] endKeys,
-      SortedMap<Integer, byte[]> noDicEndKeys) {
+      SortedMap<Integer, byte[]> noDicEndKeys, List<long[]> endKeyList) {
     if (null == dimColEvaluatorInfoList.get(0).getEndIndexKey()) {
       try {
         FilterUtil.getEndKey(dimColEvaluatorInfoList.get(0).getDimensionResolvedFilterInstance(),
-            absoluteTableIdentifier, endKeys, segmentProperties);
+            absoluteTableIdentifier, endKeys, segmentProperties, endKeyList);
         FilterUtil
             .getEndKeyForNoDictionaryDimension(dimColEvaluatorInfoList.get(0), segmentProperties,
-                noDicEndKeys);
+                noDicEndKeys, endKeyList);
       } catch (QueryExecutionException e) {
         // TODO Auto-generated catch block
-        e.printStackTrace();
+        LOGGER.error("Can not get the end key during block prune");
       }
     }
   }

--- a/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
@@ -90,7 +90,7 @@ import org.carbondata.query.filter.resolver.RowLevelFilterResolverImpl;
 import org.carbondata.query.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 import org.carbondata.query.schema.metadata.DimColumnFilterInfo;
 
-public final class FilterUtil {
+public final class  FilterUtil {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(FilterUtil.class.getName());
 
@@ -1206,8 +1206,9 @@ public final class FilterUtil {
           startkeyColumnLevel[j++] = oneStartKey[i];
         }
         Arrays.sort(startkeyColumnLevel);
-        // get the min one as start of this column level
-        startKey[i] = startkeyColumnLevel[0];
+        // get the min - 1 as start of this column level, for example if a block contains 5,6
+        // the filter is 6, but that block's start key is 5, if not -1, this block will missing.
+        startKey[i] = startkeyColumnLevel[0] - 1;
       }
     }
 

--- a/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
@@ -848,7 +848,7 @@ public final class FilterUtil {
       List<long[]> startKeyList) {
     for (Entry<CarbonDimension, List<DimColumnFilterInfo>> entry : dimensionFilter.entrySet()) {
       List<DimColumnFilterInfo> values = entry.getValue();
-      if (null == values) {
+	  if (null == values || !entry.getKey().hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
       boolean isExcludePresent = false;

--- a/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
@@ -697,8 +697,8 @@ public final class FilterUtil {
       AbsoluteTableIdentifier tableIdentifier, long[] startKey, SegmentProperties segmentProperties,
       List<long[]> startKeyList) throws QueryExecutionException {
     for(int i = 0; i < startKey.length; i++) {
-      // The min surrogate key is 2, set it as the init value for starkey of each column level
-      startKey[i] = 2;
+      // The min surrogate key is 1, set it as the init value for starkey of each column level
+      startKey[i] = 1;
     }
     getStartKeyWithFilter(dimensionFilter, startKey, startKeyList);
   }

--- a/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
+++ b/core/src/main/java/org/carbondata/query/filters/measurefilter/util/FilterUtil.java
@@ -848,7 +848,7 @@ public final class FilterUtil {
       List<long[]> startKeyList) {
     for (Entry<CarbonDimension, List<DimColumnFilterInfo>> entry : dimensionFilter.entrySet()) {
       List<DimColumnFilterInfo> values = entry.getValue();
-	  if (null == values || !entry.getKey().hasEncoding(Encoding.DICTIONARY)) {
+      if (null == values || !entry.getKey().hasEncoding(Encoding.DICTIONARY)) {
         continue;
       }
       boolean isExcludePresent = false;

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
@@ -47,7 +47,7 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
         file.createNewFile()
       }
       writer = FileFactory.getDataOutputStream(outputPath, fileType)
-      for (i <- 0 to 2;) {
+      for (i <- 0 to 2) {
         for (j <- 0 to 240000) {
           writer.writeBytes(testData(i) + "," + j + "\n")
         }
@@ -76,10 +76,8 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
         STORED BY 'org.apache.carbondata.format'
       """)
     sql(
-      """
-        LOAD DATA LOCAL INPATH './src/test/resources/block_prune_test.csv'
-        INTO table blockprune options('FILEHEADER'='name,id'))
-      """)
+        s"LOAD DATA LOCAL INPATH '$outputPath' INTO table blockprune options('FILEHEADER'='name,id')"
+      )
     // data is in all 6 blocks
     checkAnswer(
       sql(

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.carbondata.spark.testsuite.blockprune
+
+import java.io.{DataOutputStream, File}
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.common.util.CarbonHiveContext._
+import org.apache.spark.sql.common.util.QueryTest
+import org.carbondata.core.datastorage.store.impl.FileFactory
+import org.scalatest.BeforeAndAfterAll
+
+/**
+  * This class contains test cases for block prune query
+  */
+class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
+  def currentPath: String = new File(this.getClass.getResource("/").getPath + "/../../")
+    .getCanonicalPath
+  val outputPath = currentPath + "/src/test/resources/block_prune_test.csv"
+  override def beforeAll {
+    // Since the data needed for plock prune is big, need to create a temp data file
+    val testData: Array[String]= new Array[String](3);
+    testData(0) = "a"
+    testData(1) = "b"
+    testData(2) = "c"
+    var writer: DataOutputStream = null
+    try {
+      val fileType = FileFactory.getFileType(outputPath)
+      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      if (!file.exists()) {
+        file.createNewFile()
+      }
+      writer = FileFactory.getDataOutputStream(outputPath, fileType)
+      for (i <- 0 to 2;) {
+        for (j <- 0 to 240000) {
+          writer.writeBytes(testData(i) + "," + j + "\n")
+        }
+      }
+    } catch {
+      case ex: Exception =>
+        logError("Build test file for block prune failed" + ex)
+    } finally {
+      if (writer != null) {
+        try {
+          writer.close()
+        } catch {
+          case ex: Exception =>
+            logError("Close output stream catching exception:" + ex)
+        }
+      }
+    }
+
+    sql("DROP TABLE IF EXISTS blockprune")
+  }
+
+  test("test block prune query") {
+    sql(
+      """
+        CREATE TABLE IF NOT EXISTS blockprune (name string, id int)
+        STORED BY 'org.apache.carbondata.format'
+      """)
+    sql(
+      """
+        LOAD DATA LOCAL INPATH './src/test/resources/block_prune_test.csv'
+        INTO table blockprune options('FILEHEADER'='name,id'))
+      """)
+    // data is in all 6 blocks
+    checkAnswer(
+      sql(
+        """
+          select name,count(name) as amount from blockprune
+          where name='c' or name='b' or name='a' group by name
+        """),
+      Seq(Row("a", 240000), Row("b", 240000), Row("c", 240000)))
+
+    // data only in middle 2 blocks
+    checkAnswer(
+      sql(
+        """
+          select name,count(name) as amount from blockprune
+          where name='b' group by name
+        """),
+      Seq(Row("b", 240000)))
+  }
+
+  override def afterAll {
+    // delete the temp data file
+    try {
+      val fileType = FileFactory.getFileType(outputPath)
+      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      if (file.exists()) {
+        file.delete()
+      }
+    } catch {
+      case ex: Exception =>
+        logError("Delete temp test data file for block prune catching exception:" + ex)
+    }
+    sql("DROP TABLE IF EXISTS blockprune")
+  }
+
+}

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
@@ -85,7 +85,7 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
           select name,count(name) as amount from blockprune
           where name='c' or name='b' or name='a' group by name
         """),
-      Seq(Row("a", 240000), Row("b", 240000), Row("c", 240000)))
+      Seq(Row("a", 240001), Row("b", 240001), Row("c", 240001)))
 
     // data only in middle 2 blocks
     checkAnswer(
@@ -94,7 +94,7 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
           select name,count(name) as amount from blockprune
           where name='b' group by name
         """),
-      Seq(Row("b", 240000)))
+      Seq(Row("b", 240001)))
   }
 
   override def afterAll {

--- a/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
+++ b/integration/spark/src/test/scala/org/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
@@ -78,7 +78,7 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
         s"LOAD DATA LOCAL INPATH '$outputPath' INTO table blockprune options('FILEHEADER'='name,id')"
       )
-    // data is in all 6 blocks
+    // data is in all 7 blocks
     checkAnswer(
       sql(
         """
@@ -87,7 +87,7 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
         """),
       Seq(Row("a", 240001), Row("b", 240001), Row("c", 240001)))
 
-    // data only in middle 2 blocks
+    // data only in middle 3/4/5 blocks
     checkAnswer(
       sql(
         """


### PR DESCRIPTION
## Why raise this pr:
During block prune, endkey is always only decided by the last filter expression, this is a bug
and can lead wrong result,
For example, when load data whose dimension column is 120000 lines of 'a', 120000 lines of 'b', 120000 lines of 'c', if query like "select * from tablename where colname='c' or colname='b' or colname='a'" only 120000lines 'a' will be selected because of wrong endkey.

## How to solve this:
Fix the end key consider all the filter expression end key get max and start key get (min - 1) for each column level, using this to produce a new start key an a new endkey.

For more details please look at the test case.