### PR TITLE
[CARBONDATA-160]Data mismatch issue in case of multiple segment with different dictionary key size

### DIFF
--- a/core/src/main/java/org/carbondata/query/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/executer/ExcludeFilterExecuterImpl.java
@@ -43,9 +43,8 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     this.dimColEvaluatorInfo = dimColEvaluatorInfo;
     dimColumnExecuterInfo = new DimColumnExecuterFilterInfo();
     this.segmentProperties = segmentProperties;
-    FilterUtil.prepareKeysFromSurrogates(dimColEvaluatorInfo.getFilterValues(),
-        segmentProperties.getDimensionKeyGenerator(), dimColEvaluatorInfo.getDimension(),
-        dimColumnExecuterInfo);
+    FilterUtil.prepareKeysFromSurrogates(dimColEvaluatorInfo.getFilterValues(), segmentProperties,
+        dimColEvaluatorInfo.getDimension(), dimColumnExecuterInfo);
   }
 
   @Override public BitSet applyFilter(BlocksChunkHolder blockChunkHolder) {
@@ -59,8 +58,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
       blockChunkHolder.getDimensionDataChunk()[blockIndex] = blockChunkHolder.getDataBlock()
           .getDimensionChunk(blockChunkHolder.getFileReader(), blockIndex);
     }
-    return getFilteredIndexes(
-        blockChunkHolder.getDimensionDataChunk()[blockIndex],
+    return getFilteredIndexes(blockChunkHolder.getDimensionDataChunk()[blockIndex],
         blockChunkHolder.getDataBlock().nodeSize());
   }
 

--- a/core/src/main/java/org/carbondata/query/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/executer/IncludeFilterExecuterImpl.java
@@ -44,7 +44,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     this.segmentProperties = segmentProperties;
     dimColumnExecuterInfo = new DimColumnExecuterFilterInfo();
     FilterUtil.prepareKeysFromSurrogates(dimColumnEvaluatorInfo.getFilterValues(),
-        segmentProperties.getDimensionKeyGenerator(), dimColumnEvaluatorInfo.getDimension(),
+        segmentProperties, dimColumnEvaluatorInfo.getDimension(),
         dimColumnExecuterInfo);
 
   }

--- a/core/src/main/java/org/carbondata/query/filter/executer/RestructureFilterExecuterImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/executer/RestructureFilterExecuterImpl.java
@@ -20,7 +20,7 @@ package org.carbondata.query.filter.executer;
 
 import java.util.BitSet;
 
-import org.carbondata.core.keygenerator.KeyGenerator;
+import org.carbondata.core.carbon.datastore.block.SegmentProperties;
 import org.carbondata.query.carbon.processor.BlocksChunkHolder;
 import org.carbondata.query.evaluators.DimColumnExecuterFilterInfo;
 import org.carbondata.query.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
@@ -31,10 +31,10 @@ public class RestructureFilterExecuterImpl implements FilterExecuter {
   DimColumnExecuterFilterInfo dimColumnExecuterInfo;
 
   public RestructureFilterExecuterImpl(DimColumnResolvedFilterInfo dimColumnResolvedFilterInfo,
-      KeyGenerator blockKeyGenerator) {
+      SegmentProperties segmentProperties) {
     dimColumnExecuterInfo = new DimColumnExecuterFilterInfo();
     FilterUtil
-        .prepareKeysFromSurrogates(dimColumnResolvedFilterInfo.getFilterValues(), blockKeyGenerator,
+        .prepareKeysFromSurrogates(dimColumnResolvedFilterInfo.getFilterValues(), segmentProperties,
             dimColumnResolvedFilterInfo.getDimension(), dimColumnExecuterInfo);
   }
 

--- a/core/src/main/java/org/carbondata/query/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/carbondata/query/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -87,7 +87,7 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
         .get(0).getDimension().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
       return FilterUtil.getKeyArray(this.dimColEvaluatorInfoList.get(0).getFilterValues(),
           this.dimColEvaluatorInfoList.get(0).getDimension(),
-          segmentProperties.getDimensionKeyGenerator());
+          segmentProperties);
     }
     return null;
 


### PR DESCRIPTION
Problem:In case of multiple segment and each segment keygenertaor key size is not same in that case when we are converting the surrogate key  to mdkey values which are not present in the older segments are using keygenertaor, keygenerator is giving some values which is less than column cardinality

Solutions: Need add only those surrogate keys which is less than equal to cardinality of the segment