### PR TITLE
[WIP]Fix dictionary file issues, related to executor task failure. 

### DIFF
--- a/core/src/main/java/org/carbondata/core/cache/dictionary/DictionaryCacheLoaderImpl.java
+++ b/core/src/main/java/org/carbondata/core/cache/dictionary/DictionaryCacheLoaderImpl.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.util.List;
 
 import org.carbondata.common.factory.CarbonCommonFactory;
+import org.carbondata.common.logging.LogService;
+import org.carbondata.common.logging.LogServiceFactory;
 import org.carbondata.core.carbon.CarbonTableIdentifier;
 import org.carbondata.core.carbon.ColumnIdentifier;
 import org.carbondata.core.reader.CarbonDictionaryReader;
@@ -33,6 +35,12 @@ import org.carbondata.core.service.DictionaryService;
  * This class is responsible for loading the dictionary data for given columns
  */
 public class DictionaryCacheLoaderImpl implements DictionaryCacheLoader {
+
+  /**
+   * LOGGER
+   */
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(DictionaryCacheLoaderImpl.class.getName());
 
   /**
    * carbon table identifier
@@ -76,7 +84,11 @@ public class DictionaryCacheLoaderImpl implements DictionaryCacheLoader {
     if (loadSortIndex) {
       readSortIndexFile(dictionaryInfo, columnIdentifier);
     }
-    dictionaryInfo.addDictionaryChunk(dictionaryChunk);
+    if (null != dictionaryChunk && dictionaryChunk.size() > 0) {
+      dictionaryInfo.addDictionaryChunk(dictionaryChunk);
+    } else {
+      LOGGER.warn("Found empty dictionary chunk:" + columnIdentifier);
+    }
   }
 
   /**

--- a/core/src/main/java/org/carbondata/core/writer/CarbonDictionaryWriterImpl.java
+++ b/core/src/main/java/org/carbondata/core/writer/CarbonDictionaryWriterImpl.java
@@ -203,6 +203,7 @@ public class CarbonDictionaryWriterImpl implements CarbonDictionaryWriter {
       writeDictionaryFile();
       // close the thrift writer for dictionary file
       closeThriftWriter();
+      LOGGER.info("Dictionary file written successfully:" + this.columnIdentifier);
     }
   }
 
@@ -304,8 +305,10 @@ public class CarbonDictionaryWriterImpl implements CarbonDictionaryWriter {
       boolean truncateSuccess = carbonFile
           .truncate(this.dictionaryFilePath, chunkMetaObjectForLastSegmentEntry.getEnd_offset());
       if (!truncateSuccess) {
-        LOGGER.info("Diction file not truncated successfully for column " + this.columnIdentifier);
+        throw new IOException("Dictionary file not"
+               + " truncated successfully:" + this.columnIdentifier);
       }
+      LOGGER.info("Truncation successfull for dictionary:" + this.columnIdentifier);
     }
   }
 

--- a/core/src/main/java/org/carbondata/core/writer/sortindex/CarbonDictionarySortIndexWriterImpl.java
+++ b/core/src/main/java/org/carbondata/core/writer/sortindex/CarbonDictionarySortIndexWriterImpl.java
@@ -210,6 +210,7 @@ public class CarbonDictionarySortIndexWriterImpl implements CarbonDictionarySort
     writeColumnSortInfo();
     if (null != sortIndexThriftWriter) {
       sortIndexThriftWriter.close();
+      LOGGER.info("Sort index file is written successfully:" + columnIdentifier);
     }
   }
 }


### PR DESCRIPTION
1.While reading dictionary file, Do not add empty chunk to cache
2.Added more logging
3.Throw exception when truncation of inconsistent dictionary file fails