### PR TITLE
[CARBONDATA-161]Join Query with limit data mismatch issue

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/joins/CarbonJoins.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/joins/CarbonJoins.scala
@@ -59,7 +59,7 @@ case class BroadCastFilterPushJoin(
     }
     val buildPlanOutput = buildPlan.execute()
     val input: Array[InternalRow] = buildPlanOutput.map(_.copy()).collect()
-    val inputCopy: Array[InternalRow] = buildPlanOutput.map(_.copy()).collect()
+    val inputCopy: Array[InternalRow] = input.clone
     (input, inputCopy)
   }
   // Use lazy so that we won't do broadcast when calling explain but still cache the broadcast value


### PR DESCRIPTION
Problem:Join query with limit is giving different result every time 
Solution:In case of broadcast join first we are executing query in first small table and then output we are applying as a filter on big table, in case of join query to get the filter values we are executing the query again and as limit is applied query is giving different output and join condition is failing. we need to use the result of the smaller table as a filter in big table